### PR TITLE
Fix web restart and floor fire state

### DIFF
--- a/main.lg
+++ b/main.lg
@@ -376,14 +376,29 @@
                      (recur w w (term/size))))))
 
          :death
-         (loop [scroll 0]
-           (render/render-death-screen world scroll)
-           (let [k (term/read-key)]
-             (cond
-               (= k "\u001b") (assoc world :running false)
-               (or (= k "j") (= k "\u001b[B")) (recur (max 0 (dec scroll)))
-               (or (= k "k") (= k "\u001b[A")) (recur (inc scroll))
-               :else (recur scroll))))
+         (let [result (loop [scroll 0]
+                        (render/render-death-screen world scroll)
+                        (let [k (term/read-key)]
+                          (cond
+                            (or (= k "n") (= k "\r") (= k "\n") (= k " "))
+                            :new-game
+                            (= k "\u001b")
+                            (if *in-wasm*
+                              (do
+                                (render/render-hazard-prompt world "Start a new game?")
+                                (let [confirm (term/read-key)]
+                                  (if (= confirm "y")
+                                    :new-game
+                                    (recur scroll))))
+                              (assoc world :running false))
+                            (or (= k "j") (= k "\u001b[B")) (recur (max 0 (dec scroll)))
+                            (or (= k "k") (= k "\u001b[A")) (recur (inc scroll))
+                            :else (recur scroll))))]
+           (if (= result :new-game)
+             (let [w (new-game)]
+               (render/render-full w)
+               (recur w w (term/size)))
+             result))
 
          :confirm-hazard
          (do

--- a/xsofy/render.lg
+++ b/xsofy/render.lg
@@ -534,7 +534,8 @@
 
 (defn render-status [world r]
   (ui/write-line r 0 (str " yuhjklbn/1-9:move  .:wait  5/Z:rest  eUda:item  i:inv  <>:stairs  m:log  "
-                          (input/action-key-labels :help) ":help  esc:quit")
+                          (input/action-key-labels :help) ":help  esc:"
+                          (if *in-wasm* "restart" "quit"))
                  [60 60 60] ui/bg))
 
 ;; --- Quick Menu Overlay ---
@@ -944,10 +945,13 @@
                         (subs msg 0 (- tw 4))
                         msg)))))
     ;; prompt
-    (term/move-cursor (max 1 (- cx 12)) (dec th))
-    (term/set-fg 80 70 60)
-    (term/set-bg 10 10 10)
-    (term/write "[esc] to exit    [j/k] scroll")
+    (let [prompt (if *in-wasm*
+                   "[n/enter] new game    [esc] confirm restart    [j/k] scroll"
+                   "[n/enter] new game    [esc] exit    [j/k] scroll")]
+      (term/move-cursor (max 1 (- cx (quot (count prompt) 2))) (dec th))
+      (term/set-fg 80 70 60)
+      (term/set-bg 10 10 10)
+      (term/write prompt))
     (term/flush)))
 
 ;; --- Rune Codex Screen ---

--- a/xsofy/test/world_prop.lg
+++ b/xsofy/test/world_prop.lg
@@ -5,7 +5,8 @@
             [xsofy.check :as c]
             [xsofy.check-gen :as g]
             [xsofy.world :as w]
-            [xsofy.fire :as fire]))
+            [xsofy.fire :as fire]
+            [xsofy.terrain :as terrain]))
 
 (c/defprop turn-never-goes-backward
   [world g/gen-minimal-world
@@ -103,3 +104,20 @@
       ;; acceptable, e.g. didn't die). What we MUST avoid is a partial shell.
       (is (or (nil? p)
               (and (some? (:pos p)) (some? (:body p))))))))
+
+(deftest floor-save-restore-preserves-fire-ttl
+  (testing "Saved floors keep fire simulation state with fire terrain tiles."
+    (let [world (-> (g/minimal-stone-room)
+                    (assoc :depth 1 :floors {} :turn 12 :log [])
+                    (assoc-in [:entities :player]
+                      {:id :player :template :player :pos [1 1]
+                       :ticks 0
+                       :body {:hp 30 :max-hp 30 :strength 2}
+                       :inventory []}))
+          _ (terrain/tset! (:terrain world) (:width world) 2 2 15)
+          world (assoc world :fire-ttl {[2 2] 4})
+          saved (w/save-current-floor world)
+          [player items] (w/extract-player-items saved)
+          restored (w/restore-floor saved 1 player items)]
+      (is (= 4 (get-in saved [:floors 1 :fire-ttl [2 2]])))
+      (is (= 4 (get-in restored [:fire-ttl [2 2]]))))))

--- a/xsofy/world.lg
+++ b/xsofy/world.lg
@@ -226,6 +226,7 @@
                :entities floor-entities
                :stains (or (:stains world) {})
                :gases (or (:gases world) {})
+               :fire-ttl (or (:fire-ttl world) {})
                :lights (:lights world)
                :memory (or (:memory world) {})}]
     (assoc-in world [:floors (:depth world)] floor)))
@@ -255,6 +256,7 @@
          :lights (:lights floor)
          :stains (:stains floor)
          :gases (:gases floor)
+         :fire-ttl (or (:fire-ttl floor) {})
          :log (:log world)
          :turn (:turn world)
          :gold (or (:gold world) 0)


### PR DESCRIPTION
## Summary
- Preserve fire TTL when saving/restoring floors so returning to a floor does not leave harmless visual fire tiles behind.
- In web builds, prevent Escape from exiting to the terminal/program-exited screen by confirming restart on the death screen.
- Update HUD/death-screen prompts to say restart in web mode and keep native quit wording outside web mode.

## Related issues
- Fixes #21
- Related to #17

## Tests
- lg xsofy/test/run.lg
- lg -b /tmp/xsofy-check main.lg