### PR TITLE
Handle rune spell errors as backfire

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .clj-kondo
 .lsp
 CLAUDE.md
+AGENTS.md
 debug.log
 *.lgb
 xoy

--- a/docs/spell-dsl.md
+++ b/docs/spell-dsl.md
@@ -71,6 +71,7 @@ Every rune is one of:
    - `M 2 3` → 6 (product)
    - `A 3 2` → 5 (sum)
    - Nest with apply: `a F M 2 3` → `(fire (mul 2 3))` → `(fire 6)`
+   - Non-numeric math operands are spell programming errors.
 
 ### Parser Algorithm
 
@@ -85,16 +86,46 @@ parse(tokens) → steps:
     elif token is 'mul':
       a = parse_one(tokens)
       b = parse_one(tokens)
-      emit (* a b)
+      emit (* a b) or error if a/b are not numbers
     elif token is 'add':
       a = parse_one(tokens)
       b = parse_one(tokens)
-      emit (+ a b)
+      emit (+ a b) or error if a/b are not numbers
     else:
       emit (token)  ;; bare primitive, no args
 ```
 
 This is a trivial recursive descent parser. No ambiguity. No lookahead beyond one token.
+
+## Programming Errors and Backfire
+
+Rune programs can be malformed. That is part of the magic system: misunderstood reality calls should misfire in-world, not crash the engine.
+
+Evaluation is left-to-right. If a step has already changed the world, that change remains. When the evaluator reaches an invalid step, it stops the spell and returns a structured error with the offending rune, reason, and arguments.
+
+Examples:
+
+```clojure
+[:apply :fire 2]
+;; valid: fire with power 2
+
+[:apply :fire :ice]
+;; error: fire expects a number argument, but got the ice rune
+;; no fire is applied
+
+[:fire :apply :damage :ice]
+;; fire is applied first
+;; then damage errors because ice is not a number
+```
+
+Current runtime backfire rule:
+
+| Source             | Result |
+|--------------------|--------|
+| Player item rune   | Prior effects remain, then the offending rune glows crimson and zaps the player for 1 damage. |
+| Creature rune      | Prior effects remain, then the offending rune glows crimson and rings unpleasantly. |
+
+The message should expose that a rune failed without explaining the full API contract. The player sees a crimson warning tied to the item or creature source, and can infer which program shape is unsafe through experimentation.
 
 ## Context
 

--- a/xsofy/ai.lg
+++ b/xsofy/ai.lg
@@ -162,7 +162,7 @@
 (defn update-ai-state [world entity-id]
   (let [entity (get-in world [:entities entity-id])
         player (get-in world [:entities :player])]
-    (if (or (nil? entity) (nil? player))
+    (if (or (nil? entity) (nil? player) (nil? (:pos entity)) (nil? (:pos player)))
       world
       (let [ai (:ai entity)
             state (get ai :state :sleep)

--- a/xsofy/runes.lg
+++ b/xsofy/runes.lg
@@ -116,10 +116,14 @@
                       [fn-tok arg-tok]))
                   (= tok :mul)
                   (let [a (parse-one) b (parse-one)]
-                    (* (or a 0) (or b 0)))
+                    (if (and (number? a) (number? b))
+                      (* a b)
+                      {:error :bad-argument :rune :mul :args [a b]}))
                   (= tok :add)
                   (let [a (parse-one) b (parse-one)]
-                    (+ (or a 0) (or b 0)))
+                    (if (and (number? a) (number? b))
+                      (+ a b)
+                      {:error :bad-argument :rune :add :args [a b]}))
                   :else tok)))]
       (loop []
         (when (< @pos (count tokens))

--- a/xsofy/spell.lg
+++ b/xsofy/spell.lg
@@ -131,29 +131,38 @@
             (:cursors ctx))]
     (assoc ctx :world w :result amount)))
 
-(defn r-fire [ctx]
-  (let [w (reduce
-            (fn [world pos]
-              (let [[x y] pos
-                    world (fire/ignite-forced world x y 4)
-                    targets (u/targets-at world pos nil)]
-                (reduce (fn [w e] (status/apply-status w (:id e) :burning 12))
-                        world targets)))
-            (:world ctx)
-            (:cursors ctx))]
-    (assoc ctx :world w)))
+(defn r-fire
+  ([ctx] (r-fire ctx 1))
+  ([ctx power]
+   (let [power (if (number? power) (max 1 power) 1)
+         ttl (+ 3 power)
+         burn-ttl (* 12 power)
+         w (reduce
+             (fn [world pos]
+               (let [[x y] pos
+                     world (fire/ignite-forced world x y ttl)
+                     targets (u/targets-at world pos nil)]
+                 (reduce (fn [w e] (status/apply-status w (:id e) :burning burn-ttl))
+                         world targets)))
+             (:world ctx)
+             (:cursors ctx))]
+     (assoc ctx :world w))))
 
-(defn r-ice [ctx]
-  (let [w (reduce
-            (fn [world pos]
-              (let [[x y] pos
-                    world (fx/add-stain world x y :water 2)
-                    targets (u/targets-at world pos nil)]
-                (reduce (fn [w e] (status/apply-status w (:id e) :frozen 8))
-                        world targets)))
-            (:world ctx)
-            (:cursors ctx))]
-    (assoc ctx :world w)))
+(defn r-ice
+  ([ctx] (r-ice ctx 1))
+  ([ctx power]
+   (let [power (if (number? power) (max 1 power) 1)
+         ttl (* 8 power)
+         w (reduce
+             (fn [world pos]
+               (let [[x y] pos
+                     world (fx/add-stain world x y :water 2)
+                     targets (u/targets-at world pos nil)]
+                 (reduce (fn [w e] (status/apply-status w (:id e) :frozen ttl))
+                         world targets)))
+             (:world ctx)
+             (:cursors ctx))]
+     (assoc ctx :world w))))
 
 ;; Tiles you can be pushed into (walkable + hazards)
 (def pushable-tiles #{1 2 3 4 5 6 7 10 12 13 14 15 16 17 18 19})
@@ -252,27 +261,53 @@
 (def rune-defaults
   {:area 1 :spread 2 :damage 1 :heal 1})
 
+(def rune-arg-kinds
+  {:area :number
+   :spread :number
+   :damage :number
+   :heal :number
+   :fire :number
+   :ice :number})
+
 ;; --- Spell Evaluation ---
+
+(defn spell-error [ctx rune reason args]
+  (assoc ctx :error {:rune rune :reason reason :args (vec args)}))
+
+(defn valid-rune-args? [rune-key args]
+  (let [arg-kind (get rune-arg-kinds rune-key)]
+    (cond
+      (nil? arg-kind) (empty? args)
+      (= arg-kind :number) (and (= 1 (count args)) (number? (first args)))
+      :else false)))
 
 (defn eval-step [ctx step]
   (cond
+    (:error ctx) ctx
+    (and (map? step) (:error step))
+    (assoc ctx :error step)
     ;; bare keyword: call with default or no args
     (keyword? step)
     (let [f (get rune-primitives step)]
       (if f
         (let [default (get rune-defaults step)]
           (if default (f ctx default) (f ctx)))
-        ctx))
+        (spell-error ctx step :unknown-rune [])))
     ;; applied: [rune arg1 arg2 ...]
     (vector? step)
     (let [rune-key (first step)
           args (rest step)
           f (get rune-primitives rune-key)]
-      (if f
+      (cond
+        (nil? f)
+        (spell-error ctx rune-key :unknown-rune args)
+        (not (valid-rune-args? rune-key args))
+        (spell-error ctx rune-key :bad-argument args)
+        :else
         (apply f ctx args)
-        ctx))
-    ;; ignore numbers or other literals as bare steps
-    :else ctx))
+        ))
+    ;; numbers or other literals are invalid as bare pipeline steps
+    :else (spell-error ctx step :bad-step [])))
 
 (defn eval-spell [world caster-id target-pos raw-tokens]
   "Parse flat rune tokens and evaluate. Returns {:world w :vfx [events]}."
@@ -280,4 +315,5 @@
         ctx (make-context world caster-id target-pos)
         result (reduce eval-step ctx steps)]
     {:world (:world result)
-     :vfx (or (:vfx result) [])}))
+     :vfx (or (:vfx result) [])
+     :error (:error result)}))

--- a/xsofy/world.lg
+++ b/xsofy/world.lg
@@ -496,6 +496,31 @@
         tile (terrain/tget terrain width x y)]
     (apply-water-effects world entity-id tile)))
 
+(defn spell-source-name [attacker wep]
+  (if wep
+    (or (:item-name wep) (name (or (:template wep) (:id wep) :item)))
+    (entity-name attacker)))
+
+(defn spell-error-rune [world err]
+  (let [rune (:rune err)]
+    (if (keyword? rune)
+      (runes/rune-glyph (:rune-table world) rune)
+      (str rune))))
+
+(defn apply-spell-result [world attacker-id source-name result]
+  "Merge spell effects and convert rune programming errors into in-world backfire."
+  (let [w (-> (:world result)
+              (update :vfx #(vec (concat (or % []) (or (:vfx result) [])))))
+        err (:error result)]
+    (if err
+      (let [rune (spell-error-rune w err)]
+        (if (= attacker-id :player)
+          (-> w
+              (ent/damage-entity :player 1)
+              (log-msg (str "Rune " rune " on the " source-name " glows crimson and zaps you.")))
+          (log-msg w (str "Rune " rune " on the " source-name " glows crimson and rings unpleasantly."))))
+      w)))
+
 (def pushable-tiles #{1 2 3 4 5 6 7 10 12 13 14 15 16 17 18 19})
 
 (defn push-entity [world entity-id dx dy]
@@ -555,8 +580,7 @@
                                   (:runes attacker))
                     w (if (and hit-runes target-pos)
                         (let [result (spell/eval-spell w attacker-id target-pos hit-runes)]
-                          (-> (:world result)
-                              (update :vfx #(vec (concat (or % []) (or (:vfx result) []))))))
+                          (apply-spell-result w attacker-id (spell-source-name attacker wep) result))
                         w)
                     sneak-txt (if sneak " (sneak attack!)" "")]
                 (let [target-sounds (:sounds target)
@@ -746,8 +770,7 @@
                   ;; trigger spell runes at impact if creature has them
                   w (if (and spell-runes hit-pos (seq spell-runes))
                       (let [sr (spell/eval-spell w attacker-id hit-pos spell-runes)]
-                        (-> (:world sr)
-                            (update :vfx #(vec (concat (or % []) (or (:vfx sr) []))))))
+                        (apply-spell-result w attacker-id atk-name sr))
                       w)]
               (cond
                 (= hit-id :player)
@@ -1138,8 +1161,7 @@
                             w (if (and hit (:runes wep) (:hit-pos proj))
                                 (let [sr (spell/eval-spell w :player (:hit-pos proj)
                                                            (:runes wep))]
-                                  (-> (:world sr)
-                                      (update :vfx #(into (or % []) (:vfx sr)))))
+                                  (apply-spell-result w :player (spell-source-name (get-in w [:entities :player]) wep) sr))
                                 w)
                             w (consume-item w arrow-id)]
                         (-> w


### PR DESCRIPTION
## Summary
- Treat invalid rune programs as structured spell errors instead of VM/runtime crashes.
- Preserve spell effects that executed before the bad rune, then stop evaluation and trigger an in-world crimson backfire message.
- Add a 1 HP zap for player item backfires.
- Guard AI state updates against missing entity positions during death edge cases.
- Document spell programming errors and backfire semantics.
- Ignore local AGENTS.md guidance files.

## Test
- lg -b /tmp/xsofy-spell-error-check main.lg
- focused evaluator checks for valid fire, invalid fire arg, partial effects before error, bad arithmetic, and player backfire damage/logging
- reproduced #5 parser path on this branch as a structured bad-argument error instead of a crash

Fixes #1
Fixes #5
Fixes #7
Related to #2