### PR TITLE
Restart WASM game instead of quitting

### DIFF
--- a/main.lg
+++ b/main.lg
@@ -308,6 +308,16 @@
 
       :else world)))
 
+(defn new-game []
+  (let [{:keys [title scheme]} (title/show-title-screen)
+        quest (title/generate-quest)
+        _ (title/show-descending-screen 1 scheme)]
+    (-> (world/make-world 79 30)
+        (assoc :title title
+               :scheme scheme
+               :quest-item (:item quest))
+        (#(reduce world/log-msg % (:messages quest))))))
+
 (defn game-loop
   ([world]
    (render/render-full world)
@@ -384,10 +394,15 @@
          :confirm-quit
          (do
            (render/render-full world)
-           (let [k (do (render/render-hazard-prompt world "Are you sure you want to quit?")
+           (let [prompt (if *in-wasm*
+                          "Are you sure you want to restart?"
+                          "Are you sure you want to quit?")
+                 k (do (render/render-hazard-prompt world prompt)
                        (term/read-key))
                  w (if (= k "y")
-                     (assoc world :running false)
+                     (if *in-wasm*
+                       (new-game)
+                       (assoc world :running false))
                      (dissoc world :screen))]
              (if (:running w)
                (do
@@ -458,15 +473,7 @@
 (defn -main []
   (init-terminal)
   (try
-    (let [{:keys [title scheme]} (title/show-title-screen)
-          quest (title/generate-quest)
-          _ (title/show-descending-screen 1 scheme)
-          world (-> (world/make-world 79 30)
-                    (assoc :title title
-                           :scheme scheme
-                           :quest-item (:item quest))
-                    (#(reduce world/log-msg % (:messages quest))))]
-      (game-loop world))
+    (game-loop (new-game))
     (catch e
            (dbg/log "FATAL ERROR:" e)
       (shutdown-terminal)


### PR DESCRIPTION
## Summary
- Extract new-game setup so the current game can be recreated.
- Keep native terminal Esc confirmation quitting the process.
- In WASM, make Esc confirmation restart a fresh game instead of exiting.

## Test
- lg -b /tmp/xsofy-wasm-restart-check main.lg