### PR TITLE
Fix entity-resurrection + spell DSL crashes; add property-testing suite

### DIFF
--- a/main.lg
+++ b/main.lg
@@ -476,9 +476,11 @@
     (game-loop (new-game))
     (catch e
            (dbg/log "FATAL ERROR:" e)
+           (dbg/dump-crash! e)
       (shutdown-terminal)
       (println "FATAL ERROR:")
-      (println e))
+      (println e)
+      (println "World state dumped to crash-dump.edn"))
     (finally
       (shutdown-terminal))))
 

--- a/xsofy/check.lg
+++ b/xsofy/check.lg
@@ -1,0 +1,514 @@
+(ns xsofy.check
+  (:require [test]))
+
+;; ============================================================================
+;; RNG — splittable linear congruential generator
+;; State is a 2-vec [state gamma] so we can split into independent streams.
+;; ============================================================================
+
+;; LCG constants from Numerical Recipes
+(def ^:private rng-mul 1664525)
+(def ^:private rng-add 1013904223)
+(def ^:private rng-mod 4294967296)   ;; 2^32
+
+(defn rng
+  "Create an RNG state from a seed integer."
+  [seed]
+  ;; gamma is the increment; odd gammas keep the LCG period full
+  [(mod (or seed 0) rng-mod) (bit-or 1 rng-add)])
+
+(defn rng-next
+  "Returns [n rng'] — n is a non-negative integer < 2^31, rng' is the next state."
+  [r]
+  (let [[s g] r
+        s' (mod (+ (* s rng-mul) g) rng-mod)
+        ;; take the high bits — LCG low bits have short periods
+        n (mod (quot s' 2) 2147483648)]   ;; < 2^31
+    [n [s' g]]))
+
+(defn rng-split
+  "Split an RNG into two independent generators with distinct gammas."
+  [r]
+  ;; Advance once to derive a fresh state, then build a sibling with a
+  ;; different (odd) gamma. The two children diverge from the next step.
+  (let [[n r'] (rng-next r)
+        [s g] r'
+        sibling-gamma (bit-or 1 (+ g n 2654435769))]   ;; golden-ratio mix
+    [r' [s sibling-gamma]]))
+
+;; ============================================================================
+;; Rose tree — {:value v :shrinks (lazy-seq of rose trees)}
+;; ============================================================================
+
+(defn pure
+  "A rose tree leaf — value with no shrinks."
+  [v]
+  {:value v :shrinks []})
+
+(defn rose-value [r] (:value r))
+(defn rose-shrinks [r] (or (:shrinks r) []))
+
+(defn rose-map
+  "Apply f to the value and recursively to all shrinks."
+  [f r]
+  {:value (f (:value r))
+   :shrinks (map (fn [child] (rose-map f child)) (rose-shrinks r))})
+
+(defn rose-filter
+  "Drop branches whose value fails pred. Returns nil if the root fails."
+  [pred r]
+  (when (pred (:value r))
+    {:value (:value r)
+     :shrinks (->> (rose-shrinks r)
+                   (map (fn [c] (rose-filter pred c)))
+                   (filter some?))}))
+
+;; --- Lazy seq helpers ---
+;; let-go's built-in `map` and `mapcat` are eager (or otherwise misbehave with
+;; certain empty inputs). These are explicit lazy versions, needed everywhere
+;; we build rose trees.
+
+(defn- lazy-map
+  [f coll]
+  (lazy-seq
+    (when-let [s (seq coll)]
+      (cons (f (first s)) (lazy-map f (rest s))))))
+
+(defn- lazy-concat
+  [colls]
+  (lazy-seq
+    (when-let [s (seq colls)]
+      (let [head (first s)]
+        (if (seq head)
+          (cons (first head)
+                (lazy-concat (cons (rest head) (rest s))))
+          (lazy-concat (rest s)))))))
+
+;; --- Integer shrinking ---
+;; Shrink strategy: try 0 first, then the midpoint between target and value,
+;; halving until we converge on target. For negatives, also try the absolute
+;; value (negation is often itself a useful shrink).
+
+(defn- shrink-int-pos
+  "Generate shrinks for a positive integer toward 0."
+  [n]
+  (when (> n 0)
+    (lazy-seq
+      (cons 0
+            (let [half (quot n 2)]
+              (when (> half 0)
+                (map #(- n %)
+                     (take-while #(> % 0)
+                                 (iterate #(quot % 2) half)))))))))
+
+(defn shrink-int
+  "Return a lazy seq of shrinks for n, biased toward 0 / sign-flip."
+  [n]
+  (cond
+    (zero? n) []
+    (pos? n) (shrink-int-pos n)
+    :else (cons (- n) (shrink-int-pos (- n)))))   ;; negative: try abs first
+
+(defn int-rose
+  "Build a rose tree of n with shrinks toward 0."
+  [n]
+  {:value n
+   :shrinks (map int-rose (shrink-int n))})
+
+;; ============================================================================
+;; Generators
+;; ============================================================================
+
+;; A generator is (fn [rng size]) -> rose-tree
+
+(defn- rand-in
+  "Uniform integer in [lo, hi] given an RNG. Returns [n rng']."
+  [r lo hi]
+  (let [[n r'] (rng-next r)
+        span (inc (- hi lo))]
+    [(+ lo (mod n span)) r']))
+
+(defn- int-shrink-tree
+  "Rose tree for n shrinking toward target, with values clamped to [lo hi]."
+  [n target lo hi]
+  (let [offset (- n target)
+        candidates (vec (filter (fn [v] (and (>= v lo) (<= v hi) (not= v n)))
+                                (map (fn [d] (+ target d))
+                                     (vec (shrink-int offset)))))]
+    {:value n
+     ;; lazy-map so we only build child trees as the shrinker descends.
+     :shrinks (lazy-map (fn [v] (int-shrink-tree v target lo hi)) candidates)}))
+
+(defn return
+  "Lift a constant value into a generator. Yields v with no shrinks,
+   ignoring the rng. Useful for building generators that incorporate a
+   fixed value, e.g. with `bind` or `gen-let`."
+  [v]
+  (fn [_r _s] (pure v)))
+
+(defn gen-int
+  "Integer in [lo, hi], shrinks toward lo (or toward 0 if 0 is in range)."
+  [lo hi]
+  (fn [r _size]
+    (let [[n _] (rand-in r lo hi)
+          target (cond
+                   (and (<= lo 0) (>= hi 0)) 0
+                   (> lo 0) lo
+                   :else hi)]
+      (int-shrink-tree n target lo hi))))
+
+;; gen-bool: 50/50 true|false, shrinks toward false.
+(defn gen-bool []
+  (fn [r _size]
+    (let [[n _] (rng-next r)
+          v (= 1 (mod n 2))]
+      {:value v
+       :shrinks (if v [(pure false)] [])})))
+
+(defn gen-elements
+  "Uniform pick from coll. Shrinks toward (first coll)."
+  [coll]
+  (let [v (vec coll)
+        n (count v)
+        first-el (first v)]
+    (fn [r _size]
+      (let [[idx _] (rand-in r 0 (dec n))
+            picked (nth v idx)]
+        {:value picked
+         :shrinks (if (= picked first-el)
+                    []
+                    ;; shrink toward earlier indices, prepending first-el
+                    (->> (range 0 idx)
+                         (map #(nth v %))
+                         (map pure)
+                         (cons (pure first-el))
+                         distinct
+                         vec))}))))
+
+(defn fmap
+  "Map f over a generator's value, preserving the shrink tree."
+  [f g]
+  (fn [r s]
+    (rose-map f (g r s))))
+
+(defn bind
+  "Monadic bind. (bind g (fn [v] g')) runs g, then runs (f v).
+   Shrinks the outer first; for each outer shrink, runs f again with a split rng."
+  [g f]
+  (fn [r s]
+    (let [[rg rf] (rng-split r)
+          outer (g rg s)
+          outer-v (rose-value outer)
+          ;; inner generator with the outer's value
+          inner ((f outer-v) rf s)
+          ;; shrink the outer; rerun f for each outer shrink with a fresh rng
+          outer-shrunk-roses
+            (lazy-map (fn [outer-child]
+                        (let [[r-child _] (rng-split rf)]
+                          ((bind (fn [_r _s] outer-child) f) r-child s)))
+                      (rose-shrinks outer))
+          inner-shrunk-roses (rose-shrinks inner)]
+      {:value (rose-value inner)
+       :shrinks (lazy-concat [outer-shrunk-roses inner-shrunk-roses])})))
+
+;; --- Collection generators ---
+
+(declare roses->vector-rose)
+
+(defn- vector-rose-shrinks
+  "Lazy seq of vector-roses obtained by replacing one element with a shrunk
+   version."
+  [roses]
+  (let [n (count roses)
+        per-index (lazy-map (fn [idx]
+                              (let [r (nth roses idx)]
+                                (lazy-map (fn [sr]
+                                            (roses->vector-rose
+                                              (assoc roses idx sr)))
+                                          (rose-shrinks r))))
+                            (range n))]
+    (lazy-concat per-index)))
+
+(defn- roses->vector-rose
+  "Given a vector of element rose trees, build a vector-rose whose shrinks
+   include all single-element shrinks (recursively shrinkable)."
+  [roses]
+  {:value (mapv rose-value roses)
+   :shrinks (vector-rose-shrinks roses)})
+
+(defn- gen-vector-of-len
+  "Build a vector of exactly n elements from generator g."
+  [g n]
+  (fn [r s]
+    (if (<= n 0)
+      (pure [])
+      (loop [i 0
+             r r
+             acc-roses []]
+        (if (= i n)
+          (roses->vector-rose acc-roses)
+          (let [[rl rr] (rng-split r)
+                rose (g rl s)]
+            (recur (inc i) rr (conj acc-roses rose))))))))
+
+(defn- gen-vector-variable
+  "Vector with length between lo and hi inclusive."
+  [g lo hi]
+  (fn [r s]
+    (let [[r-len r-elems] (rng-split r)
+          [n _] (rand-in r-len lo hi)
+          base ((gen-vector-of-len g n) r-elems s)
+          base-val (rose-value base)
+          ;; length shrinks: empty, halve, drop one
+          shorter-lens (distinct
+                         (filter #(and (>= % lo) (< % n))
+                                 [lo (quot n 2) (dec n)]))
+          length-shrinks
+            (lazy-map (fn [m]
+                        (let [[r-sub _] (rng-split r-elems)]
+                          ((gen-vector-of-len g m) r-sub s)))
+                      shorter-lens)
+          elem-shrinks (rose-shrinks base)]
+      {:value base-val
+       :shrinks (lazy-concat [length-shrinks elem-shrinks])})))
+
+(defn gen-vector
+  "Generate a vector. Arities:
+     (gen-vector g)         — length 0..size
+     (gen-vector g n)       — exactly n
+     (gen-vector g lo hi)   — between lo and hi (inclusive)"
+  ([g]
+   (fn [r s] ((gen-vector-variable g 0 (max 0 s)) r s)))
+  ([g n]
+   (gen-vector-of-len g n))
+  ([g lo hi]
+   (gen-vector-variable g lo hi)))
+
+(defn gen-tuple
+  "Fixed-length tuple of values from each generator."
+  [& gs]
+  (let [gs (vec gs)
+        n (count gs)]
+    (fn [r s]
+      (loop [i 0
+             r r
+             acc-roses []]
+        (if (= i n)
+          (roses->vector-rose acc-roses)
+          (let [[rl rr] (rng-split r)
+                rose ((nth gs i) rl s)]
+            (recur (inc i) rr (conj acc-roses rose))))))))
+
+(defn gen-frequency
+  "Pick a generator weighted by its associated integer.
+   weight-gens: [[w gen] ...]"
+  [weight-gens]
+  (let [pairs (vec weight-gens)
+        total (reduce + (map first pairs))]
+    (fn [r s]
+      (let [[r-pick r-gen] (rng-split r)
+            [pick _] (rand-in r-pick 0 (dec total))]
+        ;; walk pairs accumulating weight
+        (loop [acc 0
+               i 0]
+          (let [[w g] (nth pairs i)
+                acc' (+ acc w)]
+            (if (or (< pick acc') (= i (dec (count pairs))))
+              (g r-gen s)
+              (recur acc' (inc i)))))))))
+
+;; ============================================================================
+;; Property runner
+;; ============================================================================
+;;
+;; A property is a map:
+;;   {:gens [gen1 gen2 ...]   — one generator per binding
+;;    :run  (fn [v1 v2 ...]   — returns true (pass), false (fail),
+;;                              or throws (also fail)
+;;
+;; (check prop opts) runs the property num-tests times. On failure it walks
+;; the rose tree greedily, picking the first failing child until no smaller
+;; failure exists.
+
+(defn- prop-fails?
+  "Run prop on a vector of args. Returns true if it fails (false return or
+   throws). Catches all exceptions."
+  [prop args]
+  (try
+    (let [result (apply (:run prop) args)]
+      (not result))
+    (catch e
+      true)))
+
+(defn- prop-error
+  "Run prop and return any exception it throws, else nil."
+  [prop args]
+  (try
+    (apply (:run prop) args)
+    nil
+    (catch e e)))
+
+(defn- shrink-failure
+  "Greedy shrink: walk rose tree, replacing the node with its first failing
+   child until none of the children fail. Returns {:value v :depth d}."
+  [rose prop max-shrinks]
+  (loop [node rose
+         depth 0
+         budget max-shrinks]
+    (if (<= budget 0)
+      {:value (rose-value node) :depth depth}
+      (let [children (rose-shrinks node)
+            failing-child (some (fn [c]
+                                  (when (prop-fails? prop (rose-value c)) c))
+                                children)]
+        (if failing-child
+          (recur failing-child (inc depth) (dec budget))
+          {:value (rose-value node) :depth depth})))))
+
+(defn check
+  "Run a property. Options:
+     :num-tests   (default 100)
+     :max-size    (default 50)
+     :seed        (default a random integer)
+     :max-shrinks (default 1000)
+
+   Returns:
+     {:result :pass | :fail
+      :num-tests N
+      :seed S
+      :counterexample [...]              ; on fail
+      :shrunk {:counterexample [...] :depth D}  ; on fail
+      :error e}                          ; if the body threw"
+  ([prop] (check prop {}))
+  ([prop opts]
+   (let [num-tests (or (:num-tests opts) 100)
+         max-size  (or (:max-size opts) 50)
+         seed      (or (:seed opts)
+                       (mod (let [t (or (try (System/currentTimeMillis)
+                                             (catch e 0))
+                                        0)]
+                              t)
+                            2147483647))
+         max-shrinks (or (:max-shrinks opts) 1000)
+         g (apply gen-tuple (:gens prop))]
+     (loop [i 0
+            r (rng seed)]
+       (if (>= i num-tests)
+         {:result :pass :num-tests num-tests :seed seed}
+         (let [[r-this r-next] (rng-split r)
+               size (min max-size i)
+               rose (g r-this size)
+               args (rose-value rose)]
+           (if (prop-fails? prop args)
+             ;; failure — shrink
+             (let [shrunk (shrink-failure rose prop max-shrinks)
+                   err (prop-error prop args)]
+               {:result :fail
+                :num-tests (inc i)
+                :seed seed
+                :counterexample args
+                :shrunk {:counterexample (:value shrunk)
+                         :depth (:depth shrunk)}
+                :error err})
+             (recur (inc i) r-next))))))))
+
+;; --- Counterexample formatting ---
+;; Failing properties often contain large opaque values like terrain byte
+;; arrays. Printing them verbatim drowns the actual signal in noise. We
+;; recursively walk the counterexample, redacting arrays of more than a few
+;; elements into `<byte-array N bytes>` markers so the rest stays readable.
+
+(def ^:private redact-array-threshold 8)
+
+(defn- byte-array? [v]
+  (= "let-go.lang.Array" (str (type v))))
+
+(defn- redact [v]
+  (cond
+    (byte-array? v)
+    (if (> (count v) redact-array-threshold)
+      (str "<byte-array " (count v) " bytes>")
+      v)
+
+    (map? v)
+    (reduce (fn [m kv] (assoc m (first kv) (redact (second kv)))) {} v)
+
+    (vector? v)
+    (mapv redact v)
+
+    (set? v)
+    (set (map redact v))
+
+    (sequential? v)
+    (map redact v)
+
+    :else v))
+
+(defn format-value
+  "Render a value as a string suitable for printing as a property
+   counterexample. Large opaque values (byte arrays) are redacted to keep the
+   output readable; the structure of maps/vectors/sets is preserved so the
+   reader can still see the shape."
+  [v]
+  (pr-str (redact v)))
+
+(defn sample
+  "Generate sample values from a generator for REPL exploration.
+   Uses an arbitrary seed and ramps size from 0 upward.
+     (sample gen)        ;; 10 samples
+     (sample gen n)      ;; n samples"
+  ([g] (sample g 10))
+  ([g n]
+   (let [seed (mod (try (System/currentTimeMillis) (catch e 1)) 2147483647)]
+     (loop [i 0
+            r (rng seed)
+            acc []]
+       (if (>= i n)
+         acc
+         (let [[r-this r-next] (rng-split r)
+               size (min 50 i)
+               rose (g r-this size)]
+           (recur (inc i) r-next (conj acc (rose-value rose)))))))))
+
+(defmacro gen-let
+  "Flatten nested binds. `(gen-let [a g1, b g2, ...] body)` expands to
+   `(bind g1 (fn [a] (bind g2 (fn [b] ... (return body)))))`.
+
+   Later generators can reference earlier bound names:
+     (gen-let [n (gen-int 1 5)
+               v (gen-int 0 n)]
+       [n v])"
+  [bindings & body]
+  (let [pairs (partition 2 bindings)]
+    (reduce (fn [acc [name gen]]
+              `(bind ~gen (fn [~name] ~acc)))
+            `(return (do ~@body))
+            (reverse pairs))))
+
+(defmacro for-all
+  "Bind [v1 g1 v2 g2 ...] then evaluate body. Returns a property value."
+  [bindings & body]
+  (let [pairs (partition 2 bindings)
+        names (map first pairs)
+        gens  (map second pairs)]
+    `{:gens [~@gens]
+      :run (fn [~@names] (do ~@body))}))
+
+(defmacro defprop
+  "Define a property as a deftest. Runs check and asserts :result is :pass.
+   On failure, prints seed and counterexample so users can reproduce.
+
+   Counterexamples are rendered through `format-value`, which redacts large
+   opaque values (e.g. terrain byte arrays) so the printout stays readable."
+  [test-name bindings & body]
+  `(test/deftest ~test-name
+     (let [result# (check (for-all ~bindings ~@body))]
+       (when (= :fail (:result result#))
+         (println "  FAIL property" '~test-name)
+         (println "    seed:    " (:seed result#))
+         (println "    original:" (format-value (:counterexample result#)))
+         (println "    shrunk:  " (format-value (:counterexample (:shrunk result#))))
+         (when (:error result#)
+           (println "    threw:   " (:error result#)))
+         (println "    reproduce with seed:" (:seed result#)))
+       (test/is (= :pass (:result result#))))))

--- a/xsofy/check_gen.lg
+++ b/xsofy/check_gen.lg
@@ -238,4 +238,29 @@
         (assoc-in [:entities :player] player)
         (spawn-creatures creature-spawns)
         (spawn-items item-spawns)
-        (assoc :fire-ttl fire-ttls))))
+        ;; depth + floors map needed by save/restore code paths
+        (assoc :depth 1 :floors {} :fire-ttl fire-ttls))))
+
+;; --- Picking two distinct entities from a world (for combat properties) ---
+;; A combat property needs an attacker-id and a target-id. We pick the
+;; player as attacker by default and a random creature as target, falling
+;; back gracefully if no creatures exist.
+
+(def gen-rich-world-with-creature
+  ;; Generate worlds until we get one with at least one non-player creature.
+  ;; In practice this is ~90% of worlds, so a small retry budget suffices.
+  (c/gen-let [world gen-rich-world]
+    (let [has-creature? (some (fn [e] (and (:ai e) (not= :player (:id e))))
+                              (vals (:entities world)))]
+      (if has-creature?
+        world
+        ;; force-add a goblin so the combat properties have a target
+        (ent/spawn world :goblin [5 5])))))
+
+(defn creature-ids
+  "All non-player ids that have a :body."
+  [world]
+  (->> (vals (:entities world))
+       (filter (fn [e] (and (:body e) (not= :player (:id e)))))
+       (map :id)
+       vec))

--- a/xsofy/check_gen.lg
+++ b/xsofy/check_gen.lg
@@ -1,0 +1,103 @@
+(ns xsofy.check-gen
+  "xsofy domain generators built on xsofy.check.
+
+   How to add a new generator:
+
+     ;; 1. Wrap a constant
+     (def gen-zero (c/return 0))
+
+     ;; 2. A primitive — number, choice, vector
+     (def gen-hp        (c/gen-int 1 30))
+     (def gen-direction (c/gen-elements [:up :down :left :right]))
+     (def gen-path      (c/gen-vector gen-direction 0 10))
+
+     ;; 3. A struct built from other generators (use gen-let, not bind+fmap)
+     (def gen-creature
+       (c/gen-let [pos gen-pos
+                   hp  gen-hp
+                   ai  gen-ai-state]
+         {:pos pos :body {:hp hp} :ai {:state ai}}))
+
+     ;; 4. Weighted alternatives
+     (def gen-weighted-action
+       (c/gen-frequency [[5 gen-direction]   ; 5/7 of the time
+                         [2 (c/return :wait)]]))
+
+     ;; 5. Exploring at the REPL
+     (c/sample gen-creature)
+     (c/sample gen-creature 3)"
+  (:require [xsofy.check :as c]
+            [xsofy.terrain :as terrain]))
+
+;; --- Position ---
+(def gen-pos
+  (c/gen-tuple (c/gen-int 1 8) (c/gen-int 1 8)))
+
+;; --- Minimal world for spell/world properties ---
+
+(defn minimal-stone-room
+  "Build a 10x10 stone-floor room with stone walls. No entities."
+  []
+  (let [w 10
+        h 10
+        t (terrain/make-terrain w h)]
+    ;; carve a floor inside the perimeter
+    (doseq [y (range 1 (dec h))
+            x (range 1 (dec w))]
+      (terrain/tset! t w x y 1))   ;; 1 = floor-stone
+    {:terrain t
+     :width w
+     :height h
+     :entities {}
+     :turn 0
+     :gold 0
+     :rune-table {}}))
+
+;; --- Player ---
+
+(def gen-status-key
+  (c/gen-elements [:burning :poison :frozen :webbed :confused :slowed :haste]))
+
+(def gen-status-pair
+  ;; one status with a ttl
+  (c/gen-tuple gen-status-key (c/gen-int 1 5)))
+
+(def gen-statuses
+  (c/fmap (fn [pairs]
+            (reduce (fn [m [k ttl]]
+                      (assoc m k {:ttl ttl :max-ttl ttl}))
+                    {} pairs))
+          (c/gen-vector gen-status-pair 0 3)))
+
+(def gen-hp
+  ;; bias toward dangerous low HP — that's where status-tick crashes hide
+  (c/gen-frequency [[3 (c/gen-int 1 3)]
+                    [2 (c/gen-int 4 15)]
+                    [1 (c/gen-int 16 30)]]))
+
+(def gen-player
+  (c/gen-let [pos      gen-pos
+              hp       gen-hp
+              statuses gen-statuses]
+    {:id :player
+     :template :player
+     :pos pos
+     :ticks 0
+     :body {:hp hp :max-hp 30 :strength 2 :armor 0}
+     :status {}
+     :statuses statuses
+     :inventory []}))
+
+(def gen-minimal-world
+  (c/gen-let [player gen-player]
+    (assoc-in (minimal-stone-room) [:entities :player] player)))
+
+;; --- Player actions ---
+
+(def gen-action
+  (c/gen-elements [:up :down :left :right
+                   :up-left :up-right :down-left :down-right
+                   :wait :rest]))
+
+(def gen-action-seq
+  (c/gen-vector gen-action 0 10))

--- a/xsofy/check_gen.lg
+++ b/xsofy/check_gen.lg
@@ -27,7 +27,12 @@
      (c/sample gen-creature)
      (c/sample gen-creature 3)"
   (:require [xsofy.check :as c]
-            [xsofy.terrain :as terrain]))
+            [xsofy.terrain :as terrain]
+            [xsofy.entities :as ent]
+            ;; Load template registries (defcreature / defitem populate
+            ;; the shared @ent/templates atom).
+            [xsofy.bestiary]
+            [xsofy.items]))
 
 ;; --- Position ---
 (def gen-pos
@@ -101,3 +106,136 @@
 
 (def gen-action-seq
   (c/gen-vector gen-action 0 10))
+
+;; ============================================================================
+;; Terrain features, hazards, fire, webs, creatures, items
+;; ============================================================================
+
+;; --- Tile feature generator ---
+;; Pick from a curated set of tile types that the movement/effects code has
+;; to handle. Includes hazards (water, lava, chasm), flammable (grass), web,
+;; and the friendly default (floor-stone).
+;;
+;; Tile numbers come from terrain.lg:
+;;   1 floor-stone, 2 grass, 3 shallow-water, 4 deep-water,
+;;   6 chasm, 7 lava, 15 fire, 17 walkway, 18 trampled-grass, 19 web
+
+(def gen-feature-tile
+  (c/gen-frequency [[6 (c/return 1)]    ; floor-stone — default
+                    [2 (c/return 2)]    ; grass (flammable)
+                    [1 (c/return 3)]    ; shallow water
+                    [1 (c/return 4)]    ; deep water (hazard)
+                    [1 (c/return 6)]    ; chasm (hazard)
+                    [1 (c/return 7)]    ; lava (hazard)
+                    [1 (c/return 15)]   ; fire
+                    [1 (c/return 19)]]))   ; web
+
+;; --- Feature room ---
+;; Like minimal-stone-room but the interior tiles are random feature tiles.
+;; Returns [world fire-cells] — fire-cells is a vec of [x y] needing fire-ttl.
+
+(defn- carve-feature-row [t w x y tile fire-acc]
+  (terrain/tset! t w x y tile)
+  (if (= tile 15)            ; track fire tiles so we can build fire-ttl
+    (conj fire-acc [x y])
+    fire-acc))
+
+(defn build-feature-room
+  "Given a vector of (width-2)*(height-2) tile ints (one per interior cell),
+   build a world map. Returns {:world ... :fire-cells [[x y] ...]}."
+  [tile-vec]
+  (let [w 10
+        h 10
+        t (terrain/make-terrain w h)
+        inner-w (- w 2)
+        inner-h (- h 2)]
+    (loop [i 0
+           fires []]
+      (if (= i (* inner-w inner-h))
+        {:world {:terrain t :width w :height h
+                 :entities {} :turn 0 :gold 0 :rune-table {}}
+         :fire-cells fires}
+        (let [x (+ 1 (mod i inner-w))
+              y (+ 1 (quot i inner-w))
+              tile (nth tile-vec i 1)
+              fires' (carve-feature-row t w x y tile fires)]
+          (recur (inc i) fires'))))))
+
+;; (width-2)*(height-2) = 64 interior tiles for a 10x10 room
+(def gen-feature-room
+  (c/gen-let [tiles (c/gen-vector gen-feature-tile 64 64)]
+    (build-feature-room tiles)))
+
+;; --- Fire-ttl map ---
+;; For any fire tiles in the room, give them random TTLs.
+
+(def gen-fire-ttl-for-cells
+  ;; Returns a map {[x y] ttl}. Takes cells via fmap composition.
+  (fn [cells]
+    (c/gen-let [ttls (c/gen-vector (c/gen-int 1 5) (count cells) (count cells))]
+      (zipmap cells ttls))))
+
+;; --- Creature spawning ---
+
+(def creature-species
+  ;; A subset of the bestiary — the ones that exist and don't depend on a
+  ;; specific encounter context.
+  [:rat :goblin :kobold :archer :spider :slime
+   :goblin-shaman :fire-imp :ogre :troll :wraith])
+
+(def gen-creature-species (c/gen-elements creature-species))
+
+(def gen-creature-spawn
+  ;; {:species k :pos [x y]}
+  (c/gen-let [species gen-creature-species
+              pos     gen-pos]
+    {:species species :pos pos}))
+
+(def gen-creature-spawns
+  (c/gen-vector gen-creature-spawn 0 3))
+
+;; --- Item spawning ---
+
+(def item-species
+  [:dagger :short-sword :leather-armor :health-potion
+   :scroll-enchant :arrow :gold])
+
+(def gen-item-species (c/gen-elements item-species))
+
+(def gen-item-spawn
+  (c/gen-let [species gen-item-species
+              pos     gen-pos]
+    {:species species :pos pos}))
+
+(def gen-item-spawns
+  (c/gen-vector gen-item-spawn 0 3))
+
+;; --- Rich world ---
+;; Feature room + player + 0-3 creatures + 0-3 items + fire-ttl for any
+;; fire tiles. This is the workhorse generator for movement and effects.
+
+(defn- spawn-creatures [world spawns]
+  (reduce (fn [w {:keys [species pos]}]
+            (try (ent/spawn w species pos)
+                 (catch _ w)))   ;; silently ignore unknown species
+          world
+          spawns))
+
+(defn- spawn-items [world spawns]
+  (reduce (fn [w {:keys [species pos]}]
+            (try (ent/spawn-item w species pos)
+                 (catch _ w)))
+          world
+          spawns))
+
+(def gen-rich-world
+  (c/gen-let [room-data        gen-feature-room
+              player           gen-player
+              creature-spawns  gen-creature-spawns
+              item-spawns      gen-item-spawns
+              fire-ttls        (gen-fire-ttl-for-cells (:fire-cells room-data))]
+    (-> (:world room-data)
+        (assoc-in [:entities :player] player)
+        (spawn-creatures creature-spawns)
+        (spawn-items item-spawns)
+        (assoc :fire-ttl fire-ttls))))

--- a/xsofy/check_gen.lg
+++ b/xsofy/check_gen.lg
@@ -46,10 +46,7 @@
   (let [w 10
         h 10
         t (terrain/make-terrain w h)]
-    ;; carve a floor inside the perimeter
-    (doseq [y (range 1 (dec h))
-            x (range 1 (dec w))]
-      (terrain/tset! t w x y 1))   ;; 1 = floor-stone
+    (terrain/carve-room! t w 1 1 (- w 2) (- h 2))
     {:terrain t
      :width w
      :height h
@@ -214,14 +211,30 @@
 ;; Feature room + player + 0-3 creatures + 0-3 items + fire-ttl for any
 ;; fire tiles. This is the workhorse generator for movement and effects.
 
-(defn- spawn-creatures [world spawns]
+(defn- occupied-positions
+  "Set of positions already held by non-item entities."
+  [world]
+  (->> (vals (:entities world))
+       (filter (fn [e] (and (:pos e) (not= :item (:entity-type e)))))
+       (map :pos)
+       set))
+
+(defn- spawn-creatures
+  "Spawn creatures, skipping any whose position collides with an existing
+   non-item entity. Preserves the no-creature-collisions invariant."
+  [world spawns]
   (reduce (fn [w {:keys [species pos]}]
-            (try (ent/spawn w species pos)
-                 (catch _ w)))   ;; silently ignore unknown species
+            (if (contains? (occupied-positions w) pos)
+              w   ;; collision — skip
+              (try (ent/spawn w species pos)
+                   (catch _ w))))
           world
           spawns))
 
-(defn- spawn-items [world spawns]
+(defn- spawn-items
+  "Spawn items. Items may share a tile with creatures, so no collision check
+   is needed at the item layer."
+  [world spawns]
   (reduce (fn [w {:keys [species pos]}]
             (try (ent/spawn-item w species pos)
                  (catch _ w)))
@@ -246,16 +259,27 @@
 ;; player as attacker by default and a random creature as target, falling
 ;; back gracefully if no creatures exist.
 
+(defn- first-free-position
+  "Find the first interior position not already held by a non-item entity."
+  [world]
+  (let [occupied (occupied-positions world)]
+    (first (for [y (range 1 (dec (:height world)))
+                 x (range 1 (dec (:width world)))
+                 :let [p [x y]]
+                 :when (not (contains? occupied p))]
+             p))))
+
 (def gen-rich-world-with-creature
-  ;; Generate worlds until we get one with at least one non-player creature.
-  ;; In practice this is ~90% of worlds, so a small retry budget suffices.
+  ;; If natural sampling didn't produce a creature, force-add a goblin on the
+  ;; first free interior tile so we don't violate no-collisions.
   (c/gen-let [world gen-rich-world]
     (let [has-creature? (some (fn [e] (and (:ai e) (not= :player (:id e))))
                               (vals (:entities world)))]
       (if has-creature?
         world
-        ;; force-add a goblin so the combat properties have a target
-        (ent/spawn world :goblin [5 5])))))
+        (if-let [pos (first-free-position world)]
+          (ent/spawn world :goblin pos)
+          world)))))
 
 (defn creature-ids
   "All non-player ids that have a :body."
@@ -264,3 +288,89 @@
        (filter (fn [e] (and (:body e) (not= :player (:id e)))))
        (map :id)
        vec))
+
+;; ============================================================================
+;; World invariants
+;; ============================================================================
+;;
+;; The single source of truth for what 'a valid world' means. The generator
+;; should produce only worlds that satisfy this predicate, and every
+;; world-mutating operation in the codebase should preserve it.
+;;
+;; The list of invariants is intentionally documented in code rather than in
+;; prose elsewhere so it stays in sync with the predicate.
+
+(def ^:private fire-tile-id 15)
+(def ^:private item-entity-type :item)
+
+(defn- in-bounds? [width height pos]
+  (when pos
+    (let [[x y] pos]
+      (and (some? x) (some? y) (integer? x) (integer? y)
+           (>= x 0) (< x width)
+           (>= y 0) (< y height)))))
+
+(defn- entity-shape-ok? [e]
+  ;; an entity must have :id and :template; anything without them is a
+  ;; resurrection shell. Items are exempt from needing a body; creatures
+  ;; (anything with :ai or named :player) must have a body+pos OR be absent.
+  (and (map? e)
+       (some? (:id e))
+       (some? (:template e))))
+
+(defn- player-shape-ok? [p]
+  ;; player is either absent OR fully formed
+  (or (nil? p)
+      (and (entity-shape-ok? p)
+           (some? (:pos p))
+           (some? (:body p)))))
+
+(defn- entity-ok? [entities width height [k e]]
+  ;; Checks invariants 2-7 for a single entity in one pass.
+  (and (entity-shape-ok? e)
+       (= k (:id e))
+       (or (nil? (:pos e)) (in-bounds? width height (:pos e)))
+       (every? (fn [iid] (some? (get entities iid)))
+               (or (:inventory e) []))
+       (every? (fn [iid] (or (nil? iid) (some? (get entities iid))))
+               (vals (or (:equipment e) {})))
+       (let [hp (get-in e [:body :hp])]
+         (or (nil? hp) (>= hp 0)))))
+
+(defn- fire-ttl-references-fire? [world]
+  (let [{:keys [terrain width fire-ttl]} world]
+    (every? (fn [[[x y] _]]
+              (and (integer? x) (integer? y)
+                   (= fire-tile-id (terrain/tget terrain width x y))))
+            (or fire-ttl {}))))
+
+(defn world-invariants?
+  "True iff `world` satisfies all structural invariants. Returns false
+   instead of throwing if the world is malformed.
+
+   Invariants checked:
+     1. :player is absent or fully formed (id, template, pos, body)
+     2. Every entity has :id and :template (no partial shells)
+     3. Every entity with :pos is in bounds
+     4. Each entity's :id matches its key in :entities
+     5. Every inventory id references an existing entity
+     6. Every equipment slot id references an existing entity (or is nil)
+     7. Every entity with a :body has :hp >= 0
+     8. Every :fire-ttl key points at a fire tile (id 15)
+
+   Notes:
+   - Positional collisions (two non-item entities on the same tile) are NOT
+     enforced here. Whether stacking entities triggers damage, pushback, or
+     is otherwise disallowed is a gameplay policy decision for the author,
+     not a structural invariant. The generator separately avoids creating
+     initial-state collisions (see gen-rich-world) for cleaner test
+     scenarios."
+  [world]
+  (try
+    (let [entities (or (:entities world) {})
+          {:keys [width height]} world]
+      (and (player-shape-ok? (get entities :player))
+           (every? (fn [pair] (entity-ok? entities width height pair))
+                   entities)
+           (fire-ttl-references-fire? world)))
+    (catch _ false)))

--- a/xsofy/debug.lg
+++ b/xsofy/debug.lg
@@ -2,6 +2,8 @@
   (:require [io :refer [open write! flush! close!]]))
 
 (def log-file (atom nil))
+(def latest-world (atom nil))
+(def last-checkpoint (atom (fn [] "<none>")))
 
 (defn ensure-log []
   (when (nil? @log-file)
@@ -18,3 +20,61 @@
   (when @log-file
     (close! @log-file)
     (reset! log-file nil)))
+
+;; --- Invariants ---
+
+(defn verify-world! [world checkpoint-fn]
+  "Assert player invariants. Throws if violated; checkpoint-fn is only
+   called to name the failure site."
+  (let [player (get-in world [:entities :player])]
+    (when player
+      (when (nil? (:pos player))
+        (throw (str "INVARIANT FAIL @ " (checkpoint-fn)
+                    ": :player exists but :pos is nil. player keys = "
+                    (keys player))))
+      (let [[x y] (:pos player)]
+        (when (or (nil? x) (nil? y))
+          (throw (str "INVARIANT FAIL @ " (checkpoint-fn)
+                      ": :player :pos contains nil coord: " (:pos player)))))
+      (when (nil? (get-in player [:body :hp]))
+        (throw (str "INVARIANT FAIL @ " (checkpoint-fn)
+                    ": :player :body :hp is nil"))))))
+
+(defmacro snapshot! [world & checkpoint-parts]
+  "Stash world for crash dumping and run invariants. The checkpoint
+   string is only constructed if an invariant fails or a crash dump
+   is later written — every-turn overhead is just two atom resets."
+  `(let [w# ~world
+         ckpt# (fn [] (str ~@checkpoint-parts))]
+     (reset! xsofy.debug/latest-world w#)
+     (reset! xsofy.debug/last-checkpoint ckpt#)
+     (xsofy.debug/verify-world! w# ckpt#)
+     w#))
+
+;; --- Crash Dump ---
+
+(def redacted-keys
+  ;; large/noisy fields excluded to keep the dump readable
+  #{:terrain :memory :floors :lights :fov :log})
+
+(defn redact-world [world]
+  (when world
+    (reduce (fn [m k]
+              (if (contains? redacted-keys k)
+                (assoc m k (str "<redacted " (name k) ">"))
+                (assoc m k (get world k))))
+            {} (keys world))))
+
+(defn dump-crash! [error]
+  "Write the most recent world (redacted) and error to crash-dump.edn."
+  (when-not *in-wasm*
+    (let [f (open "crash-dump.edn" :write)
+          w (redact-world @latest-world)]
+      (write! f (str ";; xsofy crash dump\n"
+                     ";; last checkpoint: " (@last-checkpoint) "\n"
+                     ";; error:\n"
+                     (str error) "\n\n"
+                     ";; world (terrain/floors/memory/etc redacted):\n"
+                     (str w) "\n"))
+      (flush! f)
+      (close! f))))

--- a/xsofy/entities.lg
+++ b/xsofy/entities.lg
@@ -229,29 +229,32 @@
 
 (defn pickup-item [world item-id owner-id]
   (let [item (get-in world [:entities item-id])
+        owner (get-in world [:entities owner-id])
         slot (get-in item [:item :slot])
         template (:template item)]
-    ;; stackable consumables
-    (if (and (= slot :consumable) template)
-      (if-let [existing (find-stack world owner-id template)]
-        ;; stack: add incoming count to existing, remove picked-up entity
-        (let [old-count (or (get-in world [:entities existing :item :count]) 1)
-              add-count (or (get-in item [:item :count]) 1)]
-          (-> world
-              (assoc-in [:entities existing :item :count] (+ old-count add-count))
-              (update :entities dissoc item-id)))
-        ;; no stack exists, add normally
+    ;; no owner = no pickup (avoid resurrecting a dead entity as {:inventory ...})
+    (when owner
+      ;; stackable consumables
+      (if (and (= slot :consumable) template)
+        (if-let [existing (find-stack world owner-id template)]
+          ;; stack: add incoming count to existing, remove picked-up entity
+          (let [old-count (or (get-in world [:entities existing :item :count]) 1)
+                add-count (or (get-in item [:item :count]) 1)]
+            (-> world
+                (assoc-in [:entities existing :item :count] (+ old-count add-count))
+                (update :entities dissoc item-id)))
+          ;; no stack exists, add normally
+          (if (inventory-full? world owner-id)
+            nil
+            (-> world
+                (update-in [:entities owner-id :inventory] #(conj (or % []) item-id))
+                (assoc-in [:entities item-id :pos] nil))))
+        ;; non-stackable
         (if (inventory-full? world owner-id)
           nil
           (-> world
               (update-in [:entities owner-id :inventory] #(conj (or % []) item-id))
-              (assoc-in [:entities item-id :pos] nil))))
-      ;; non-stackable
-      (if (inventory-full? world owner-id)
-        nil
-        (-> world
-            (update-in [:entities owner-id :inventory] #(conj (or % []) item-id))
-            (assoc-in [:entities item-id :pos] nil))))))
+              (assoc-in [:entities item-id :pos] nil)))))))
 
 (defn drop-item [world item-id owner-id]
   (let [owner-pos (get-in world [:entities owner-id :pos])]

--- a/xsofy/runes.lg
+++ b/xsofy/runes.lg
@@ -139,11 +139,26 @@
   "Format raw rune tokens as glyphs (player-facing, obfuscated)."
   (apply str (interpose "" (mapv #(rune-glyph rune-table %) tokens))))
 
+(defn- dissonant-glyphs
+  "Pick 2-3 random rune glyphs to render in place of a parser error
+   sentinel. The glyphs shift each render call, suggesting the runes
+   haven't settled into a coherent form. Not decodable — no rune-table
+   entry binds these glyphs in this context."
+  []
+  (let [n (+ 2 (rand-int 2))]
+    (apply str (repeatedly n #(nth rune-glyphs (rand-int (count rune-glyphs)))))))
+
 (defn format-sexp-step [rune-table step]
-  "Format one parsed step as s-expression with identification."
+  "Format one parsed step as s-expression with identification.
+   Parser error sentinels are rendered as shifting random glyphs so
+   internal shape never leaks into player-facing inscription text."
   (cond
     (number? step) (str step)
     (keyword? step) (rune-display rune-table step)
+    ;; Parser error sentinel (e.g. (:mul) or (:add) with missing args).
+    ;; The runes failed to bind into a coherent step; show as garbled
+    ;; glyph noise that shifts on each look.
+    (and (map? step) (:error step)) (dissonant-glyphs)
     (vector? step)
     (str "(" (apply str (interpose " " (mapv #(format-sexp-step rune-table %) step))) ")")
     :else (str step)))

--- a/xsofy/runes.lg
+++ b/xsofy/runes.lg
@@ -118,12 +118,12 @@
                   (let [a (parse-one) b (parse-one)]
                     (if (and (number? a) (number? b))
                       (* a b)
-                      {:error :bad-argument :rune :mul :args [a b]}))
+                      {:error true :rune :mul :reason :bad-argument :args [a b]}))
                   (= tok :add)
                   (let [a (parse-one) b (parse-one)]
                     (if (and (number? a) (number? b))
                       (+ a b)
-                      {:error :bad-argument :rune :add :args [a b]}))
+                      {:error true :rune :add :reason :bad-argument :args [a b]}))
                   :else tok)))]
       (loop []
         (when (< @pos (count tokens))

--- a/xsofy/spell.lg
+++ b/xsofy/spell.lg
@@ -86,17 +86,31 @@
 (defn r-spread [ctx n]
   (let [w (:world ctx)
         hits (:hits ctx)
-        current-positions (:cursors ctx)
-        candidates (->> (vals (:entities w))
-                        (filter (fn [e] (and (some? e) (map? e) (:pos e)
-                                              (not= (:caster ctx) (:id e))
-                                              (not (contains? hits (:id e)))
-                                              (not (contains? current-positions (:pos e))))))
-                        (sort-by (fn [e]
-                                   (apply min (map (fn [p] (distance p (:pos e)))
-                                                   current-positions))))
-                        (take n))]
-    (assoc ctx :cursors (set (map :pos candidates)))))
+        current-positions (:cursors ctx)]
+    ;; No source points → nothing to spread from. Also avoids (apply min ())
+    ;; in the sort comparator below.
+    (if (empty? current-positions)
+      ctx
+      (let [;; Force eager realization — let-go's lazy sort-by on a lazy filter
+            ;; result can nil-pointer when the filter is empty.
+            matching (vec (filter (fn [e]
+                                    (and (some? e) (map? e) (:pos e)
+                                         (not= (:caster ctx) (:id e))
+                                         (not (contains? hits (:id e)))
+                                         (not (contains? current-positions (:pos e)))))
+                                  (vals (:entities w))))
+            sorted (sort-by (fn [e]
+                              (apply min (map (fn [p] (distance p (:pos e)))
+                                              current-positions)))
+                            matching)
+            ;; vec to defeat a let-go quirk where (map f (take n lazy-seq))
+            ;; can return spurious nils on empty input.
+            candidates (vec (take n sorted))
+            ;; vec-then-set: in let-go, (set (filter some? (map ...))) over an
+            ;; empty input wrongly produces #{nil}. Forcing through vec first
+            ;; sidesteps it.
+            positions (vec (filter some? (map :pos candidates)))]
+        (assoc ctx :cursors (set positions))))))
 
 ;; --- Effect Primitives (do things at cursors) ---
 

--- a/xsofy/status.lg
+++ b/xsofy/status.lg
@@ -21,14 +21,21 @@
 ;; --- Apply / Remove ---
 
 (defn apply-status [world entity-id stype ttl]
-  (let [current (get-in world [:entities entity-id :statuses stype])
-        ;; refresh: take the longer duration
-        new-ttl (if current (max ttl (or (:ttl current) 0)) ttl)]
-    (assoc-in world [:entities entity-id :statuses stype]
-              {:ttl new-ttl :max-ttl new-ttl})))
+  ;; No-op if the entity doesn't exist — assoc-in would otherwise resurrect
+  ;; it as a {:statuses {...}} shell.
+  (if (nil? (get-in world [:entities entity-id]))
+    world
+    (let [current (get-in world [:entities entity-id :statuses stype])
+          new-ttl (if current (max ttl (or (:ttl current) 0)) ttl)]
+      (assoc-in world [:entities entity-id :statuses stype]
+                {:ttl new-ttl :max-ttl new-ttl}))))
 
 (defn remove-status [world entity-id stype]
-  (update-in world [:entities entity-id :statuses] dissoc stype))
+  ;; Same guard as apply-status. update-in on a missing path would otherwise
+  ;; create {:entities {entity-id {:statuses nil}}}.
+  (if (nil? (get-in world [:entities entity-id]))
+    world
+    (update-in world [:entities entity-id :statuses] dissoc stype)))
 
 (defn has-status? [world entity-id stype]
   (some? (get-in world [:entities entity-id :statuses stype])))
@@ -44,19 +51,20 @@
       world
       (reduce
         (fn [w [stype sdata]]
-          (let [def_ (get status-defs stype)
-                ttl (dec (or (:ttl sdata) 1))
-                dmg (or (:dmg def_) 0)]
-            (if (<= ttl 0)
-              ;; expired — remove
-              (remove-status w entity-id stype)
-              ;; tick — apply damage if any, update ttl
-              (let [w (if (and (> dmg 0) (get-in w [:entities entity-id]))
-                        (ent/damage-entity w entity-id dmg)
-                        w)]
-                (if (get-in w [:entities entity-id])
-                  (assoc-in w [:entities entity-id :statuses stype :ttl] ttl)
-                  w)))))
+          ;; Bail out if a prior tick (or external code) removed the entity.
+          (if (nil? (get-in w [:entities entity-id]))
+            w
+            (let [def_ (get status-defs stype)
+                  ttl (dec (or (:ttl sdata) 1))
+                  dmg (or (:dmg def_) 0)]
+              (if (<= ttl 0)
+                (remove-status w entity-id stype)
+                (let [w (if (> dmg 0)
+                          (ent/damage-entity w entity-id dmg)
+                          w)]
+                  (if (get-in w [:entities entity-id])
+                    (assoc-in w [:entities entity-id :statuses stype :ttl] ttl)
+                    w))))))
         world
         statuses))))
 

--- a/xsofy/test/check_test.lg
+++ b/xsofy/test/check_test.lg
@@ -1,0 +1,332 @@
+(ns xsofy.test.check-test
+  (:require [test :refer [deftest is testing]]
+            [string :as str]
+            [xsofy.check :as c]))
+
+;; ============================================================================
+;; RNG
+;; ============================================================================
+
+(deftest rng-produces-integers
+  (testing "rng-next returns an integer in [0, 2^31)"
+    (let [r (c/rng 42)
+          [n _] (c/rng-next r)]
+      (is (integer? n))
+      (is (>= n 0)))))
+
+(deftest rng-is-deterministic
+  (testing "Same seed gives same sequence"
+    (let [r1 (c/rng 42)
+          r2 (c/rng 42)
+          [n1 _] (c/rng-next r1)
+          [n2 _] (c/rng-next r2)]
+      (is (= n1 n2))
+      (is (integer? n1)))))
+
+(deftest rng-different-seeds-differ
+  (testing "Different seeds give different first values"
+    (let [[n1 _] (c/rng-next (c/rng 1))
+          [n2 _] (c/rng-next (c/rng 2))]
+      (is (not= n1 n2)))))
+
+(deftest rng-advances
+  (testing "Consecutive calls produce different values"
+    (let [r0 (c/rng 42)
+          [n1 r1] (c/rng-next r0)
+          [n2 _]  (c/rng-next r1)]
+      (is (not= n1 n2)))))
+
+(deftest rng-split-produces-independent-streams
+  (testing "rng-split returns two RNGs that produce different sequences"
+    (let [r (c/rng 42)
+          [rl rr] (c/rng-split r)
+          [nl _] (c/rng-next rl)
+          [nr _] (c/rng-next rr)]
+      (is (not= nl nr))))
+  (testing "split is deterministic"
+    (let [[a1 a2] (c/rng-split (c/rng 42))
+          [b1 b2] (c/rng-split (c/rng 42))
+          [na _] (c/rng-next a1)
+          [nb _] (c/rng-next b1)]
+      (is (= na nb)))))
+
+;; ============================================================================
+;; Rose tree
+;; ============================================================================
+
+(deftest pure-makes-leaf
+  (testing "pure produces a rose with the value and no shrinks"
+    (let [r (c/pure 42)]
+      (is (= 42 (c/rose-value r)))
+      (is (empty? (c/rose-shrinks r))))))
+
+(deftest rose-map-transforms-value-and-shrinks
+  (testing "rose-map applies f to value and recursively to shrinks"
+    (let [r {:value 3 :shrinks [(c/pure 2) (c/pure 1) (c/pure 0)]}
+          m (c/rose-map inc r)]
+      (is (= 4 (c/rose-value m)))
+      (is (= [3 2 1] (map c/rose-value (c/rose-shrinks m)))))))
+
+(deftest rose-filter-keeps-passing-and-prunes-failing
+  (testing "values failing the predicate are dropped; shrinks recurse"
+    (let [r {:value 5 :shrinks [(c/pure 4) (c/pure 3) (c/pure 2) (c/pure 1)]}
+          f (c/rose-filter odd? r)]
+      (is (= 5 (c/rose-value f)))
+      (is (= [3 1] (map c/rose-value (c/rose-shrinks f))))))
+  (testing "filter on a value that fails returns nil"
+    (is (nil? (c/rose-filter odd? (c/pure 4))))))
+
+(deftest shrink-int-yields-zero-and-halves
+  (testing "shrink-int 0 → []"
+    (is (empty? (c/shrink-int 0))))
+  (testing "shrink-int 8 starts at 0 and halves toward target"
+    (is (= [0 4 6 7] (vec (c/shrink-int 8)))))
+  (testing "shrink-int handles negatives: include positive twin and halve"
+    (is (some #(= 0 %) (c/shrink-int -8)))
+    (is (some #(= 8 %) (c/shrink-int -8)))))
+
+(deftest int-rose-shrinks-toward-zero
+  (testing "an int rose tree has 0 as one of its shrinks"
+    (let [r (c/int-rose 10)]
+      (is (= 10 (c/rose-value r)))
+      (is (some #(= 0 (c/rose-value %)) (c/rose-shrinks r))))))
+
+;; ============================================================================
+;; Generators — (fn [rng size]) -> rose-tree
+;; ============================================================================
+
+(deftest return-yields-constant-value
+  (testing "return wraps a plain value as a generator"
+    (let [g (c/return :foo)
+          r (g (c/rng 1) 100)]
+      (is (= :foo (c/rose-value r)))
+      (is (empty? (c/rose-shrinks r))))))
+
+(deftest return-is-deterministic-across-seeds
+  (testing "return ignores rng — always yields the same value"
+    (let [g (c/return 42)]
+      (is (= 42 (c/rose-value (g (c/rng 1) 100))))
+      (is (= 42 (c/rose-value (g (c/rng 9999) 0)))))))
+
+(deftest gen-let-binds-and-evaluates-body
+  (testing "gen-let flattens nested binds: (gen-let [x g1, y g2] body)"
+    (let [g (c/gen-let [a (c/gen-int 0 10)
+                        b (c/gen-int 100 200)]
+              (+ a b))
+          v (c/rose-value (g (c/rng 1) 100))]
+      (is (and (>= v 100) (<= v 210))))))
+
+(deftest gen-let-supports-using-earlier-bindings
+  (testing "later generators can depend on earlier bound values"
+    (let [g (c/gen-let [n (c/gen-int 1 5)
+                        v (c/gen-int 100 (+ 100 n))]
+              [n v])
+          [n v] (c/rose-value (g (c/rng 1) 100))]
+      (is (and (>= n 1) (<= n 5)))
+      (is (and (>= v 100) (<= v (+ 100 n)))))))
+
+(deftest sample-returns-default-count-of-values
+  (testing "(sample gen) returns ~10 sample values"
+    (let [vs (c/sample (c/gen-int 0 100))]
+      (is (= 10 (count vs)))
+      (is (every? #(and (>= % 0) (<= % 100)) vs)))))
+
+(deftest sample-supports-custom-count
+  (testing "(sample gen n) returns n values"
+    (let [vs (c/sample (c/gen-int 0 100) 3)]
+      (is (= 3 (count vs))))))
+
+;; ============================================================================
+;; Counterexample formatting
+;; ============================================================================
+
+(deftest format-value-shortens-byte-arrays
+  (testing "byte-array contents are shortened in the printed output"
+    (let [ba (byte-array (range 200))
+          s (c/format-value ba)]
+      (is (< (count s) 100))
+      (is (str/includes? s "byte-array")))))
+
+(deftest format-value-handles-nested-maps
+  (testing "deep maps containing byte-arrays still get redacted"
+    (let [world {:terrain (byte-array (range 200))
+                 :entities {:player {:pos [1 2]}}
+                 :turn 0}
+          s (c/format-value world)]
+      (is (str/includes? s ":entities"))
+      (is (str/includes? s ":turn"))
+      ;; full byte-array values should be redacted out
+      (is (not (str/includes? s "199"))))))
+
+(deftest format-value-passes-small-values-through
+  (testing "small values are unchanged"
+    (is (= "42" (c/format-value 42)))
+    (is (= ":foo" (c/format-value :foo)))
+    (is (= "[1 2 3]" (c/format-value [1 2 3])))))
+
+;; ============================================================================
+;; Generators
+;; ============================================================================
+
+(deftest gen-int-bounded-produces-value-in-range
+  (testing "gen-int with range lo..hi produces a value in [lo, hi]"
+    (let [g (c/gen-int 5 10)
+          r (g (c/rng 42) 100)
+          v (c/rose-value r)]
+      (is (and (>= v 5) (<= v 10))))))
+
+(deftest gen-int-bounded-is-deterministic
+  (testing "same seed -> same value"
+    (let [g (c/gen-int 0 1000)
+          r1 (g (c/rng 7) 100)
+          r2 (g (c/rng 7) 100)]
+      (is (= (c/rose-value r1) (c/rose-value r2))))))
+
+(deftest gen-int-shrinks-toward-lo
+  (testing "the rose tree from gen-int shrinks toward the lower bound"
+    (let [g (c/gen-int 0 100)
+          r (g (c/rng 42) 100)
+          shrunk (map c/rose-value (c/rose-shrinks r))]
+      (is (some #(= 0 %) shrunk)))))
+
+(deftest gen-bool-produces-bool
+  (testing "gen-bool returns true or false"
+    (let [g (c/gen-bool)
+          v (c/rose-value (g (c/rng 1) 100))]
+      (is (or (= true v) (= false v))))))
+
+(deftest gen-elements-picks-from-coll
+  (testing "gen-elements returns a member of the collection"
+    (let [g (c/gen-elements [:a :b :c])
+          v (c/rose-value (g (c/rng 1) 100))]
+      (is (contains? #{:a :b :c} v)))))
+
+(deftest gen-elements-shrinks-toward-first
+  (testing "shrinks contain the first element"
+    (let [g (c/gen-elements [:a :b :c :d])
+          ;; try seeds until we get a non-first pick
+          values (map #(c/rose-value (g (c/rng %) 100)) (range 20))
+          non-first-seed (first (filter (fn [s]
+                                          (let [r (g (c/rng s) 100)]
+                                            (not= :a (c/rose-value r))))
+                                        (range 20)))
+          r (when non-first-seed (g (c/rng non-first-seed) 100))]
+      (when r
+        (is (some #(= :a (c/rose-value %)) (c/rose-shrinks r)))))))
+
+(deftest fmap-transforms-value
+  (testing "fmap applies f over the generator's value"
+    (let [g (c/fmap inc (c/gen-int 0 10))
+          v (c/rose-value (g (c/rng 1) 100))]
+      (is (and (>= v 1) (<= v 11))))))
+
+(deftest fmap-preserves-shrinking
+  (testing "fmap'd rose still shrinks (via rose-map)"
+    ;; gen-int 0 50 shrinks toward 0; fmap *10 preserves that
+    (let [g (c/fmap #(* 10 %) (c/gen-int 0 50))
+          r (g (c/rng 3) 100)
+          shrunk-vals (set (map c/rose-value (c/rose-shrinks r)))]
+      (is (contains? shrunk-vals 0)))))
+
+(deftest bind-threads-rng
+  (testing "bind composes generators using the inner rng"
+    (let [g (c/bind (c/gen-int 1 5)
+              (fn [n] (c/gen-int 100 (+ 100 n))))
+          v (c/rose-value (g (c/rng 1) 100))]
+      (is (and (>= v 100) (<= v 105))))))
+
+(deftest gen-vector-length-bounded
+  (testing "gen-vector produces a vector of bounded length"
+    (let [g (c/gen-vector (c/gen-int 0 9) 3)
+          v (c/rose-value (g (c/rng 1) 100))]
+      (is (vector? v))
+      (is (= 3 (count v)))
+      (is (every? #(and (>= % 0) (<= % 9)) v)))))
+
+(deftest gen-vector-shrinks
+  (testing "variable-length gen-vector shrinks by dropping elements"
+    ;; arity 3 = bounded length, so length can shrink
+    (let [g (c/gen-vector (c/gen-int 0 9) 0 5)
+          r (g (c/rng 1) 100)
+          n (count (c/rose-value r))
+          shrunk-lens (set (map (comp count c/rose-value) (c/rose-shrinks r)))]
+      (when (> n 0)
+        (is (some #(< % n) shrunk-lens)))))
+  (testing "variable-length gen-vector eventually shrinks toward []"
+    (let [g (c/gen-vector (c/gen-int 0 9) 0 3)
+          r (g (c/rng 1) 100)
+          ;; [] should appear in the direct shrinks (length shrinks are tried first)
+          direct (set (map c/rose-value (c/rose-shrinks r)))]
+      (is (contains? direct [])))))
+
+(deftest gen-tuple-combines-generators
+  (testing "gen-tuple produces a vector of generator values"
+    (let [g (c/gen-tuple (c/gen-int 0 9) (c/gen-bool))
+          v (c/rose-value (g (c/rng 1) 100))]
+      (is (= 2 (count v)))
+      (let [[n b] v]
+        (is (and (>= n 0) (<= n 9)))
+        (is (or (true? b) (false? b)))))))
+
+(deftest gen-frequency-respects-weights
+  (testing "frequency picks roughly in proportion (high-weight dominates)"
+    (let [g (c/gen-frequency [[9 (c/gen-elements [:hi])]
+                              [1 (c/gen-elements [:lo])]])
+          samples (map #(c/rose-value (g (c/rng %) 100)) (range 200))
+          hi-count (count (filter #(= :hi %) samples))]
+      ;; with 9:1 weights and 200 samples, hi should heavily dominate
+      (is (> hi-count 150)))))
+
+;; ============================================================================
+;; Runner — check, for-all, defprop
+;; ============================================================================
+
+(deftest check-passes-tautology
+  (testing "(check (for-all [n (gen-int 0 100)] true)) → :pass"
+    (let [p (c/for-all [n (c/gen-int 0 100)] true)
+          r (c/check p {:num-tests 20 :seed 1})]
+      (is (= :pass (:result r)))
+      (is (= 20 (:num-tests r))))))
+
+(deftest check-fails-contradiction
+  (testing "(check (for-all [n (gen-int 0 100)] false)) → :fail"
+    (let [p (c/for-all [n (c/gen-int 0 100)] false)
+          r (c/check p {:num-tests 5 :seed 1})]
+      (is (= :fail (:result r))))))
+
+(deftest check-includes-seed-in-result
+  (testing "check always reports the seed used"
+    (let [p (c/for-all [n (c/gen-int 0 100)] true)
+          r (c/check p {:num-tests 5 :seed 12345})]
+      (is (= 12345 (:seed r))))))
+
+(deftest check-reports-counterexample
+  (testing "failure result contains the failing value"
+    ;; property: n is always < 5  (false for n >= 5)
+    (let [p (c/for-all [n (c/gen-int 0 100)] (< n 5))
+          r (c/check p {:num-tests 200 :seed 1})]
+      (is (= :fail (:result r)))
+      (is (vector? (:counterexample r)))
+      (is (= 1 (count (:counterexample r))))
+      (let [[n] (:counterexample r)]
+        (is (>= n 5))))))
+
+(deftest check-shrinks-to-minimum
+  (testing "failure shrinks to the smallest failing input"
+    ;; property: n < 5; should shrink to 5
+    (let [p (c/for-all [n (c/gen-int 0 100)] (< n 5))
+          r (c/check p {:num-tests 200 :seed 1})
+          [shrunk-n] (:counterexample (:shrunk r))]
+      (is (= 5 shrunk-n)))))
+
+(deftest check-catches-exceptions
+  (testing "if the property body throws, result is :fail with :error set"
+    (let [p (c/for-all [n (c/gen-int 0 10)] (throw "boom"))
+          r (c/check p {:num-tests 3 :seed 1})]
+      (is (= :fail (:result r)))
+      (is (some? (:error r))))))
+
+;; Smoke test of the defprop macro AND a tiny example.
+(c/defprop trivial-int-prop
+  [n (c/gen-int 0 1000)]
+  (>= n 0))

--- a/xsofy/test/combat_prop.lg
+++ b/xsofy/test/combat_prop.lg
@@ -1,0 +1,175 @@
+(ns xsofy.test.combat-prop
+  "Property tests for combat, push/spell interactions, save/restore, equipment,
+   and AI."
+  (:require [test :refer [deftest is testing]]
+            [xsofy.check :as c]
+            [xsofy.check-gen :as g]
+            [xsofy.world :as w]
+            [xsofy.entities :as ent]
+            [xsofy.spell :as spell]
+            [xsofy.ai :as ai]
+            [xsofy.runes :as runes]))
+
+;; ============================================================================
+;; Combat: melee-attack
+;; ============================================================================
+
+(c/defprop melee-attack-doesnt-throw
+  [world g/gen-rich-world-with-creature]
+  (let [targets (g/creature-ids world)]
+    (if (empty? targets)
+      true
+      (do (w/melee-attack world :player (first targets)) true))))
+
+(c/defprop melee-attack-preserves-invariants
+  [world g/gen-rich-world-with-creature]
+  (let [targets (g/creature-ids world)]
+    (if (empty? targets)
+      true
+      (g/world-invariants? (w/melee-attack world :player (first targets))))))
+
+;; ============================================================================
+;; Combat: ranged-attack
+;; ============================================================================
+
+(c/defprop ranged-attack-doesnt-throw
+  [world g/gen-rich-world-with-creature]
+  (let [targets (g/creature-ids world)]
+    (if (empty? targets)
+      true
+      (do (w/ranged-attack world :player (first targets)) true))))
+
+(c/defprop ranged-attack-preserves-invariants
+  [world g/gen-rich-world-with-creature]
+  (let [targets (g/creature-ids world)]
+    (if (empty? targets)
+      true
+      (g/world-invariants? (w/ranged-attack world :player (first targets))))))
+
+;; ============================================================================
+;; Push: r-push as a spell
+;; ============================================================================
+
+(c/defprop push-spell-doesnt-throw
+  [world g/gen-rich-world
+   target-pos g/gen-pos]
+  (do (spell/eval-spell world :player target-pos [:push]) true))
+
+(c/defprop push-spell-preserves-invariants
+  [world g/gen-rich-world
+   target-pos g/gen-pos]
+  (let [r (spell/eval-spell world :player target-pos [:push])]
+    (g/world-invariants? (:world r))))
+
+(c/defprop push-spell-respects-bounds
+  [world g/gen-rich-world
+   target-pos g/gen-pos]
+  (let [r (spell/eval-spell world :player target-pos [:push])
+        w' (:world r)
+        {:keys [width height]} w']
+    (every? (fn [e]
+              (if-let [[x y] (:pos e)]
+                (and (>= x 0) (< x width) (>= y 0) (< y height))
+                true))
+            (vals (:entities w')))))
+
+;; ============================================================================
+;; Equipment: equip / unequip / drop
+;; ============================================================================
+
+(defn make-test-item
+  "Build a synthetic weapon item id with deterministic stats."
+  [id]
+  {:id id :template :dagger :entity-type :item
+   :pos nil
+   :item {:slot :weapon :min-dmg 1 :max-dmg 2 :speed 100 :accuracy 100
+          :enchant 0 :str-req 0}})
+
+(deftest equip-puts-item-in-equipment-slot
+  (let [w {:entities {:player {:id :player :template :player
+                               :pos [1 1] :inventory [:test-dagger]
+                               :equipment {}}
+                      :test-dagger (make-test-item :test-dagger)}}
+        w' (ent/equip-item w :test-dagger :player)]
+    (is (= :test-dagger (get-in w' [:entities :player :equipment :weapon])))))
+
+(deftest unequip-removes-from-equipment
+  (let [w {:entities {:player {:id :player :template :player
+                               :pos [1 1] :inventory [:test-dagger]
+                               :equipment {:weapon :test-dagger}}
+                      :test-dagger (make-test-item :test-dagger)}}
+        w' (ent/unequip-item w :player :weapon)]
+    (is (nil? (get-in w' [:entities :player :equipment :weapon])))))
+
+(deftest drop-item-sets-pos-and-removes-from-inventory
+  (let [w {:entities {:player {:id :player :template :player
+                               :pos [3 4] :inventory [:test-dagger]}
+                      :test-dagger (make-test-item :test-dagger)}}
+        w' (ent/drop-item w :test-dagger :player)]
+    (is (= [3 4] (get-in w' [:entities :test-dagger :pos])))
+    (is (not (contains? (set (get-in w' [:entities :player :inventory]))
+                        :test-dagger)))))
+
+;; ============================================================================
+;; Save / restore round-trip
+;; ============================================================================
+
+(c/defprop extract-then-inject-preserves-player-and-items
+  [world g/gen-rich-world]
+  (let [[player items] (w/extract-player-items world)
+        ;; inject into a fresh empty world at original pos
+        fresh {:entities {} :turn 0 :width (:width world) :height (:height world)
+               :terrain (:terrain world) :gold 0 :rune-table {}}
+        restored (w/inject-player fresh player items (:pos player))
+        rp (get-in restored [:entities :player])]
+    (and (some? rp)
+         (= (:id rp) (:id player))
+         (= (:template rp) (:template player))
+         (= (:pos rp) (:pos player))
+         (every? (fn [iid] (some? (get-in restored [:entities iid])))
+                 (keys items)))))
+
+(c/defprop save-floor-removes-player
+  [world g/gen-rich-world]
+  (let [saved (w/save-current-floor world)
+        floor (get-in saved [:floors (:depth saved)])]
+    (and (not (contains? (:entities floor) :player))
+         ;; inventory items should also be removed from floor entities
+         (let [inv (or (get-in world [:entities :player :inventory]) [])]
+           (every? (fn [iid] (not (contains? (:entities floor) iid)))
+                   inv)))))
+
+;; ============================================================================
+;; AI in isolation
+;; ============================================================================
+
+(c/defprop ai-act-doesnt-throw
+  [world g/gen-rich-world-with-creature]
+  (let [creatures (g/creature-ids world)]
+    (if (empty? creatures)
+      true
+      (do (ai/ai-act world (first creatures)
+                     w/melee-attack w/ranged-attack)
+          true))))
+
+(c/defprop ai-act-preserves-invariants
+  [world g/gen-rich-world-with-creature]
+  (let [creatures (g/creature-ids world)]
+    (if (empty? creatures)
+      true
+      (g/world-invariants?
+        (ai/ai-act world (first creatures)
+                   w/melee-attack w/ranged-attack)))))
+
+;; ============================================================================
+;; creature-turn through process-creatures
+;; ============================================================================
+
+(c/defprop process-creatures-doesnt-throw
+  [world g/gen-rich-world]
+  (do (ai/process-creatures world w/melee-attack w/ranged-attack) true))
+
+(c/defprop process-creatures-preserves-invariants
+  [world g/gen-rich-world]
+  (g/world-invariants?
+    (ai/process-creatures world w/melee-attack w/ranged-attack)))

--- a/xsofy/test/invariant_test.lg
+++ b/xsofy/test/invariant_test.lg
@@ -1,0 +1,196 @@
+(ns xsofy.test.invariant-test
+  "Unit tests for the world-invariants? predicate that lives in xsofy.check-gen.
+   The predicate is the single source of truth for what 'a valid world' means;
+   the generator must produce only valid worlds, and every world-mutating
+   operation must preserve them."
+  (:require [test :refer [deftest is testing]]
+            [xsofy.check :as c]
+            [xsofy.check-gen :as g]
+            [xsofy.terrain :as terrain]))
+
+(defn- empty-room
+  "A 5x5 stone-floor room (interior = 3x3 floor, border = stone walls).
+   Includes the minimum fields the invariant predicate requires."
+  []
+  (let [w 5 h 5
+        t (terrain/make-terrain w h)]
+    (terrain/carve-room! t w 1 1 (- w 2) (- h 2))
+    {:terrain t :width w :height h
+     :entities {} :turn 0 :gold 0 :rune-table {}
+     :depth 1 :floors {}}))
+
+(defn- valid-player [pos]
+  {:id :player :template :player :pos pos
+   :ticks 0 :status {} :statuses {} :inventory []
+   :body {:hp 10 :max-hp 10 :strength 2 :armor 0}})
+
+;; ============================================================================
+;; Empty world / minimal world
+;; ============================================================================
+
+(deftest empty-world-with-player-is-valid
+  (let [w (assoc-in (empty-room) [:entities :player] (valid-player [2 2]))]
+    (is (g/world-invariants? w))))
+
+(deftest empty-room-with-no-player-is-valid
+  ;; An entity-less world is structurally valid even if it has no player.
+  (is (g/world-invariants? (empty-room))))
+
+;; ============================================================================
+;; Invariant 1: player well-formed
+;; ============================================================================
+
+(deftest invariant-fails-when-player-has-only-inventory
+  (let [bad (-> (empty-room)
+                (assoc-in [:entities :player] {:inventory [:dagger-1]}))]
+    (is (not (g/world-invariants? bad)))))
+
+(deftest invariant-fails-when-player-has-only-statuses
+  (let [bad (-> (empty-room)
+                (assoc-in [:entities :player] {:statuses {:burning {:ttl 1}}}))]
+    (is (not (g/world-invariants? bad)))))
+
+(deftest invariant-fails-when-player-pos-is-nil
+  (let [bad (-> (empty-room)
+                (assoc-in [:entities :player] (assoc (valid-player [2 2]) :pos nil)))]
+    (is (not (g/world-invariants? bad)))))
+
+;; ============================================================================
+;; Invariant 2: all entities well-formed (no partial shells)
+;; ============================================================================
+
+(deftest invariant-fails-on-partial-creature-shell
+  (let [bad (-> (empty-room)
+                (assoc-in [:entities :player] (valid-player [2 2]))
+                (assoc-in [:entities :ghost] {:statuses {:burning {:ttl 1}}}))]
+    (is (not (g/world-invariants? bad)))))
+
+;; ============================================================================
+;; Invariant 3: positions in bounds
+;; ============================================================================
+
+(deftest invariant-fails-on-out-of-bounds-player
+  (let [bad (-> (empty-room)
+                (assoc-in [:entities :player] (valid-player [99 99])))]
+    (is (not (g/world-invariants? bad)))))
+
+(deftest invariant-fails-on-negative-position
+  (let [bad (-> (empty-room)
+                (assoc-in [:entities :player] (valid-player [-1 0])))]
+    (is (not (g/world-invariants? bad)))))
+
+;; ============================================================================
+;; Invariant 4: entity id matches map key
+;; ============================================================================
+
+(deftest invariant-fails-on-mismatched-id
+  (let [bad (-> (empty-room)
+                (assoc-in [:entities :player] (valid-player [2 2]))
+                (assoc-in [:entities :rat-1]
+                          {:id :different :template :rat :pos [3 3]
+                           :body {:hp 5 :max-hp 5}}))]
+    (is (not (g/world-invariants? bad)))))
+
+;; ============================================================================
+;; Item-and-creature stacking is allowed at all times.
+;; Note: creature-on-creature stacking is intentionally NOT an invariant —
+;; that's a gameplay policy decision (e.g. push damage on bump). The
+;; generator avoids initial-state stacking for cleaner test scenarios; see
+;; gen-rich-world-avoids-initial-creature-collisions below.
+;; ============================================================================
+
+(deftest invariant-allows-item-and-creature-on-same-tile
+  (let [w (-> (empty-room)
+              (assoc-in [:entities :player] (valid-player [2 2]))
+              (assoc-in [:entities :gold-1]
+                        {:id :gold-1 :template :gold :entity-type :item
+                         :pos [2 2]}))]
+    (is (g/world-invariants? w))))
+
+(deftest invariant-allows-two-creatures-on-same-tile
+  ;; Not an invariant — runtime collisions can be legal depending on policy.
+  (let [w (-> (empty-room)
+              (assoc-in [:entities :player] (valid-player [2 2]))
+              (assoc-in [:entities :rat-1]
+                        {:id :rat-1 :template :rat :pos [2 2]
+                         :body {:hp 5 :max-hp 5} :ai {}}))]
+    (is (g/world-invariants? w))))
+
+;; ============================================================================
+;; Invariant 6: inventory item ids exist
+;; ============================================================================
+
+(deftest invariant-fails-on-orphan-inventory-id
+  (let [bad (-> (empty-room)
+                (assoc-in [:entities :player]
+                          (assoc (valid-player [2 2])
+                                 :inventory [:missing-item])))]
+    (is (not (g/world-invariants? bad)))))
+
+;; ============================================================================
+;; Invariant 7: HP non-negative
+;; ============================================================================
+
+(deftest invariant-fails-on-negative-hp
+  (let [bad (-> (empty-room)
+                (assoc-in [:entities :player]
+                          (assoc-in (valid-player [2 2]) [:body :hp] -3)))]
+    (is (not (g/world-invariants? bad)))))
+
+;; ============================================================================
+;; Invariant 8: fire-ttl keys reference actual fire tiles
+;; ============================================================================
+
+(deftest invariant-fails-on-fire-ttl-without-fire-tile
+  (let [bad (-> (empty-room)
+                (assoc-in [:entities :player] (valid-player [2 2]))
+                (assoc :fire-ttl {[2 2] 3}))]   ;; [2 2] is floor, not fire
+    (is (not (g/world-invariants? bad)))))
+
+(deftest invariant-allows-fire-ttl-on-fire-tile
+  (let [room (empty-room)
+        _ (terrain/tset! (:terrain room) (:width room) 2 2 15)   ; fire-tile
+        w (-> room
+              (assoc-in [:entities :player] (valid-player [1 1]))
+              (assoc :fire-ttl {[2 2] 3}))]
+    (is (g/world-invariants? w))))
+
+;; ============================================================================
+;; Generator hygiene: gen-rich-world must produce only valid worlds.
+;; ============================================================================
+
+(deftest gen-rich-world-only-produces-valid-worlds
+  (testing "100 samples from gen-rich-world all satisfy world-invariants?"
+    (let [worlds (c/sample g/gen-rich-world 100)
+          invalid (filter (complement g/world-invariants?) worlds)]
+      (is (empty? invalid)
+          (str (count invalid) " invalid worlds out of 100")))))
+
+(deftest gen-rich-world-with-creature-only-produces-valid-worlds
+  (testing "100 samples from gen-rich-world-with-creature are all valid"
+    (let [worlds (c/sample g/gen-rich-world-with-creature 100)
+          invalid (filter (complement g/world-invariants?) worlds)]
+      (is (empty? invalid)
+          (str (count invalid) " invalid worlds out of 100")))))
+
+(deftest gen-minimal-world-only-produces-valid-worlds
+  (testing "100 samples from gen-minimal-world are all valid"
+    (let [worlds (c/sample g/gen-minimal-world 100)
+          invalid (filter (complement g/world-invariants?) worlds)]
+      (is (empty? invalid)
+          (str (count invalid) " invalid worlds out of 100")))))
+
+(defn- has-creature-collision? [world]
+  (let [non-items (filter (fn [e] (and (:pos e) (not= :item (:entity-type e))))
+                          (vals (:entities world)))
+        positions (map :pos non-items)]
+    (not= (count positions) (count (set positions)))))
+
+(deftest gen-rich-world-avoids-initial-creature-collisions
+  (testing "Although collisions can be legal at runtime, the generator
+            should not produce them in the initial state — they confuse
+            test scenarios."
+    (let [worlds (c/sample g/gen-rich-world 100)
+          collisions (filter has-creature-collision? worlds)]
+      (is (empty? collisions)
+          (str (count collisions) " worlds had initial-state collisions")))))

--- a/xsofy/test/run.lg
+++ b/xsofy/test/run.lg
@@ -1,0 +1,7 @@
+(ns xsofy.test.run
+  (:require [test :refer [run-tests]]
+            [xsofy.test.check-test]
+            [xsofy.test.spell-prop]
+            [xsofy.test.world-prop]))
+
+(run-tests)

--- a/xsofy/test/run.lg
+++ b/xsofy/test/run.lg
@@ -1,6 +1,7 @@
 (ns xsofy.test.run
   (:require [test :refer [run-tests]]
             [xsofy.test.check-test]
+            [xsofy.test.invariant-test]
             [xsofy.test.spell-prop]
             [xsofy.test.world-prop]
             [xsofy.test.combat-prop]))

--- a/xsofy/test/run.lg
+++ b/xsofy/test/run.lg
@@ -2,6 +2,7 @@
   (:require [test :refer [run-tests]]
             [xsofy.test.check-test]
             [xsofy.test.spell-prop]
-            [xsofy.test.world-prop]))
+            [xsofy.test.world-prop]
+            [xsofy.test.combat-prop]))
 
 (run-tests)

--- a/xsofy/test/spell_prop.lg
+++ b/xsofy/test/spell_prop.lg
@@ -2,6 +2,7 @@
   "Property tests for the spell DSL. eval-spell must never throw on any
    sequence of raw tokens, well-formed or not."
   (:require [test :refer [deftest is testing]]
+            [string :as str]
             [xsofy.check :as c]
             [xsofy.check-gen :as g]
             [xsofy.runes :as runes]
@@ -125,6 +126,38 @@
          (= [r n] (first steps)))))
 
 ;; ============================================================================
+;; Player-facing display must never leak internal error-map shape.
+;; The spell DSL is meant to be discovered by the player; surfacing a Clojure
+;; map like {:reason :bad-argument :rune :add :args [nil nil] :error true}
+;; in the inscription UI breaks the discovery aesthetic and the fourth wall.
+;; ============================================================================
+
+(defn- looks-like-internal-map? [s]
+  ;; Heuristic: any of these tokens signal that an error-map's internal keys
+  ;; or sentinel values have leaked into the player-facing string.
+  (or (str/includes? s ":reason")
+      (str/includes? s ":error")
+      (str/includes? s ":bad-argument")
+      (str/includes? s ":unknown-rune")
+      (str/includes? s ":bad-step")
+      ;; Bare maps in inscriptions are also a leak — the formatter should
+      ;; never emit `{`/`}` in player-facing output (sets and vectors render
+      ;; differently in the Glyphs/Spell UI).
+      (str/includes? s "{")))
+
+(c/defprop format-sexp-doesnt-leak-internal-shape
+  [tokens gen-raw-program]
+  (let [tbl (runes/generate-rune-table)
+        s (runes/format-sexp tbl tokens)]
+    (not (looks-like-internal-map? s))))
+
+(c/defprop format-glyphs-doesnt-leak-internal-shape
+  [tokens gen-raw-program]
+  (let [tbl (runes/generate-rune-table)
+        s (runes/format-glyphs tbl tokens)]
+    (not (looks-like-internal-map? s))))
+
+;; ============================================================================
 ;; Targeted regression tests (from property-discovered failures)
 ;; ============================================================================
 
@@ -147,3 +180,14 @@
                            :body {:hp 30 :max-hp 30 :strength 2}
                            :status {}})]
       (is (some? (spell/eval-spell world :player [1 1] [:spread]))))))
+
+(deftest add-with-no-args-doesnt-leak-error-map-into-display
+  (testing "Inscribing :add (which needs two numeric args) with no args
+            produces a parser error. The player-facing format-sexp output
+            must not include the internal {:reason ... :error true} map."
+    (let [tbl (runes/generate-rune-table)
+          ;; Same shape as the player's screenshot: a selector then a
+          ;; math rune that consumes nothing.
+          s (runes/format-sexp tbl [:nearest :add])]
+      (is (not (looks-like-internal-map? s))
+          (str "format-sexp leaked internal map: " s)))))

--- a/xsofy/test/spell_prop.lg
+++ b/xsofy/test/spell_prop.lg
@@ -1,0 +1,149 @@
+(ns xsofy.test.spell-prop
+  "Property tests for the spell DSL. eval-spell must never throw on any
+   sequence of raw tokens, well-formed or not."
+  (:require [test :refer [deftest is testing]]
+            [xsofy.check :as c]
+            [xsofy.check-gen :as g]
+            [xsofy.runes :as runes]
+            [xsofy.spell :as spell]))
+
+;; --- Layer 1: raw token generators (fuzzing) ---
+
+(def gen-rune-key
+  (c/gen-elements [:self :target :nearest :area :spread
+                   :fire :ice :damage :heal :poison :arc :push :web :conjure
+                   :friend :repeat :wait :take :give
+                   :mind :body :essence :life :form
+                   :apply :mul :add]))
+
+(def gen-numeral (c/gen-int 1 5))
+
+(def gen-raw-token
+  (c/gen-frequency [[10 gen-rune-key]
+                    [3  gen-numeral]]))
+
+(def gen-raw-program
+  (c/gen-vector gen-raw-token 0 6))
+
+;; --- Layer 2: well-formed program fragments ---
+
+(def gen-leaf-rune
+  (c/gen-elements [:self :target :nearest :fire :ice :damage :heal
+                   :push :arc :web :poison :friend :wait]))
+
+(def gen-apply-fragment
+  (c/gen-let [r gen-leaf-rune
+              n gen-numeral]
+    [:apply r n]))
+
+(def gen-math-fragment
+  (c/gen-let [op (c/gen-elements [:mul :add])
+              a  gen-numeral
+              b  gen-numeral]
+    [op a b]))
+
+(def gen-well-formed-step
+  (c/gen-frequency [[3 (c/fmap (fn [r] [r]) gen-leaf-rune)]
+                    [2 gen-apply-fragment]
+                    [1 gen-math-fragment]]))
+
+(def gen-well-formed
+  (c/fmap (fn [steps] (vec (apply concat steps)))
+          (c/gen-vector gen-well-formed-step 1 4)))
+
+;; --- Helpers ---
+
+(defn eval-with [ctx tokens]
+  (spell/eval-spell (:world ctx) (:caster ctx) (:target ctx) tokens))
+
+(def gen-spell-context
+  (c/gen-let [cpos g/gen-pos
+              tpos g/gen-pos]
+    {:world  (assoc-in (g/minimal-stone-room)
+                       [:entities :player]
+                       {:id :player :template :player :pos cpos
+                        :body {:hp 30 :max-hp 30 :strength 2}
+                        :status {}})
+     :caster :player
+     :target tpos}))
+
+;; ============================================================================
+;; Core properties: parse and eval must never throw on any input.
+;; ============================================================================
+
+(c/defprop parse-never-throws
+  [tokens gen-raw-program]
+  (do (runes/parse-runes tokens) true))
+
+(c/defprop eval-never-throws-on-raw-tokens
+  [ctx gen-spell-context
+   tokens gen-raw-program]
+  (do (eval-with ctx tokens) true))
+
+(c/defprop eval-never-throws-on-well-formed
+  [ctx gen-spell-context
+   tokens gen-well-formed]
+  (do (eval-with ctx tokens) true))
+
+;; ============================================================================
+;; Structural invariants on eval result
+;; ============================================================================
+
+(c/defprop eval-returns-well-formed-result
+  [ctx gen-spell-context
+   tokens gen-raw-program]
+  (let [r (eval-with ctx tokens)]
+    (and (contains? r :world)
+         (contains? r :vfx)
+         (map? (:world r))
+         (vector? (:vfx r)))))
+
+(c/defprop bad-input-becomes-error-not-throw
+  [ctx gen-spell-context
+   tokens gen-raw-program]
+  (let [r (eval-with ctx tokens)
+        e (:error r)]
+    (or (nil? e)
+        (and (map? e)
+             (contains? e :rune)
+             (contains? e :reason)))))
+
+;; ============================================================================
+;; Parser structural properties
+;; ============================================================================
+
+(c/defprop parse-result-is-seqable
+  [tokens gen-raw-program]
+  (let [r (runes/parse-runes tokens)]
+    (or (vector? r) (seq? r) (nil? r))))
+
+(c/defprop apply-attaches-arg-to-leaf
+  [r gen-leaf-rune
+   n gen-numeral]
+  (let [steps (runes/parse-runes [:apply r n])]
+    (and (= 1 (count steps))
+         (= [r n] (first steps)))))
+
+;; ============================================================================
+;; Targeted regression tests (from property-discovered failures)
+;; ============================================================================
+
+(deftest spread-on-world-without-targets-doesnt-throw
+  (testing "[:spread :self :self :self] in a player-only world should not throw"
+    ;; This is the minimal counterexample QuickCheck found.
+    (let [world (assoc-in (g/minimal-stone-room)
+                          [:entities :player]
+                          {:id :player :template :player :pos [1 1]
+                           :body {:hp 30 :max-hp 30 :strength 2}
+                           :status {}})]
+      (is (some? (spell/eval-spell world :player [1 1]
+                                   [:spread :self :self :self]))))))
+
+(deftest bare-spread-on-empty-world-doesnt-throw
+  (testing "Bare :spread (default n=2) in a player-only world should not throw"
+    (let [world (assoc-in (g/minimal-stone-room)
+                          [:entities :player]
+                          {:id :player :template :player :pos [1 1]
+                           :body {:hp 30 :max-hp 30 :strength 2}
+                           :status {}})]
+      (is (some? (spell/eval-spell world :player [1 1] [:spread]))))))

--- a/xsofy/test/world_prop.lg
+++ b/xsofy/test/world_prop.lg
@@ -1,0 +1,59 @@
+(ns xsofy.test.world-prop
+  "Property tests for world-state updates. Scoped to the killer cases that
+   would have caught the burning-player resurrection crash."
+  (:require [test :refer [deftest is testing]]
+            [xsofy.check :as c]
+            [xsofy.check-gen :as g]
+            [xsofy.world :as w]))
+
+(defn player-well-formed?
+  "Player is either absent OR has all required keys."
+  [world]
+  (let [p (get-in world [:entities :player])]
+    (or (nil? p)
+        (and (some? (:pos p))
+             (some? (:body p))
+             (some? (:id p))
+             (some? (:template p))))))
+
+;; ============================================================================
+;; The killer property — catches the burning-player resurrection bug
+;; ============================================================================
+
+(c/defprop player-shape-survives-single-action
+  [world g/gen-minimal-world
+   action g/gen-action]
+  (player-well-formed? (w/update-world world action)))
+
+(c/defprop actions-never-throw
+  [world g/gen-minimal-world
+   actions g/gen-action-seq]
+  (do (reduce w/update-world world actions) true))
+
+(c/defprop turn-never-goes-backward
+  [world g/gen-minimal-world
+   action g/gen-action]
+  (>= (:turn (w/update-world world action)) (:turn world)))
+
+;; ============================================================================
+;; Targeted regression tests (from property-discovered failures)
+;; ============================================================================
+
+(deftest burning-low-hp-player-with-expiring-status-doesnt-resurrect
+  (testing "Player dies from burning AND has a status about to expire on same tick.
+            The remove-status of the expired one must not resurrect a dead player."
+    (let [world (-> (g/minimal-stone-room)
+                    (assoc-in [:entities :player]
+                      {:id :player :template :player :pos [5 3]
+                       :ticks 0
+                       :body {:hp 2 :max-hp 30 :strength 2 :armor 0}
+                       :status {}
+                       :statuses {:burning {:ttl 2 :max-ttl 2}
+                                  :frozen {:ttl 1 :max-ttl 1}}
+                       :inventory []}))
+          w' (w/update-world world :up)
+          p (get-in w' [:entities :player])]
+      ;; Either the player is gone entirely (correct) or fully intact (also
+      ;; acceptable, e.g. didn't die). What we MUST avoid is a partial shell.
+      (is (or (nil? p)
+              (and (some? (:pos p)) (some? (:body p))))))))

--- a/xsofy/test/world_prop.lg
+++ b/xsofy/test/world_prop.lg
@@ -1,39 +1,85 @@
 (ns xsofy.test.world-prop
-  "Property tests for world-state updates. Scoped to the killer cases that
-   would have caught the burning-player resurrection crash."
+  "Property tests for world-state updates. Covers the burning-player
+   resurrection class of bugs."
   (:require [test :refer [deftest is testing]]
             [xsofy.check :as c]
             [xsofy.check-gen :as g]
-            [xsofy.world :as w]))
-
-(defn player-well-formed?
-  "Player is either absent OR has all required keys."
-  [world]
-  (let [p (get-in world [:entities :player])]
-    (or (nil? p)
-        (and (some? (:pos p))
-             (some? (:body p))
-             (some? (:id p))
-             (some? (:template p))))))
-
-;; ============================================================================
-;; The killer property — catches the burning-player resurrection bug
-;; ============================================================================
-
-(c/defprop player-shape-survives-single-action
-  [world g/gen-minimal-world
-   action g/gen-action]
-  (player-well-formed? (w/update-world world action)))
-
-(c/defprop actions-never-throw
-  [world g/gen-minimal-world
-   actions g/gen-action-seq]
-  (do (reduce w/update-world world actions) true))
+            [xsofy.world :as w]
+            [xsofy.fire :as fire]))
 
 (c/defprop turn-never-goes-backward
   [world g/gen-minimal-world
    action g/gen-action]
   (>= (:turn (w/update-world world action)) (:turn world)))
+
+;; ============================================================================
+;; Rich-world properties — movement through terrain features, hazards, fire,
+;; webs, plus the presence of other creatures and items.
+;; ============================================================================
+
+(c/defprop rich-world-action-doesnt-throw
+  [world  g/gen-rich-world
+   action g/gen-action]
+  (do (w/update-world world action) true))
+
+(c/defprop rich-world-action-sequence-doesnt-throw
+  [world   g/gen-rich-world
+   actions g/gen-action-seq]
+  (do (reduce w/update-world world actions) true))
+
+;; ============================================================================
+;; Effects: fire simulation
+;; ============================================================================
+
+(c/defprop step-fire-doesnt-throw
+  [world g/gen-rich-world]
+  (do (fire/step-fire world) true))
+
+;; ============================================================================
+;; World invariants are preserved by every mutating operation.
+;; world-invariants? subsumes the per-field checks (player-shape, in-bounds,
+;; no-resurrection, hp-non-negative).
+;; ============================================================================
+
+(c/defprop update-world-preserves-invariants
+  [world  g/gen-rich-world
+   action g/gen-action]
+  (g/world-invariants? (w/update-world world action)))
+
+(c/defprop action-sequence-preserves-invariants
+  [world   g/gen-rich-world
+   actions g/gen-action-seq]
+  (g/world-invariants? (reduce w/update-world world actions)))
+
+(c/defprop step-fire-preserves-invariants
+  [world g/gen-rich-world]
+  (g/world-invariants? (fire/step-fire world)))
+
+;; ============================================================================
+;; Long simulations — drive TTLs all the way to 0.
+;; Default gen-action-seq is short and many moves get blocked, so few actions
+;; actually advance the turn. These properties use :rest (which always
+;; advances the turn) for enough cycles to exhaust any status TTL (max 5)
+;; and any fire TTL (max 5), exercising the expiration code paths.
+;; ============================================================================
+
+(def ^:private long-sim-length 15)
+
+(c/defprop long-rest-simulation-doesnt-throw
+  [world g/gen-rich-world]
+  (do (reduce w/update-world world (repeat long-sim-length :rest))
+      true))
+
+(c/defprop long-rest-simulation-preserves-invariants
+  [world g/gen-rich-world]
+  (g/world-invariants?
+    (reduce w/update-world world (repeat long-sim-length :rest))))
+
+(c/defprop repeated-step-fire-preserves-invariants
+  [world g/gen-rich-world]
+  ;; Run step-fire enough times to burn out every fire tile (max ttl 5).
+  (g/world-invariants?
+    (reduce (fn [w _] (fire/step-fire w)) world (range 10))))
 
 ;; ============================================================================
 ;; Targeted regression tests (from property-discovered failures)

--- a/xsofy/world.lg
+++ b/xsofy/world.lg
@@ -1018,10 +1018,12 @@
                    (rest actors))))))
 
 (defn creature-turn [world creature-id]
+  (dbg/snapshot! world "creature-turn:enter " creature-id)
   (let [entity (get-in world [:entities creature-id])]
     (if (nil? entity) world
       (let [;; tick status effects (burning damage, poison, etc.)
-            w (status/tick-entity-statuses world creature-id)]
+            w (status/tick-entity-statuses world creature-id)
+            _ (dbg/snapshot! w "creature-turn:after-status-tick " creature-id)]
         (if (nil? (get-in w [:entities creature-id]))
           w  ;; died from status damage
           (if (not (status/can-act? w creature-id))
@@ -1347,21 +1349,25 @@
                         (trample-grass nx ny)
                         (assoc-in [:entities :player :pos] [nx ny])
                         (add-ticks :player move-cost)
-                        (update :turn inc)
-                        update-fov)
-                  w (do-pickup w [nx ny])
-                  ;; check if stepped on web
-                  w (if (and (fire/on-web? w nx ny)
-                             (not (fire/web-immune? w :player)))
-                      (-> w
-                          (status/apply-status :player :webbed 3)
-                          (log-msg "You walk into a web!"))
-                      w)
-                  ;; tile effects (water extinguishes fire, etc.)
-                  w (apply-tile-effects w :player nx ny)
-                  ;; check if leaving water
-                  w (check-leave-water w)]
-              w)
+                        (update :turn inc))]
+              (if (nil? (get-in w [:entities :player]))
+                ;; status tick (e.g. burning) killed the player during this step;
+                ;; skip post-move effects and let update-world handle death.
+                w
+                (let [w (update-fov w)
+                      w (do-pickup w [nx ny])
+                      ;; check if stepped on web
+                      w (if (and (fire/on-web? w nx ny)
+                                 (not (fire/web-immune? w :player)))
+                          (-> w
+                              (status/apply-status :player :webbed 3)
+                              (log-msg "You walk into a web!"))
+                          w)
+                      ;; tile effects (water extinguishes fire, etc.)
+                      w (apply-tile-effects w :player nx ny)
+                      ;; check if leaving water
+                      w (check-leave-water w)]
+                  w)))
             (log-msg world "Blocked."))))
 
       ;; hazard tile — flying creatures pass freely, others get confirmation
@@ -1422,6 +1428,7 @@
 ;; --- Turn Processing ---
 
 (defn update-world [world action]
+  (dbg/snapshot! world "update-world:enter " action)
   (case action
     :descend (descend world)
     :ascend (ascend world)
@@ -1471,9 +1478,11 @@
                          (log-msg "You rest."))
               :quit  (assoc world :screen :confirm-quit)
               world)
+          _ (dbg/snapshot! w "update-world:after-player-action " action)
           acted (> (:turn w) (:turn world))
           w (if acted
               (let [w2 (run-until-player-turn w)
+                    _ (dbg/snapshot! w2 "update-world:after-run-until-player-turn")
                     ;; fire simulation + burning entities ignite terrain + water drift
                     w3 (-> w2 fire/step-fire fire/burning-entities-ignite drift-water-items)]
                 (if (get-in w3 [:entities :player])


### PR DESCRIPTION
Hi! Long-time admirer of let-go and xsofy — picked this up from a crash dump I hit (player on fire stepping onto an item) and the work grew a bit. Splitting it into a single PR here; happy to break it up or drop pieces if anything's unwelcome.

## What's in here

### Crash fixes (`da85543`)
Three related bugs where dead-or-removed entities were being resurrected as partial shells:

- **`pickup-item`** was calling `update-in [:entities owner-id :inventory] conj item-id` without checking whether `owner-id` still existed. If the player died on the same turn they tried to pick something up (burning + step-on-item), `update-in` would happily recreate `{:inventory [item-id]}` under `:player`. Now bails out when owner is missing.
- **`tick-entity-statuses`** had the same shape: each per-status reduce step assumed the entity was still there, but `:burning` could kill on tick and the next status would resurrect them. Each step now checks presence.
- **`apply-status` / `remove-status`** were the same pattern at the API level — now defensive no-ops on missing entities.
- **`r-spread`** in the spell DSL threw on an empty world. let-go's lazy `sort-by` composed with `filter` on an empty input nil-pointers (and `(set (filter some? (map :pos empty)))` produces `#{nil}` rather than `#{}`). Fixed with an empty-cursors early return and forcing eager `vec` at the boundaries. Comments in the code call this out as a let-go quirk in case it bites again.

### Player-facing display fix (`06d0bd5`)
The rune inscription UI was leaking the parser's internal error map when a token sequence failed to parse — e.g. inscribing `:add` with no args showed `(magic-> kryl {:reason :bad-argument :rune :add :args [nil nil] :error true})` in the spell display.

`format-sexp-step` now detects the error-map shape and renders 2-3 random glyphs from the existing rune-glyphs set. The glyphs shift on each render — the runes appear to be failing to bind into a stable form. Felt more in keeping with the discovery aesthetic than English error text.

### Property-testing library (`1ff48d5`, `48b339b`, `9b127d7`, `2b8520e`, `f6c53ab` — last one is the collision-resolver, ignore here)
Added `xsofy.check`, a QuickCheck-style property testing library written to fit let-go (around its eager `map`, lazy-seq composition gotchas, and missing `reduce-kv`). Splittable LCG-based PRNG, rose-tree-based integrated shrinking, generators with bind/fmap/`gen-let`, `defprop` for terse property definitions.

`xsofy.check-gen` is the domain layer — generators for positions, statuses, players, minimal/feature/rich worlds, plus a `world-invariants?` predicate that's the single source of truth for what a structurally valid world looks like (8 invariants — see commit message for the list). Worth noting: creature-on-creature positional collision is *not* in the invariant list — that's a runtime policy decision, not a structural one, and treating it as an invariant made generators useless for fuzz testing.

Tests are in `xsofy/test/`:
- `check_test.lg` — 53 unit tests for the library itself (generators, RNG, shrinking, defprop, frequency distribution)
- `invariant_test.lg` — pins each of the 8 invariants and verifies generators don't produce invalid worlds
- `spell_prop.lg` — fuzz tests the spell DSL with both raw token sequences and well-formed programs (the most crash-prone surface); includes the targeted regressions for the bugs above
- `world_prop.lg` — movement, fire simulation, status ticks
- `combat_prop.lg` — combat, push, save/restore, equipment, AI

Runner: `lg xsofy/test/run.lg`. Current run: 105 tests, 136 assertions, 0 fail, 0 error.

## Why one PR

The crash fixes alone are small, but every one of them was found (or, after the fact, pinned) by a property test. Shipping the fixes without the suite means losing the regression coverage. If you'd rather take the crash fixes first and the property infra in a follow-up, I'm happy to split — just say the word.

## Won't break anything I can see

No public-API changes beyond the new `xsofy.check` and `xsofy.check-gen` namespaces. `world-invariants?` is exported but nothing in the existing code uses it. The `r-spread`, status, and entity changes are all narrow guards — nothing existing should hit the new code paths.