### PR TITLE
Fix keypad movement, stairs burning, and whip reach

### DIFF
--- a/main.lg
+++ b/main.lg
@@ -331,6 +331,13 @@
                (render/render-full w)
                (recur w w (term/size))))
 
+         :help
+         (do (render/render-help-screen world)
+             (term/read-key)
+             (let [w (dissoc world :screen)]
+               (render/render-full w)
+               (recur w w (term/size))))
+
          :inventory
          (do (render/render-inventory-screen world)
              (let [k (term/read-key)

--- a/xsofy/combat.lg
+++ b/xsofy/combat.lg
@@ -170,9 +170,16 @@
       ;; war hammer impact: just the target (knockback handled separately)
       :impact [[tx ty]]
 
-      ;; whip reach: scan straight line up to 5 tiles for first creature
-      :reach (vec (map (fn [i] [(+ px (* dx (inc i))) (+ py (* dy (inc i)))])
-                       (range 5)))
+      ;; whip reach: scan straight line up to 5 tiles, stopping at blockers
+      :reach (let [{:keys [terrain width height]} world]
+               (loop [i 1 positions []]
+                 (if (> i 5)
+                   positions
+                   (let [x (+ px (* dx i))
+                         y (+ py (* dy i))]
+                     (if (terrain/transparent? terrain width height x y)
+                       (recur (inc i) (conj positions [x y]))
+                       positions)))))
 
       ;; flail skip: tile at range 2, fallback to range 1
       :skip [[(+ px (* dx 2)) (+ py (* dy 2))] [tx ty]]

--- a/xsofy/fire.lg
+++ b/xsofy/fire.lg
@@ -15,6 +15,7 @@
 (def fire-damage 3)
 (def fire-spread-chance 30)  ;; percent per adjacent flammable per tick
 (def fire-default-ttl 5)
+(def protected-tiles #{13 14})  ;; stairs must survive dragon fire and rune fire
 
 (defn ignite [world x y]
   "Set a tile on fire. Only works on flammable tiles or if forced."
@@ -29,9 +30,12 @@
   "Force fire at a position regardless of terrain."
   (let [{:keys [terrain width]} world
         tile (terrain/tget terrain width x y)]
-    (when (and (not= tile 0) (not= tile 8) (not= tile 7))  ;; not void, wall, lava
+    (when (and (not= tile 0) (not= tile 8) (not= tile 7)
+               (not (contains? protected-tiles tile)))  ;; not void, wall, lava, stairs
       (terrain/tset! terrain width x y fire-tile))
-    (assoc-in world [:fire-ttl [x y]] ttl)))
+    (if (contains? protected-tiles tile)
+      world
+      (assoc-in world [:fire-ttl [x y]] ttl))))
 
 (defn step-fire [world]
   "One tick of fire simulation. Spread, damage, burn out."

--- a/xsofy/input.lg
+++ b/xsofy/input.lg
@@ -1,44 +1,53 @@
 (ns xsofy.input)
 
+(def key-bindings
+  [{:action :up          :category :movement   :label "Move up"          :keys ["\u001b[A" "k" "8"] :help-keys ["k" "8" "Up"]}
+   {:action :down        :category :movement   :label "Move down"        :keys ["\u001b[B" "j" "2"] :help-keys ["j" "2" "Down"]}
+   {:action :left        :category :movement   :label "Move left"        :keys ["\u001b[D" "h" "4"] :help-keys ["h" "4" "Left"]}
+   {:action :right       :category :movement   :label "Move right"       :keys ["\u001b[C" "l" "6"] :help-keys ["l" "6" "Right"]}
+   {:action :up-left     :category :movement   :label "Move up-left"     :keys ["y" "7"] :help-keys ["y" "7"]}
+   {:action :up-right    :category :movement   :label "Move up-right"    :keys ["u" "9"] :help-keys ["u" "9"]}
+   {:action :down-left   :category :movement   :label "Move down-left"   :keys ["b" "1"] :help-keys ["b" "1"]}
+   {:action :down-right  :category :movement   :label "Move down-right"  :keys ["n" "3"] :help-keys ["n" "3"]}
+   {:action :run-up      :category :movement   :label "Run up"           :keys ["\u001b[1;2A" "K"] :help-keys ["K" "Shift-Up"]}
+   {:action :run-down    :category :movement   :label "Run down"         :keys ["\u001b[1;2B" "J"] :help-keys ["J" "Shift-Down"]}
+   {:action :run-left    :category :movement   :label "Run left"         :keys ["\u001b[1;2D" "H"] :help-keys ["H" "Shift-Left"]}
+   {:action :run-right   :category :movement   :label "Run right"        :keys ["\u001b[1;2C" "L"] :help-keys ["L" "Shift-Right"]}
+   {:action :wait        :category :actions    :label "Wait one turn"     :keys ["." "z"] :help-keys ["." "z"]}
+   {:action :rest        :category :actions    :label "Rest until interrupted" :keys ["5" "Z"] :help-keys ["5" "Z"]}
+   {:action :autoexplore :category :actions    :label "Autoexplore"       :keys ["x"] :help-keys ["x"]}
+   {:action :descend     :category :actions    :label "Descend stairs"    :keys [">"] :help-keys [">"]}
+   {:action :ascend      :category :actions    :label "Ascend stairs"     :keys ["<"] :help-keys ["<"]}
+   {:action :pickup      :category :items      :label "Pick up item"      :keys ["g" ","] :help-keys ["g" ","]}
+   {:action :equip-menu  :category :items      :label "Equip item"        :keys ["e"] :help-keys ["e"]}
+   {:action :unequip-menu :category :items     :label "Unequip item"      :keys ["U"] :help-keys ["U"]}
+   {:action :drop-menu   :category :items      :label "Drop item"         :keys ["d"] :help-keys ["d"]}
+   {:action :use-menu    :category :items      :label "Use item"          :keys ["a"] :help-keys ["a"]}
+   {:action :fire        :category :actions    :label "Fire bow"          :keys ["f"] :help-keys ["f"]}
+   {:action :inventory   :category :items      :label "Open inventory"    :keys ["i"] :help-keys ["i"]}
+   {:action :rune-codex  :category :information :label "Open rune codex"  :keys ["r"] :help-keys ["r"]}
+   {:action :messages    :category :information :label "Open message log" :keys ["m"] :help-keys ["m"]}
+   {:action :help        :category :information :label "Open keybindings" :keys ["?"] :help-keys ["?"]}
+   {:action :quit        :category :system     :label "Quit"              :keys ["\u001b"] :help-keys ["Esc"]}])
+
+(defn key-matches? [k binding]
+  (some (fn [key] (= k key)) (:keys binding)))
+
+(defn binding-for-key [k]
+  (first (filter (fn [binding] (key-matches? k binding)) key-bindings)))
+
+(defn binding-for-action [action]
+  (first (filter (fn [binding] (= action (:action binding))) key-bindings)))
+
+(defn binding-key-labels [binding]
+  (apply str (interpose ", " (or (:help-keys binding) (:keys binding)))))
+
+(defn action-key-labels [action]
+  (if-let [binding (binding-for-action action)]
+    (binding-key-labels binding)
+    "?"))
+
 (defn parse-key [k]
-  (case k
-    "\u001b[A" :up
-    "\u001b[B" :down
-    "\u001b[C" :right
-    "\u001b[D" :left
-    "h"        :left
-    "j"        :down
-    "k"        :up
-    "l"        :right
-    "y"        :up-left
-    "u"        :up-right
-    "b"        :down-left
-    "n"        :down-right
-    ;; shift+arrow = run
-    "\u001b[1;2A" :run-up
-    "\u001b[1;2B" :run-down
-    "\u001b[1;2C" :run-right
-    "\u001b[1;2D" :run-left
-    ;; uppercase HJKL = run
-    "H"        :run-left
-    "J"        :run-down
-    "K"        :run-up
-    "L"        :run-right
-    "."        :wait
-    "z"        :wait
-    "Z"        :rest
-    "x"        :autoexplore
-    ">"        :descend
-    "<"        :ascend
-    "g"        :pickup
-    ","        :pickup
-    "e"        :equip-menu
-    "U"        :unequip-menu
-    "d"        :drop-menu
-    "a"        :use-menu
-    "f"        :fire
-    "i"        :inventory
-    "r"        :rune-codex
-    "m"        :messages
-    "\u001b"   :quit
+  (if-let [binding (binding-for-key k)]
+    (:action binding)
     :unknown))

--- a/xsofy/render.lg
+++ b/xsofy/render.lg
@@ -10,6 +10,7 @@
             [xsofy.effects :as fx]
             [xsofy.status :as status]
             [xsofy.runes :as runes]
+            [xsofy.input :as input]
             [xsofy.title :as title]
             [xsofy.ui :as ui]))
 
@@ -532,7 +533,8 @@
 ;; --- Status Panel ---
 
 (defn render-status [world r]
-  (ui/write-line r 0 " yuhjklbn:move  .:wait  eUda:item  i:inv  <>:stairs  m:log  esc:quit"
+  (ui/write-line r 0 (str " yuhjklbn/1-9:move  .:wait  5/Z:rest  eUda:item  i:inv  <>:stairs  m:log  "
+                          (input/action-key-labels :help) ":help  esc:quit")
                  [60 60 60] ui/bg))
 
 ;; --- Quick Menu Overlay ---
@@ -630,6 +632,45 @@
                         (max 60 (- brightness 20))
                         (max 40 (- brightness 80))]
                        ui/bg)))
+    (ui/write-line inner (dec (:h inner))
+                   " [press any key to close]"
+                   [80 80 80] ui/bg)
+    (term/flush)))
+
+;; --- Help Screen (modal) ---
+
+(def help-categories
+  [[:movement "Movement"]
+   [:actions "Actions"]
+   [:items "Items"]
+   [:information "Information"]
+   [:system "System"]])
+
+(defn render-help-row [r y binding]
+  (ui/write-line r y (str " " (input/binding-key-labels binding)) [180 170 130] ui/bg)
+  (ui/write-at r 24 y (:label binding) [170 170 170] ui/bg))
+
+(defn render-help-column [r categories]
+  (let [row (atom 0)]
+    (doseq [[category title] categories]
+      (when (< @row (:h r))
+        (ui/write-line r @row (str " " title) [220 200 160] ui/bg)
+        (swap! row inc)
+        (let [bindings (vec (filter (fn [binding] (= category (:category binding)))
+                                    input/key-bindings))]
+          (dotimes [i (min (count bindings) (- (:h r) @row))]
+            (render-help-row r @row (nth bindings i))
+            (swap! row inc)))
+        (swap! row inc)))))
+
+(defn render-help-screen [world]
+  (let [[tw th] (or (term/size) [ui/game-width ui/game-height])
+        r (ui/rect 1 1 tw th)
+        inner (ui/box r "Keybindings" [180 170 140] ui/bg)
+        [left right] (ui/rect-split-h inner (quot (:w inner) 2))]
+    (ui/clear-rect inner)
+    (render-help-column left (subvec help-categories 0 2))
+    (render-help-column right (subvec help-categories 2))
     (ui/write-line inner (dec (:h inner))
                    " [press any key to close]"
                    [80 80 80] ui/bg)

--- a/xsofy/world.lg
+++ b/xsofy/world.lg
@@ -1426,6 +1426,7 @@
     :descend (descend world)
     :ascend (ascend world)
     :messages (assoc world :screen :messages)
+    :help (assoc world :screen :help)
     :pickup (pickup world)
     :inventory (assoc world :screen :inventory)
     :rune-codex (assoc world :screen :rune-codex)


### PR DESCRIPTION
## Summary
- Fixes #10 by adding 10-key movement bindings: 1/2/3/4/6/7/8/9 for movement and 5 for rest.
- Fixes #11 by protecting stair tiles from forced fire so dragon/rune fire cannot burn away descent or ascent stairs.
- Fixes #12 by making whip reach stop at opaque terrain instead of hitting through walls.
- Bonus: adds a data-driven full-screen keybinding help view opened with ? and updates the HUD to advertise it.

## Verification
- lg -e input mapping checks for ?, h, 1, and 5
- lg -e forced-fire check that stair tile 13 remains unchanged
- lg -e reach targeting check that whip positions stop before a wall
- lg -e namespace load check for xsofy.world, xsofy.render, and xsofy.input
- lg -e direct render-help-screen smoke check