### PR TITLE
Add scrollable message log

### DIFF
--- a/main.lg
+++ b/main.lg
@@ -308,6 +308,50 @@
 
       :else world)))
 
+(defn message-page-size []
+  (let [[_tw th] (term/size)]
+    (max 1 (dec (render/message-visible-lines th)))))
+
+(defn clamp-message-scroll [world scroll]
+  (let [[_tw th] (term/size)
+        visible-lines (render/message-visible-lines th)
+        max-scroll (render/max-message-scroll world visible-lines)]
+    (assoc world :message-scroll (max 0 (min max-scroll scroll)))))
+
+(defn scroll-messages [world delta]
+  (clamp-message-scroll world (+ (or (:message-scroll world) 0) delta)))
+
+(defn close-messages-screen [world]
+  (dissoc world :screen :message-scroll))
+
+(defn messages-input [world k]
+  (let [page (message-page-size)]
+    (cond
+      (or (= k "\u001b") (= k "q") (= k "m") (= k "\r"))
+      (close-messages-screen world)
+
+      (or (= k "k") (= k "\u001b[A"))
+      (scroll-messages world 1)
+
+      (or (= k "j") (= k "\u001b[B") (= k " "))
+      (scroll-messages world -1)
+
+      (or (= k "\u001b[5~") (= k "K"))
+      (scroll-messages world page)
+
+      (or (= k "\u001b[6~") (= k "J"))
+      (scroll-messages world (- page))
+
+      (= k "g")
+      (let [[_tw th] (term/size)
+            visible-lines (render/message-visible-lines th)]
+        (clamp-message-scroll world (render/max-message-scroll world visible-lines)))
+
+      (= k "G")
+      (clamp-message-scroll world 0)
+
+      :else world)))
+
 (defn new-game []
   (let [{:keys [title scheme]} (title/show-title-screen)
         quest (title/generate-quest)
@@ -329,10 +373,13 @@
        (case screen
          :messages
          (do (render/render-messages-screen world)
-             (term/read-key)
-             (let [w (dissoc world :screen)]
-               (render/render-full w)
-               (recur w w (term/size))))
+             (let [k (term/read-key)
+                   w (messages-input world k)]
+               (if (:screen w)
+                 (recur w w prev-size)
+                 (do
+                   (render/render-full w)
+                   (recur w w (term/size))))))
 
          :rune-codex
          (do (render/render-rune-codex world)

--- a/xsofy/render.lg
+++ b/xsofy/render.lg
@@ -301,6 +301,27 @@
     (str (:msg entry) " (x" (:count entry) ")")
     (str entry)))
 
+(defn message-visible-lines [term-height]
+  (max 1 (- term-height 3)))
+
+(defn message-log-window [log visible-lines scroll-offset]
+  (let [log (vec (or log []))
+        log-count (count log)
+        visible-lines (max 1 visible-lines)
+        max-scroll (max 0 (- log-count visible-lines))
+        scroll (min (max 0 (or scroll-offset 0)) max-scroll)
+        end-idx (- log-count scroll)
+        start-idx (max 0 (- end-idx visible-lines))]
+    {:entries (subvec log start-idx end-idx)
+     :start start-idx
+     :end end-idx
+     :count log-count
+     :scroll scroll
+     :max-scroll max-scroll}))
+
+(defn max-message-scroll [world visible-lines]
+  (:max-scroll (message-log-window (:log world) visible-lines (:message-scroll world))))
+
 (defn render-log [world r]
   (ui/clear-rect r)
   (let [log (vec (or (:log world) []))
@@ -618,22 +639,28 @@
   (let [[tw th] (term/size)
         r (ui/rect 1 1 tw th)
         inner (ui/box r "Message Log" [180 170 140] ui/bg)
-        log (:log world)
-        visible-lines (- (:h inner) 1)
-        recent (take-last visible-lines log)
-        cnt (count recent)]
+        visible-lines (message-visible-lines th)
+        window (message-log-window (:log world) visible-lines (:message-scroll world))
+        entries (:entries window)
+        cnt (count entries)]
     (ui/clear-rect inner)
-    (dotimes [i cnt]
-      (let [msg (format-log-entry (nth recent i))
-            age (- cnt i 1)
-            brightness (max 60 (- 220 (* age 6)))]
-        (ui/write-line inner i (str " " msg)
-                       [brightness
-                        (max 60 (- brightness 20))
-                        (max 40 (- brightness 80))]
-                       ui/bg)))
+    (if (= cnt 0)
+      (ui/write-line inner 0 " No messages yet." [90 90 90] ui/bg)
+      (dotimes [i cnt]
+        (let [msg (format-log-entry (nth entries i))
+              age (- cnt i 1)
+              brightness (max 60 (- 220 (* age 6)))]
+          (ui/write-line inner i (str " " msg)
+                         [brightness
+                          (max 60 (- brightness 20))
+                          (max 40 (- brightness 80))]
+                         ui/bg))))
     (ui/write-line inner (dec (:h inner))
-                   " [press any key to close]"
+                   (str " "
+                        (if (> (:count window) 0)
+                          (str (inc (:start window)) "-" (:end window) "/" (:count window))
+                          "0/0")
+                        "  [k/up older  j/down newer  PgUp/PgDn  g/G  Esc]")
                    [80 80 80] ui/bg)
     (term/flush)))
 

--- a/xsofy/test/render_test.lg
+++ b/xsofy/test/render_test.lg
@@ -1,0 +1,29 @@
+(ns xsofy.test.render-test
+  (:require [test :refer [deftest is testing]]
+            [xsofy.render :as render]))
+
+(deftest message-log-window-shows-newest-entries-by-default
+  (testing "newest entries are visible when scroll is zero"
+    (let [window (render/message-log-window ["a" "b" "c" "d"] 2 0)]
+      (is (= ["c" "d"] (:entries window)))
+      (is (= 2 (:start window)))
+      (is (= 4 (:end window)))
+      (is (= 2 (:max-scroll window))))))
+
+(deftest message-log-window-scrolls-to-older-entries
+  (testing "positive scroll offsets move the window toward older entries"
+    (let [window (render/message-log-window ["a" "b" "c" "d"] 2 1)]
+      (is (= ["b" "c"] (:entries window)))
+      (is (= 1 (:scroll window)))))
+
+  (testing "scroll offsets are clamped to the oldest page"
+    (let [window (render/message-log-window ["a" "b" "c" "d"] 2 99)]
+      (is (= ["a" "b"] (:entries window)))
+      (is (= 2 (:scroll window))))))
+
+(deftest message-log-window-handles-empty-log
+  (testing "empty logs produce an empty visible window"
+    (let [window (render/message-log-window [] 2 1)]
+      (is (= [] (:entries window)))
+      (is (= 0 (:count window)))
+      (is (= 0 (:max-scroll window))))))

--- a/xsofy/test/run.lg
+++ b/xsofy/test/run.lg
@@ -2,6 +2,7 @@
   (:require [test :refer [run-tests]]
             [xsofy.test.check-test]
             [xsofy.test.invariant-test]
+            [xsofy.test.render-test]
             [xsofy.test.spell-prop]
             [xsofy.test.world-prop]
             [xsofy.test.combat-prop]))

--- a/xsofy/world.lg
+++ b/xsofy/world.lg
@@ -297,7 +297,7 @@
 
 ;; --- Message Log ---
 
-(def max-log 50)
+(def max-log 200)
 
 (defn log-msg [world msg]
   (update world :log (fn [log]


### PR DESCRIPTION
## Summary
- Make the existing message log modal scrollable with vi/arrow, page, and top/bottom controls.
- Show the visible message range and close hints in the modal footer.
- Retain more history by raising the log cap to 200 entries.
- Add pure tests for message log windowing.

Fixes #20

## Tests
- lg xsofy/test/run.lg
- lg -b /private/tmp/xsofy-message-log-check main.lg