### PR TITLE
Add xsofy.hash — pure-Lisp xxh3-64 implementation

### DIFF
--- a/xsofy/hash.lg
+++ b/xsofy/hash.lg
@@ -1,0 +1,1486 @@
+(ns xsofy.hash
+  "xxh3-64 hash function in pure Lisp, plus a canonical byte encoder for
+   salt-keys (v1 encoding) and a three-layer macro pipeline for compile-time
+   folding of constant salt-key prefixes.
+
+   All hash state is held in int64 cells interpreted as the lower 64 bits of
+   an unsigned integer. The u64-* helpers wrap let-go primitives chosen for
+   modular-2^64 semantics:
+
+     u64+      -> unchecked-add             (Clojure-parity wrap on overflow)
+     u64*      -> unchecked-multiply        (Clojure-parity wrap on overflow)
+     u64-xor   -> bit-xor                   (bit-parallel, no masking needed)
+     u64-shr   -> unsigned-bit-shift-right  (zero-fill, not sign-extend)
+     u64-shl   -> bit-shift-left            (Go's int64 << uint wraps at 2^64)
+     u64-rotl  -> u64-shl + u64-shr via bit-or  (rotate-left, mod 64)
+
+   Future helpers will follow the same convention.
+
+   Note: u64+ needs let-go's unchecked-add primitive (clojure.core parity).
+   Until the upstream let-go PR lands, xsofy runs against a patched binary
+   via the ../bin/lg wrapper.")
+
+(defn u64+
+  "Modular addition: (a + b) mod 2^64. Wraps on overflow."
+  [a b]
+  (unchecked-add a b))
+
+(defn u64*
+  "Modular multiplication: (a * b) mod 2^64. Wraps on overflow.
+   Wraps unchecked-multiply so the u64-* helper family shares a named surface."
+  [a b]
+  (unchecked-multiply a b))
+
+;; XOR is bit-parallel — bit-xor on int64 cells already gives the correct
+;; u64 XOR result without masking. Aliased here so all u64-* helpers
+;; share a named surface (and so the family table in the ns docstring
+;; reads coherently).
+;;
+;; Note: let-go's bit-xor is strictly binary (unlike Clojure's variadic
+;; clojure.core/bit-xor). u64-xor inherits that 2-ary contract. Multi-term
+;; XOR chains in xxh3 mixers must use nested calls.
+(def u64-xor bit-xor)
+
+(defn u64-shr
+  "Logical right shift by n bits. Zero-fills high bits, unlike bit-shift-right which sign-extends.
+   Wraps unsigned-bit-shift-right so the u64-* helper family shares a named surface and a single
+   instrumentation point if needed.
+
+   n must be in [0, 64). Negative or large n is undefined behavior: let-go's underlying shift
+   coerces n to uint, so out-of-range values silently produce 0."
+  [x n]
+  (unsigned-bit-shift-right x n))
+
+(defn u64-shl
+  "Modular left shift: returns the low 64 bits of (x << n). Identity at n=0;
+   returns 0 for n >= 64 (any bits shifted past the top fall off).
+
+   let-go's bit-shift-left already wraps cleanly in Go's int64: (bit-shift-left 1 63)
+   yields Long/MIN_VALUE (0x8000000000000000), (bit-shift-left 1 64) yields 0, and
+   (bit-shift-left 3 63) yields Long/MIN_VALUE (the low bit falls off the top).
+   So u64-shl is a thin wrapper that gives the u64-* helper family a single
+   named surface and a single instrumentation point if needed.
+
+   n must be in [0, 64). Negative or large n is undefined behavior: let-go's underlying shift
+   coerces n to uint, so out-of-range values silently produce 0."
+  [x n]
+  (bit-shift-left x n))
+
+(defn u64-rotl
+  "Rotate-left by n bits over the low 64 bits of x. Bits shifted past the top
+   wrap around to the bottom. Built on u64-shl and u64-shr OR'd together.
+
+   n is normalized via (mod n 64) so any integer n is well-defined, and n=0 /
+   n=64 are explicitly the identity. We special-case (zero? n) rather than
+   relying on the silent-0 behavior of (u64-shr x 64) — rotation by a full
+   cycle is meaningful, so we don't want the result to depend on a footgun in
+   the underlying shift primitives."
+  [x n]
+  (let [n (mod n 64)]
+    (if (zero? n)
+      x
+      (bit-or (u64-shl x n)
+              (u64-shr x (- 64 n))))))
+
+(defn u64*-128
+  "Full 128-bit unsigned product of two u64s. Returns a 2-vector [hi lo] where
+   hi and lo are int64 cells interpreted as the upper and lower 64 bits of the
+   full 128-bit unsigned product. Required by xxh3-64's mul-fold step, which
+   XORs the two halves together.
+
+   Implementation follows Go's math/bits.Mul64 (a well-tested reference):
+   split each input into 32-bit halves, compute the four pairwise products,
+   then carry the cross terms through. Each pairwise product of 32-bit
+   halves is at most (2^32 - 1)^2 < 2^64, so it fits in a u64 cell — we use
+   unchecked-multiply for the wrap-mod-2^64 semantics on the cross-term
+   sums that DO overflow. The low 64 bits collapse to a single unchecked
+   multiply of the original inputs (this is what u64* computes), bypassing
+   any need to reassemble lo from the partial products.
+
+   Inputs are interpreted as unsigned: a negative int64 cell is treated as
+   its 2^64-complement. Output cells follow the same convention."
+  [a b]
+  (let [mask32 0xFFFFFFFF
+        a-lo (bit-and a mask32)
+        a-hi (u64-shr a 32)
+        b-lo (bit-and b mask32)
+        b-hi (u64-shr b 32)
+        ;; w0 = low-low product. Each half is in [0, 2^32), so w0 < 2^64.
+        ;; bit-and ensures a-lo and b-lo are non-negative int64s, so a plain
+        ;; multiply is safe here — but we use unchecked-multiply uniformly
+        ;; for the family's mod-2^64 contract.
+        w0 (unchecked-multiply a-lo b-lo)
+        ;; t = a-hi * b-lo + (w0 >> 32). u64-shr gives the carry from w0
+        ;; into the next 32-bit lane. t can exceed 2^63 (its high bits feed
+        ;; into the hi half), so unchecked-add wraps cleanly.
+        t (unchecked-add (unchecked-multiply a-hi b-lo)
+                         (u64-shr w0 32))
+        w1 (bit-and t mask32)
+        w2 (u64-shr t 32)
+        ;; Add the a-lo * b-hi cross product into w1's lane.
+        w1-cross (unchecked-add w1 (unchecked-multiply a-lo b-hi))
+        ;; hi = a-hi * b-hi + w2 + (w1-cross >> 32). All sums wrap cleanly via
+        ;; unchecked-add — this is the high 64 bits of the 128-bit product.
+        hi (unchecked-add (unchecked-multiply a-hi b-hi)
+                          (unchecked-add w2 (u64-shr w1-cross 32)))
+        ;; lo = the low 64 bits of a * b, which by definition is the mod-2^64
+        ;; product — exactly what unchecked-multiply on the original inputs
+        ;; produces. Computing lo this way avoids reassembling it from the
+        ;; partial products and avoids any sign-extension subtlety.
+        lo (unchecked-multiply a b)]
+    [hi lo]))
+
+(defn mul-fold
+  "Compute the full 128-bit product a * b, then XOR the high and low halves
+   to fold to a single u64. This is xxh3-64's core mixer primitive — used in
+   every short and medium input path. Folding both halves preserves more
+   entropy than truncating to the low 64 bits would, and is what makes
+   xxh3-64's avalanche behavior strong on tiny inputs.
+
+   We pull the halves out of the [hi lo] vector returned by u64*-128 with
+   clojure.core/nth because let-go does not support vector destructuring
+   in let bindings."
+  [a b]
+  (let [r (u64*-128 a b)]
+    (u64-xor (clojure.core/nth r 0)
+             (clojure.core/nth r 1))))
+
+(defn read-u64-le
+  "Read 8 little-endian bytes from buf at offset i, assembling a u64 cell.
+   buf is a vector of int byte values in [0, 255]; the byte at (i+0) becomes
+   the low 8 bits of the result and the byte at (i+7) becomes the high 8 bits.
+   The byte at (i+7) is shifted by 56, so if its high bit is set the result is
+   negative as a signed int64 (e.g. all-0xFF bytes assemble to -1).
+
+   Caller must ensure (>= (count buf) (+ i 8)); we don't bounds-check on the
+   hot path (xxh3-64 callers slice or pad explicitly).
+
+   Loop arithmetic uses plain inc and + because k stays in [0, 8] and (+ i k)
+   stays bounded by the caller's buffer length — no overflow path here. Only
+   the accumulator uses the u64- family because that's the cell that grows
+   into the negative-int64 region for high-bit-set inputs."
+  [buf i]
+  (loop [k 0
+         acc 0]
+    (if (>= k 8)
+      acc
+      (recur (inc k)
+             (u64+ acc (u64-shl (clojure.core/nth buf (+ i k))
+                                (* k 8)))))))
+
+(defn read-u32-le
+  "Read 4 little-endian bytes from buf at offset i, returning a u64 cell whose
+   low 32 bits hold the assembled u32 (high 32 bits zero). buf is a vector of
+   int byte values in [0, 255]; (i+0) is the low byte, (i+3) is the high byte
+   (shifted by 24). All-0xFF input assembles to 0xFFFFFFFF (= 4294967295), a
+   positive int64 — sign-extension would give -1 and is a bug to watch for.
+
+   Caller must ensure (>= (count buf) (+ i 4))."
+  [buf i]
+  (loop [k 0
+         acc 0]
+    (if (>= k 4)
+      acc
+      (recur (inc k)
+             (u64+ acc (u64-shl (clojure.core/nth buf (+ i k))
+                                (* k 8)))))))
+
+;; ============================================================================
+;; xxh3-64 constants
+;; ============================================================================
+;;
+;; The five PRIME64 constants and the 192-byte default secret are reproduced
+;; verbatim from upstream xxHash (Cyan4973/xxHash, xxhash.h). They are private
+;; to xsofy.hash — only the xxh3-64 implementation and its salt-key encoder
+;; need to see them. xxh3-secret-cell is public so tests can spot-check the
+;; secret hasn't drifted.
+;;
+;; Source: xxhash.h, definition of XXH3_kSecret. The byte block in the C
+;; source reads as 12 rows of 16 bytes (= 192 bytes total). Each consecutive
+;; 8-byte group is interpreted as a little-endian u64, giving the 24 cells
+;; below: byte[0] of the C block is the LEAST-significant byte of cell 0,
+;; byte[8] is the least-significant byte of cell 1, and so on.
+;;
+;; The published xxh3-64 empty-input vector with seed 0 is 0x2D06800538D394C2.
+;; Any typo in the bytes below would surface as a published-vector mismatch.
+
+;; Hex literals that exceed Long/MAX_VALUE (those starting with 8-F at the
+;; high nibble) are now read as BigInt for Clojure parity. unchecked-long
+;; truncates them back to int64 via two's-complement low-64 bits, giving
+;; us the bit pattern we want for u64 arithmetic. Literals that fit in
+;; int64 (high nibble 0-7) pass through unchanged.
+(def ^:private prime64-1 (unchecked-long 0x9E3779B185EBCA87))
+(def ^:private prime64-2 (unchecked-long 0xC2B2AE3D27D4EB4F))
+(def ^:private prime64-3 0x165667B19E3779F9)
+(def ^:private prime64-4 (unchecked-long 0x85EBCA77C2B2AE63))
+(def ^:private prime64-5 0x27D4EB2F165667C5)
+
+(def ^:private xxh3-secret
+  ;; 24 little-endian u64 cells == 192 bytes. The trailing-comment bytes are
+  ;; the original C bytes in source order; reading them right-to-left within
+  ;; each row reconstructs the hex literal on the left.
+  ;;
+  ;; Each literal is fed through unchecked-long to truncate the BigInt the
+  ;; reader produces (Clojure parity for values > Long/MAX_VALUE) back to
+  ;; int64 via two's-complement low-64 bits. Values that fit in int64 pass
+  ;; through unchanged.
+  (mapv unchecked-long
+    [0xbe4ba423396cfeb8  ; bytes 0-7:    b8 fe 6c 39 23 a4 4b be
+     0x1cad21f72c81017c  ; bytes 8-15:   7c 01 81 2c f7 21 ad 1c
+     0xdb979083e96dd4de  ; bytes 16-23:  de d4 6d e9 83 90 97 db
+     0x1f67b3b7a4a44072  ; bytes 24-31:  72 40 a4 a4 b7 b3 67 1f
+     0x78e5c0cc4ee679cb  ; bytes 32-39:  cb 79 e6 4e cc c0 e5 78
+     0x2172ffcc7dd05a82  ; bytes 40-47:  82 5a d0 7d cc ff 72 21
+     0x8e2443f7744608b8  ; bytes 48-55:  b8 08 46 74 f7 43 24 8e
+     0x4c263a81e69035e0  ; bytes 56-63:  e0 35 90 e6 81 3a 26 4c
+     0xcb00c391bb52283c  ; bytes 64-71:  3c 28 52 bb 91 c3 00 cb
+     0xa32e531b8b65d088  ; bytes 72-79:  88 d0 65 8b 1b 53 2e a3
+     0x4ef90da297486471  ; bytes 80-87:  71 64 48 97 a2 0d f9 4e
+     0xd8acdea946ef1938  ; bytes 88-95:  38 19 ef 46 a9 de ac d8
+     0x3f349ce33f76faa8  ; bytes 96-103: a8 fa 76 3f e3 9c 34 3f
+     0x1d4f0bc7c7bbdcf9  ; bytes 104-111: f9 dc bb c7 c7 0b 4f 1d
+     0x3159b4cd4be0518a  ; bytes 112-119: 8a 51 e0 4b cd b4 59 31
+     0x647378d9c97e9fc8  ; bytes 120-127: c8 9f 7e c9 d9 78 73 64
+     0xc3ebd33483acc5ea  ; bytes 128-135: ea c5 ac 83 34 d3 eb c3
+     0xeb6313faffa081c5  ; bytes 136-143: c5 81 a0 ff fa 13 63 eb
+     0x49daf0b751dd0d17  ; bytes 144-151: 17 0d dd 51 b7 f0 da 49
+     0x9e68d429265516d3  ; bytes 152-159: d3 16 55 26 29 d4 68 9e
+     0xfca1477d58be162b  ; bytes 160-167: 2b 16 be 58 7d 47 a1 fc
+     0xce31d07ad1b8f88f  ; bytes 168-175: 8f f8 b8 d1 7a d0 31 ce
+     0x280416958f3acb45  ; bytes 176-183: 45 cb 3a 8f 95 16 04 28
+     0x7e404bbbcafbd7af])) ; bytes 184-191: af d7 fb ca bb 4b 40 7e
+
+(defn xxh3-secret-cell
+  "Returns cell n (0-indexed) of the xxh3 default secret. Each cell is one
+   u64 (8 bytes, little-endian assembly of the corresponding xxhash.h source
+   bytes). Public to support regression-testing the secret against upstream.
+   n must be in [0, 24)."
+  [n]
+  (clojure.core/nth xxh3-secret n))
+
+;; ============================================================================
+;; xxh3-64 mixers
+;; ============================================================================
+;;
+;; Each of these comes verbatim from xxhash.h. See the linked function next
+;; to each defn. The cell-based helpers below assume all secret byte offsets
+;; used by the short and medium input paths are 8-aligned u64 reads OR are
+;; reads of the low/high 32-bit halves of a single u64 cell — both true for
+;; the 0-128 byte regimes. If a future path requires unaligned reads it will
+;; need a splice helper.
+
+(defn- xxh64-avalanche
+  "XXH64 final-mix avalanche. From xxhash.h: hash ^= hash>>33; *= P2; ^=
+   hash>>29; *= P3; ^= hash>>32. The two multiplies use the int64 unchecked
+   multiply path so the wrap is mod-2^64 (not overflow-trapping)."
+  [h]
+  (let [h (u64-xor h (u64-shr h 33))
+        h (u64* h prime64-2)
+        h (u64-xor h (u64-shr h 29))
+        h (u64* h prime64-3)
+        h (u64-xor h (u64-shr h 32))]
+    h))
+
+(def ^:private prime-mx1 0x165667919E3779F9)
+(def ^:private prime-mx2 (unchecked-long 0x9FB21C651E98DF25))
+
+(defn- xxh3-avalanche
+  "xxh3 fast avalanche from xxhash.h: h ^= h>>37; *= PRIME_MX1; ^= h>>32.
+   Used by len-9to16 and len-17to128 paths."
+  [h]
+  (let [h (u64-xor h (u64-shr h 37))
+        h (u64* h prime-mx1)
+        h (u64-xor h (u64-shr h 32))]
+    h))
+
+(defn- xxh3-rrmxmx
+  "xxh3 rrmxmx finalizer from xxhash.h: h ^= rotl(h,49) ^ rotl(h,24); *=
+   PRIME_MX2; ^= (h>>35) + len; *= PRIME_MX2; ^= h>>28. Used only by the
+   4to8 short-input path."
+  [h len]
+  (let [h (u64-xor h (u64-xor (u64-rotl h 49) (u64-rotl h 24)))
+        h (u64* h prime-mx2)
+        h (u64-xor h (u64+ (u64-shr h 35) len))
+        h (u64* h prime-mx2)
+        h (u64-xor h (u64-shr h 28))]
+    h))
+
+(defn- secret-le64
+  "Return the LE u64 starting at BYTE offset (* 8 cell-idx) in the default
+   secret. Only 8-aligned offsets are supported — all short and medium input
+   paths use 8-aligned secret reads, and we assert that contract here so a
+   future caller can't pass an unaligned offset silently."
+  [byte-offset]
+  (let [cell (u64-shr byte-offset 3)
+        rem  (bit-and byte-offset 7)]
+    (assert (zero? rem)
+            (str "secret-le64: byte offset " byte-offset
+                 " is not 8-aligned (mod 8 = " rem ")"))
+    (clojure.core/nth xxh3-secret cell)))
+
+(defn- secret-le32-lo
+  "Low 32 bits of secret cell 0, which is the same as the LE32 read at byte
+   offset 0 in the default secret. Pulled out as a helper so the 1to3 path
+   reads identically to its C counterpart (LE32(secret+0) vs LE32(secret+4))."
+  []
+  (bit-and (clojure.core/nth xxh3-secret 0) 0xFFFFFFFF))
+
+(defn- secret-le32-hi
+  "High 32 bits of secret cell 0, which is the LE32 read at byte offset 4
+   in the default secret. The shift is logical (zero-fill) so the resulting
+   u64 cell is in [0, 2^32)."
+  []
+  (u64-shr (clojure.core/nth xxh3-secret 0) 32))
+
+(defn- swap32
+  "Byte-reverse the low 32 bits of v, returning a u64 cell with the swapped
+   value in its low 32 bits (high 32 bits zero). Used by the 4to8 path's
+   seed mangling step. Mirrors XXH_swap32 from xxhash.h."
+  [v]
+  (let [v (bit-and v 0xFFFFFFFF)]
+    (bit-or (bit-or (bit-and (u64-shl v 24) 0xFF000000)
+                    (bit-and (u64-shl v  8) 0x00FF0000))
+            (bit-or (bit-and (u64-shr v  8) 0x0000FF00)
+                    (bit-and (u64-shr v 24) 0x000000FF)))))
+
+(defn- swap64
+  "Byte-reverse a full u64. Mirrors XXH_swap64 from xxhash.h. Each byte
+   lane is masked separately to make the shift+mask boundaries unambiguous;
+   a buggy mask that pulls bits in from adjacent lanes would surface here."
+  [v]
+  (bit-or
+   (bit-or
+    (bit-or (bit-and (u64-shl v 56) (unchecked-long 0xFF00000000000000))
+            (bit-and (u64-shl v 40) 0x00FF000000000000))
+    (bit-or (bit-and (u64-shl v 24) 0x0000FF0000000000)
+            (bit-and (u64-shl v  8) 0x000000FF00000000)))
+   (bit-or
+    (bit-or (bit-and (u64-shr v  8) 0x00000000FF000000)
+            (bit-and (u64-shr v 24) 0x0000000000FF0000))
+    (bit-or (bit-and (u64-shr v 40) 0x000000000000FF00)
+            (bit-and (u64-shr v 56) 0x00000000000000FF)))))
+
+;; ============================================================================
+;; xxh3-64 short input paths (0-16 bytes)
+;; ============================================================================
+
+(defn- xxh3-64-empty
+  "Empty-input case from XXH3_len_0to16_64b: avalanche of seed XOR'd with the
+   secret-cell-7 XOR secret-cell-8 (byte offsets 56 and 64). The published
+   xxh3-64 empty-input vector with seed 0 is 0x2D06800538D394C2."
+  [seed]
+  (xxh64-avalanche
+   (u64-xor seed
+            (u64-xor (secret-le64 56) (secret-le64 64)))))
+
+(defn- xxh3-64-1to3
+  "XXH3_len_1to3_64b. Input is 1 to 3 bytes. Combines three sampled bytes and
+   the length into a 32-bit word, XORs with a 32-bit secret diff plus seed,
+   then runs XXH64_avalanche.
+
+     combined u32: c1<<16 | c2<<24 | c3<<0 | len<<8
+       c1 = input[0]
+       c2 = input[len/2]
+       c3 = input[len-1]
+     bitflip u64 : (LE32(secret+0) ^ LE32(secret+4)) + seed"
+  [input seed]
+  (let [len (count input)
+        c1  (clojure.core/nth input 0)
+        c2  (clojure.core/nth input (u64-shr len 1))
+        c3  (clojure.core/nth input (dec len))
+        ;; All shifts here stay within u32 boundaries; we keep them in the
+        ;; u64 domain (u64-shl + bit-or) so the result is an int64 cell.
+        combined (bit-or (bit-or (u64-shl c1 16) (u64-shl c2 24))
+                         (bit-or c3              (u64-shl len 8)))
+        bitflip  (u64+ (u64-xor (secret-le32-lo) (secret-le32-hi)) seed)
+        keyed    (u64-xor combined bitflip)]
+    (xxh64-avalanche keyed)))
+
+(defn- xxh3-64-4to8
+  "XXH3_len_4to8_64b. Input is 4 to 8 bytes.
+
+     seed' = seed XOR (swap32(seed) << 32)
+     input64 = LE32(input+len-4) + (LE32(input) << 32)
+     bitflip = (LE64(secret+8) ^ LE64(secret+16)) - seed'
+     keyed  = input64 ^ bitflip
+     return rrmxmx(keyed, len)
+
+   Note the seed mangle: the upper-32-bit swap is what makes seed=0 still
+   produce a unique hash per length even when no bits flip."
+  [input seed]
+  (let [len    (count input)
+        seed'  (u64-xor seed (u64-shl (swap32 seed) 32))
+        input1 (read-u32-le input 0)
+        input2 (read-u32-le input (- len 4))
+        bitflip (unchecked-subtract (u64-xor (secret-le64 8) (secret-le64 16))
+                                    seed')
+        input64 (u64+ input2 (u64-shl input1 32))
+        keyed   (u64-xor input64 bitflip)]
+    (xxh3-rrmxmx keyed len)))
+
+(defn- xxh3-64-9to16
+  "XXH3_len_9to16_64b. Input is 9 to 16 bytes. Reads one u64 at the start
+   and one u64 at (len - 8) (overlapping for len < 16, which is fine — the
+   overlap is part of the design):
+
+     bitflip1 = (LE64(secret+24) ^ LE64(secret+32)) + seed
+     bitflip2 = (LE64(secret+40) ^ LE64(secret+48)) - seed
+     input_lo = LE64(input)         ^ bitflip1
+     input_hi = LE64(input+len-8)   ^ bitflip2
+     acc      = len + swap64(input_lo) + input_hi + mul_fold(input_lo, input_hi)
+     return xxh3-avalanche(acc)
+
+   Two mul-folds' worth of mixing concentrated into a single mul-fold plus
+   the swap64; this is where the bulk of the entropy expansion lives for
+   short-but-not-tiny inputs."
+  [input seed]
+  (let [len      (count input)
+        bitflip1 (u64+ (u64-xor (secret-le64 24) (secret-le64 32)) seed)
+        bitflip2 (unchecked-subtract (u64-xor (secret-le64 40) (secret-le64 48))
+                                     seed)
+        input-lo (u64-xor (read-u64-le input 0)           bitflip1)
+        input-hi (u64-xor (read-u64-le input (- len 8))   bitflip2)
+        acc      (u64+ (u64+ (u64+ len (swap64 input-lo))
+                             input-hi)
+                       (mul-fold input-lo input-hi))]
+    (xxh3-avalanche acc)))
+
+;; ============================================================================
+;; xxh3-64 medium input path (17-128 bytes)
+;; ============================================================================
+
+(defn- xxh3-mix-16b
+  "XXH3_mix16B (xxhash.h:4732). Reads two LE u64s from input at byte offsets
+   input-off and input-off+8, XORs each with a seeded secret word, then
+   mul-folds the two halves to a single u64. The +seed / -seed asymmetry
+   between the two secret lanes is what makes the mixer non-degenerate
+   when seed is changed."
+  [input input-off secret-byte-off seed]
+  (let [input-lo (read-u64-le input input-off)
+        input-hi (read-u64-le input (+ input-off 8))
+        sec-lo   (secret-le64 secret-byte-off)
+        sec-hi   (secret-le64 (+ secret-byte-off 8))]
+    (mul-fold
+     (u64-xor input-lo (u64+ sec-lo seed))
+     (u64-xor input-hi (unchecked-subtract sec-hi seed)))))
+
+(defn- xxh3-64-17to128
+  "XXH3_len_17to128_64b. Input is 17 to 128 bytes. Mid-range Mum-hash
+   variant: accumulate (len * PRIME64_1) plus 2/4/6/8 mix16B rounds
+   (depending on length boundaries 32, 64, 96), then xxh3-avalanche.
+
+   The pairing is symmetric — each branch adds one mix at offset 16*i from
+   the start AND one at offset (len - 16*(i+1)) from the end (i.e. measured
+   from the back), with secret offsets ramping up. The longest match
+   (input+48, input+len-64) only fires when len > 96, etc."
+  [input seed]
+  (let [len (count input)
+        acc (u64* len prime64-1)
+        ;; Always pair (input+0, secret+0) with (input+len-16, secret+16).
+        ;; The (> len 32 / 64 / 96) branches add intermediate pairs *before*
+        ;; this final pair is folded in. We thread acc through each addition.
+        acc (if (> len 32)
+              (let [acc (if (> len 64)
+                          (let [acc (if (> len 96)
+                                      (let [acc (u64+ acc (xxh3-mix-16b input 48 96 seed))
+                                            acc (u64+ acc (xxh3-mix-16b input (- len 64) 112 seed))]
+                                        acc)
+                                      acc)
+                                acc (u64+ acc (xxh3-mix-16b input 32 64 seed))
+                                acc (u64+ acc (xxh3-mix-16b input (- len 48) 80 seed))]
+                            acc)
+                          acc)
+                    acc (u64+ acc (xxh3-mix-16b input 16 32 seed))
+                    acc (u64+ acc (xxh3-mix-16b input (- len 32) 48 seed))]
+                acc)
+              acc)
+        acc (u64+ acc (xxh3-mix-16b input 0           0  seed))
+        acc (u64+ acc (xxh3-mix-16b input (- len 16) 16  seed))]
+    (xxh3-avalanche acc)))
+
+;; ============================================================================
+;; Byte-form secret + unaligned mix16B helper
+;; ============================================================================
+;;
+;; The 129-240 and >= 241 paths both need to read u64s from the secret at
+;; non-8-aligned byte offsets (e.g. XXH3_MIDSIZE_STARTOFFSET=3 in the midsize
+;; path; XXH_SECRET_LASTACC_START=7 and XXH_SECRET_MERGEACCS_START=11 in the
+;; long path). secret-le64 asserts 8-alignment by design, so we materialize
+;; a 192-byte view of the same secret cells once at load time and read it
+;; via the generic read-u64-le helper. The bytes are LE within each cell,
+;; matching how the C code reads the underlying byte buffer.
+
+(defn- u64-le-bytes
+  "Decompose a u64 into a length-8 vector of little-endian int byte values
+   in [0, 255]. Used wherever we materialize a u64 cell to a byte view."
+  [n]
+  (mapv #(bit-and (u64-shr n (* % 8)) 0xFF) (range 8)))
+
+(defn- secret-cells->bytes
+  "Flatten a vector of u64 secret cells into a 192-element byte vector
+   (8 little-endian bytes per cell). Pulled into a defn so the result is
+   computed once at namespace-load time and shared across all callers."
+  [cells]
+  (vec (mapcat u64-le-bytes cells)))
+
+(def ^:private xxh3-secret-bytes (secret-cells->bytes xxh3-secret))
+
+(defn- xxh3-mix-16b-byte-secret
+  "Variant of xxh3-mix-16b (xxhash.h:4732) that reads the secret from an
+   arbitrary byte-offset (possibly unaligned) in the default byte-form
+   secret. Used by the midsize path for the tail/extended-rounds mixers
+   (offsets 119 and 16i+3 — both unaligned)."
+  [input input-off secret-byte-off seed]
+  (let [input-lo (read-u64-le input input-off)
+        input-hi (read-u64-le input (+ input-off 8))
+        sec-lo   (read-u64-le xxh3-secret-bytes secret-byte-off)
+        sec-hi   (read-u64-le xxh3-secret-bytes (+ secret-byte-off 8))]
+    (mul-fold
+     (u64-xor input-lo (u64+ sec-lo seed))
+     (u64-xor input-hi (unchecked-subtract sec-hi seed)))))
+
+;; ============================================================================
+;; xxh3-64 midsize input path (129-240 bytes)
+;; ============================================================================
+;;
+;; The 129-240 byte range has its own dedicated mixer (XXH3_len_129to240_64b
+;; in xxhash.h) — it does NOT use the long-input stripe accumulator. The
+;; structure is: 8 mix16B rounds against the leading 128 bytes, then a
+;; mix16B "tail" against the last 16 bytes (which catches the trailing
+;; partial 16-byte chunk for inputs whose length is not a multiple of 16),
+;; then mix16B rounds for any 16-byte groups between bytes 128 and len-16,
+;; with a secret offset bumped by XXH3_MIDSIZE_STARTOFFSET=3 so this lane
+;; reads unaligned secret bytes (different secret window than the first 8).
+;; The two halves are kept in separate accumulators and avalanche-mixed
+;; independently before a final additive merge and a second avalanche.
+
+(def ^:private xxh3-midsize-startoffset 3)
+(def ^:private xxh3-midsize-lastoffset  17)
+(def ^:private xxh3-secret-size-min     136)
+
+(defn- xxh3-64-129to240
+  "XXH3_len_129to240_64b. Input is 129 to 240 bytes.
+
+   acc      = len * PRIME64_1 + sum_{i=0..7} mix16B(input + 16i, secret + 16i, seed)
+   acc_end  = mix16B(input + len - 16, secret + (SECRET_SIZE_MIN - MIDSIZE_LASTOFFSET), seed)
+   acc      = xxh3-avalanche(acc)
+   for i in 8..nbRounds-1:
+     acc_end += mix16B(input + 16i, secret + 16(i-8) + MIDSIZE_STARTOFFSET, seed)
+   return xxh3-avalanche(acc + acc_end)
+
+   nbRounds = floor(len / 16). For len in (128, 240], 8 <= nbRounds <= 15.
+   The MIDSIZE_STARTOFFSET=3 bump on the tail secret is what makes this
+   path mix differently than the 17to128 path for the overlapping 128-byte
+   prefix — the second batch of mix16B rounds reads unaligned secret bytes."
+  [input seed]
+  (let [len (count input)
+        nb-rounds (u64-shr len 4)
+        ;; First 8 mix16B rounds against secret bytes 0..127.
+        acc0 (u64* len prime64-1)
+        acc1 (u64+ acc0 (xxh3-mix-16b input  0   0  seed))
+        acc2 (u64+ acc1 (xxh3-mix-16b input 16  16  seed))
+        acc3 (u64+ acc2 (xxh3-mix-16b input 32  32  seed))
+        acc4 (u64+ acc3 (xxh3-mix-16b input 48  48  seed))
+        acc5 (u64+ acc4 (xxh3-mix-16b input 64  64  seed))
+        acc6 (u64+ acc5 (xxh3-mix-16b input 80  80  seed))
+        acc7 (u64+ acc6 (xxh3-mix-16b input 96  96  seed))
+        acc8 (u64+ acc7 (xxh3-mix-16b input 112 112 seed))
+        ;; Tail mix16B against the last 16 bytes, using a secret window
+        ;; that starts at byte (SECRET_SIZE_MIN - MIDSIZE_LASTOFFSET) = 119.
+        ;; 119 is not 8-aligned (119 mod 8 = 7), so xxh3-mix-16b cannot be
+        ;; used directly — we inline the unaligned variant via the byte-secret
+        ;; helper below in xxh3-secret-bytes. We fall through here and let
+        ;; the loop tail handle it after the avalanche.
+        acc-final (xxh3-avalanche acc8)
+        ;; secret-byte offset 119: byte 7 of cell 14 (bytes 112-119) is the
+        ;; first byte we read; the remaining 15 bytes span cells 15 and 16.
+        ;; Read unaligned via the byte-form secret.
+        acc-end-init (xxh3-mix-16b-byte-secret input (- len 16)
+                                               (- xxh3-secret-size-min
+                                                  xxh3-midsize-lastoffset)
+                                               seed)]
+    ;; Second batch: mix16B for i in 8..nbRounds-1. Secret offset
+    ;; 16*(i-8) + 3 — byte-aligned only at the +3 step, so always unaligned.
+    (loop [i 8
+           acc-end acc-end-init]
+      (if (>= i nb-rounds)
+        (xxh3-avalanche (u64+ acc-final acc-end))
+        (recur (inc i)
+               (u64+ acc-end
+                     (xxh3-mix-16b-byte-secret input (* 16 i)
+                                               (+ (* 16 (- i 8))
+                                                  xxh3-midsize-startoffset)
+                                               seed)))))))
+
+;; ============================================================================
+;; xxh3-64 long input path (>= 241 bytes) — stripe accumulator
+;; ============================================================================
+;;
+;; For inputs >= 241 bytes, xxh3-64 maintains an 8-lane u64 accumulator and
+;; folds the input in 64-byte stripes against successive secret windows.
+;; Every (SECRET_SIZE - STRIPE_LEN) / SECRET_CONSUME_RATE = 16 stripes (a
+;; full "block" = 1024 bytes), the accumulator is "scrambled" against the
+;; last 64 bytes of the secret. The final stripe is always computed against
+;; an offset-back secret window (LASTACC_START=7 bytes back from the end),
+;; even when it overlaps with the previous stripe. Finalization merges the
+;; 8 lanes into a single u64 via XXH3_mergeAccs.
+;;
+;; Constants — all reproduced verbatim from xxhash.h (lines 4863-4865, 5817+,
+;; 6015, 6056, 6064, 6491):
+;;   XXH_STRIPE_LEN              = 64    (one stripe = 8 u64 = 64 bytes)
+;;   XXH_ACC_NB                  = 8     (8 u64 accumulator lanes)
+;;   XXH_SECRET_CONSUME_RATE     = 8     (secret advances 8 bytes per stripe)
+;;   XXH_SECRET_LASTACC_START    = 7     (last-stripe secret offset from end)
+;;   XXH_SECRET_MERGEACCS_START  = 11    (merge-accs secret offset from start)
+;;   XXH3_INTERNALBUFFER_SIZE    = 256   (streaming buffer size, 4 stripes)
+;;
+;; Derived (for the default 192-byte secret):
+;;   NB_STRIPES_PER_BLOCK = (192 - 64) / 8 = 16
+;;   BLOCK_LEN            = 16 * 64       = 1024
+
+(def ^:private xxh-stripe-len           64)
+(def ^:private xxh-acc-nb                8)
+(def ^:private xxh-secret-consume-rate   8)
+(def ^:private xxh-secret-lastacc-start  7)
+(def ^:private xxh-secret-mergeaccs-start 11)
+(def ^:private xxh3-internalbuffer-size 256)
+
+(def ^:private xxh-nb-stripes-per-block 16)
+(def ^:private xxh-block-len           1024)
+
+(def ^:private prime32-1 0x9E3779B1)
+(def ^:private prime32-2 0x85EBCA77)
+(def ^:private prime32-3 0xC2B2AE3D)
+
+;; XXH3_INIT_ACC from xxhash.h:6064. The 8 lanes are the published initial
+;; values for the long-input accumulator. Order is significant — lanes are
+;; addressed by index in accumulate-512 and scramble-acc.
+(def ^:private xxh3-init-acc
+  [prime32-3 prime64-1 prime64-2 prime64-3
+   prime64-4 prime32-2 prime64-5 prime32-1])
+
+(defn- init-custom-secret
+  "Compute the seed-customized secret for the long-input path. Per
+   XXH3_initCustomSecret_scalar (xxhash.h:5858): for each 16-byte chunk i
+   in 0..11, write (le_secret_u64(16i) + seed) as the first 8 bytes and
+   (le_secret_u64(16i + 8) - seed) as the next 8 bytes, all little-endian.
+
+   Result is a 192-byte vector of int byte values, same shape as
+   xxh3-secret-bytes. For seed=0 this returns the default secret bytes
+   (the lo/hi cells round-trip through +0/-0)."
+  [seed]
+  (vec (mapcat (fn [i]
+                 (let [lo (u64+              (secret-le64 (* 16 i))       seed)
+                       hi (unchecked-subtract (secret-le64 (+ (* 16 i) 8)) seed)]
+                   (concat (u64-le-bytes lo) (u64-le-bytes hi))))
+               (range 12))))
+
+(defn- accumulate-512
+  "XXH3_accumulate_512_scalar (xxhash.h:5800). Process one 64-byte stripe
+   into the 8-lane accumulator using a 64-byte secret window.
+
+   For each lane (0..7):
+     data_val = LE64(input + 8*lane)
+     data_key = data_val XOR LE64(secret + 8*lane)
+     acc[lane XOR 1] += data_val        ; cross-lane add (lanes swap pairs)
+     acc[lane]       += (data_key & 0xFFFFFFFF) * (data_key >> 32)
+
+   The XOR-1 cross-lane add interleaves adjacent pairs (0<->1, 2<->3, ...),
+   so the order of lane updates matters: we must compute all data_vals first
+   (so the same lane that's about to be cross-added receives the original
+   value, not the already-cross-added one). We snapshot acc into a vector
+   and apply the updates lane-by-lane in a single sweep.
+
+   Inputs:
+     acc           — 8-vector of u64 cells
+     input         — 8-byte slice (called with offset to give a 64-byte view)
+     input-off     — byte offset into input (start of the stripe)
+     secret-bytes  — the byte-form secret (192 elements)
+     secret-off    — byte offset into the secret (start of the 64-byte window)
+
+   Returns: new 8-vector of updated u64 cells."
+  [acc input input-off secret-bytes secret-off]
+  ;; Read all 8 data_vals first so the cross-lane add reads the pre-update
+  ;; lane values. (The C version reads from input each iteration, which has
+  ;; the same effect since input is not being mutated; but to keep our pure
+  ;; functional shape clean, we read once and apply once.)
+  (let [d0 (read-u64-le input input-off)
+        d1 (read-u64-le input (+ input-off 8))
+        d2 (read-u64-le input (+ input-off 16))
+        d3 (read-u64-le input (+ input-off 24))
+        d4 (read-u64-le input (+ input-off 32))
+        d5 (read-u64-le input (+ input-off 40))
+        d6 (read-u64-le input (+ input-off 48))
+        d7 (read-u64-le input (+ input-off 56))
+        s0 (read-u64-le secret-bytes secret-off)
+        s1 (read-u64-le secret-bytes (+ secret-off 8))
+        s2 (read-u64-le secret-bytes (+ secret-off 16))
+        s3 (read-u64-le secret-bytes (+ secret-off 24))
+        s4 (read-u64-le secret-bytes (+ secret-off 32))
+        s5 (read-u64-le secret-bytes (+ secret-off 40))
+        s6 (read-u64-le secret-bytes (+ secret-off 48))
+        s7 (read-u64-le secret-bytes (+ secret-off 56))
+        k0 (u64-xor d0 s0)
+        k1 (u64-xor d1 s1)
+        k2 (u64-xor d2 s2)
+        k3 (u64-xor d3 s3)
+        k4 (u64-xor d4 s4)
+        k5 (u64-xor d5 s5)
+        k6 (u64-xor d6 s6)
+        k7 (u64-xor d7 s7)
+        mask32 0xFFFFFFFF
+        ;; per-lane mul: low32 * high32 of the keyed value
+        m0 (u64* (bit-and k0 mask32) (u64-shr k0 32))
+        m1 (u64* (bit-and k1 mask32) (u64-shr k1 32))
+        m2 (u64* (bit-and k2 mask32) (u64-shr k2 32))
+        m3 (u64* (bit-and k3 mask32) (u64-shr k3 32))
+        m4 (u64* (bit-and k4 mask32) (u64-shr k4 32))
+        m5 (u64* (bit-and k5 mask32) (u64-shr k5 32))
+        m6 (u64* (bit-and k6 mask32) (u64-shr k6 32))
+        m7 (u64* (bit-and k7 mask32) (u64-shr k7 32))
+        a0 (clojure.core/nth acc 0)
+        a1 (clojure.core/nth acc 1)
+        a2 (clojure.core/nth acc 2)
+        a3 (clojure.core/nth acc 3)
+        a4 (clojure.core/nth acc 4)
+        a5 (clojure.core/nth acc 5)
+        a6 (clojure.core/nth acc 6)
+        a7 (clojure.core/nth acc 7)]
+    ;; lane^1 cross-add: each acc[lane] gets (data_val from lane^1) added,
+    ;; plus its own self-mul. Equivalent to: a[0] += d1 + m0; a[1] += d0 + m1;
+    ;; a[2] += d3 + m2; a[3] += d2 + m3; etc.
+    [(u64+ a0 (u64+ d1 m0))
+     (u64+ a1 (u64+ d0 m1))
+     (u64+ a2 (u64+ d3 m2))
+     (u64+ a3 (u64+ d2 m3))
+     (u64+ a4 (u64+ d5 m4))
+     (u64+ a5 (u64+ d4 m5))
+     (u64+ a6 (u64+ d7 m6))
+     (u64+ a7 (u64+ d6 m7))]))
+
+(defn- scramble-acc
+  "XXH3_scrambleAcc_scalar (xxhash.h:5849). Per-block scramble of the 8-lane
+   accumulator against a 64-byte secret window (the last 64 bytes of the
+   secret, by convention).
+
+   For each lane:
+     a = acc[lane]
+     a ^= a >> 47          ; xorshift
+     a ^= LE64(secret + 8*lane)
+     a *= PRIME32_1
+     acc[lane] = a
+
+   PRIME32_1 is the 32-bit prime constant (the low 32 bits of PRIME64_1);
+   the C code uses xxh_u64 here so the multiply is mod-2^64."
+  [acc secret-bytes secret-off]
+  (loop [i 0
+         out []]
+    (if (>= i xxh-acc-nb)
+      out
+      (let [a (clojure.core/nth acc i)
+            a (u64-xor a (u64-shr a 47))
+            a (u64-xor a (read-u64-le secret-bytes (+ secret-off (* 8 i))))
+            a (u64* a prime32-1)]
+        (recur (inc i) (conj out a))))))
+
+(defn- xxh3-mix-2accs
+  "XXH3_mix2Accs (xxhash.h:6020). Mul-fold of two adjacent accumulator
+   lanes against two adjacent secret u64s. The unit step of mergeAccs."
+  [acc lane-off secret-bytes secret-off]
+  (mul-fold
+   (u64-xor (clojure.core/nth acc lane-off)
+            (read-u64-le secret-bytes secret-off))
+   (u64-xor (clojure.core/nth acc (inc lane-off))
+            (read-u64-le secret-bytes (+ secret-off 8)))))
+
+(defn- merge-accs
+  "XXH3_mergeAccs (xxhash.h:6028). Final-merge the 8-lane accumulator into
+   a single u64, then run xxh3-avalanche.
+
+   result = start
+   for i in 0..3:
+     result += mix2accs(acc[2i], acc[2i+1], secret + secret-off + 16i)
+   return avalanche(result)
+
+   secret-off is XXH_SECRET_MERGEACCS_START=11 (unaligned)."
+  [acc secret-bytes secret-off start]
+  (loop [i 0
+         result start]
+    (if (>= i 4)
+      (xxh3-avalanche result)
+      (recur (inc i)
+             (u64+ result
+                   (xxh3-mix-2accs acc (* 2 i)
+                                   secret-bytes
+                                   (+ secret-off (* 16 i))))))))
+
+(defn- process-stripes
+  "Accumulate `n-stripes` consecutive stripes from `input` (starting at
+   `input-off`) into `acc`, using the secret window that starts at byte
+   offset `secret-base-off` and advances by SECRET_CONSUME_RATE=8 per stripe.
+
+   This is the inner loop of XXH3_hashLong_internal_loop's block processing,
+   factored out for re-use by the streaming digest path."
+  [acc input input-off n-stripes secret-bytes secret-base-off]
+  (loop [s 0
+         a acc]
+    (if (>= s n-stripes)
+      a
+      (recur (inc s)
+             (accumulate-512 a input (+ input-off (* s xxh-stripe-len))
+                             secret-bytes (+ secret-base-off
+                                             (* s xxh-secret-consume-rate)))))))
+
+(defn- xxh3-64-long
+  "XXH3_hashLong_64b_internal (xxhash.h:6067). One-shot long-input hash.
+
+   Drives the stripe accumulator through `nb_blocks` full 1024-byte blocks
+   (each = 16 stripes + a scramble), then a partial final block, then a
+   guaranteed-final stripe at (len - STRIPE_LEN) against the offset-back
+   secret window. The final stripe always runs even if it overlaps the
+   previous stripe — that's part of the spec.
+
+   For seed = 0 we hash against the default secret bytes; otherwise we
+   generate a custom secret via init-custom-secret. Both paths produce
+   the same result for seed=0 (the lo+0/hi-0 round-trip is the identity).
+
+   Caller contract: (>= len 241). Shorter inputs are routed to the
+   midsize or short paths by the dispatcher."
+  [input seed]
+  (let [secret-bytes (if (zero? seed) xxh3-secret-bytes (init-custom-secret seed))
+        len (count input)
+        nb-blocks (clojure.core/quot (dec len) xxh-block-len)
+        ;; Process full blocks: each is 16 stripes of accumulate + a scramble.
+        acc-after-blocks
+        (loop [n 0
+               a xxh3-init-acc]
+          (if (>= n nb-blocks)
+            a
+            (let [block-off (* n xxh-block-len)
+                  a-stripes (process-stripes a input block-off
+                                             xxh-nb-stripes-per-block
+                                             secret-bytes 0)
+                  a-scrambled (scramble-acc a-stripes secret-bytes
+                                            (- 192 xxh-stripe-len))]
+              (recur (inc n) a-scrambled))))
+        ;; Partial last block (may be 0 stripes if len-1 is exactly a multiple
+        ;; of block_len). The "- 1" matches the C code's nb_stripes calc.
+        partial-off (* nb-blocks xxh-block-len)
+        nb-stripes-partial (clojure.core/quot (- (dec len)
+                                                 (* nb-blocks xxh-block-len))
+                                              xxh-stripe-len)
+        acc-after-partial (process-stripes acc-after-blocks input partial-off
+                                           nb-stripes-partial secret-bytes 0)
+        ;; Always run the last stripe at byte (len - STRIPE_LEN), regardless
+        ;; of whether it overlaps the previous stripe. Secret window is
+        ;; SECRET_LASTACC_START=7 bytes back from the end.
+        acc-final (accumulate-512 acc-after-partial input (- len xxh-stripe-len)
+                                  secret-bytes
+                                  (- 192 xxh-stripe-len xxh-secret-lastacc-start))]
+    (merge-accs acc-final secret-bytes
+                xxh-secret-mergeaccs-start
+                (u64* len prime64-1))))
+
+;; ============================================================================
+;; xxh3-64 dispatch
+;; ============================================================================
+
+(defn xxh3-64
+  "Compute the xxh3-64 hash of a byte vector with optional seed (default 0).
+
+   Input must be a vector of int byte values in [0, 255]. Returns an int64
+   cell interpreted as a u64.
+
+   Routes by length to the appropriate code path:
+     0       -> xxh3-64-empty
+     1-3     -> xxh3-64-1to3
+     4-8     -> xxh3-64-4to8
+     9-16    -> xxh3-64-9to16
+     17-128  -> xxh3-64-17to128
+     129-240 -> xxh3-64-129to240    (PR1b)
+     >= 241  -> xxh3-64-long        (PR1b)
+
+   Conforms bit-for-bit to the reference implementation at
+   https://github.com/Cyan4973/xxHash for the full input range."
+  ([input] (xxh3-64 input 0))
+  ([input seed]
+   (let [len (count input)]
+     (cond
+       (zero? len)  (xxh3-64-empty    seed)
+       (<= len 3)   (xxh3-64-1to3     input seed)
+       (<= len 8)   (xxh3-64-4to8     input seed)
+       (<= len 16)  (xxh3-64-9to16    input seed)
+       (<= len 128) (xxh3-64-17to128  input seed)
+       (<= len 240) (xxh3-64-129to240 input seed)
+       :else        (xxh3-64-long     input seed)))))
+
+;; ============================================================================
+;; Streaming xxh3-64 API
+;; ============================================================================
+;;
+;; xxh3-init / xxh3-update / xxh3-digest mirror XXH3_64bits_reset_withSeed /
+;; XXH3_64bits_update / XXH3_64bits_digest from xxhash.h. The state is the
+;; same machine as the one-shot long path drives, but exposed as 3 steps so
+;; callers can fold bytes incrementally:
+;;
+;;     (-> (xxh3-init seed)
+;;         (xxh3-update bytes-1)
+;;         (xxh3-update bytes-2)
+;;         (xxh3-update bytes-N)
+;;         (xxh3-digest))
+;;
+;; Producing the same u64 as (xxh3-64 (vec (concat bytes-1 .. bytes-N)) seed).
+;;
+;; State shape (as a vector — let-go does not support keyword map access
+;; on the hot path):
+;;   [0] acc             — 8-vector of u64 accumulator lanes
+;;   [1] buffer          — vector of buffered bytes (up to 256)
+;;   [2] total-len       — total bytes folded so far (u64)
+;;   [3] nb-stripes-so-far — stripes consumed in the current block (0..15)
+;;   [4] seed            — original seed
+;;   [5] secret-bytes    — byte-form secret (default for seed=0, custom otherwise)
+;;   [6] last-stripe     — the last 64-byte stripe consumed (nil if none yet).
+;;                         Used by digest when bufferedSize < STRIPE_LEN: it
+;;                         catches up the tail of last-stripe to fill out
+;;                         the final stripe. Matches XXH3_digest_long's
+;;                         catchup behavior (xxhash.h:6569).
+;;
+;; The "buffer" carries up to XXH3_INTERNALBUFFER_SIZE = 256 bytes. When an
+;; update fills it past 256, we consume 4 stripes from it (each 64 bytes)
+;; and reset to empty. When total-len <= XXH3_MIDSIZE_MAX = 240 at digest
+;; time we fall back to the short/medium one-shot — the C code does the
+;; same, since the long-input machine is unstable for short totalLen.
+
+(defn xxh3-init
+  "Returns an opaque streaming state initialized with the given seed.
+
+   The state is a vector — opaque to callers; treat it as a black box and
+   pipe it through xxh3-update / xxh3-digest. For a one-shot hash use
+   (xxh3-64 input seed) instead — it's a cheaper code path that skips the
+   incremental buffering."
+  ([] (xxh3-init 0))
+  ([seed]
+   (let [secret-bytes (if (zero? seed) xxh3-secret-bytes (init-custom-secret seed))]
+     [xxh3-init-acc       ; [0] acc
+      []                  ; [1] buffer
+      0                   ; [2] total-len
+      0                   ; [3] nb-stripes-so-far
+      seed                ; [4] seed
+      secret-bytes        ; [5] secret-bytes
+      nil])))             ; [6] last-stripe (nil until first stripe consumed)
+
+(defn- consume-stripes
+  "Fold `n-stripes` stripes from `bytes` (starting at byte offset `input-off`)
+   into the accumulator, advancing `nb-stripes-so-far` and triggering a
+   scramble each time we hit a block boundary (16 stripes).
+
+   Returns [new-acc new-nb-stripes-so-far]. Mirrors XXH3_consumeStripes
+   from xxhash.h:6412 but factored to a pure-value return shape."
+  [acc nb-stripes-so-far bytes input-off n-stripes secret-bytes]
+  (loop [remaining n-stripes
+         off       input-off
+         a         acc
+         sof       nb-stripes-so-far]
+    (if (zero? remaining)
+      [a sof]
+      ;; How many stripes to process before the next block boundary?
+      ;; let-go bug: shadowing a binding (e.g. binding `next-sof` twice in
+      ;; the same `let`) inside a `loop` produces an "index out of range"
+      ;; on the second iteration. We use distinct names (sof-pre-scramble
+      ;; vs sof-after-scramble) and a single conditional pair to avoid it.
+      (let [room-in-block     (- xxh-nb-stripes-per-block sof)
+            this-iter         (if (< remaining room-in-block) remaining room-in-block)
+            a-after           (loop [k 0 acc-k a]
+                                (if (>= k this-iter)
+                                  acc-k
+                                  (recur (inc k)
+                                         (accumulate-512 acc-k bytes
+                                                         (+ off (* k xxh-stripe-len))
+                                                         secret-bytes
+                                                         (* (+ sof k)
+                                                            xxh-secret-consume-rate)))))
+            sof-pre-scramble  (+ sof this-iter)
+            block-full?       (= sof-pre-scramble xxh-nb-stripes-per-block)
+            a-scrambled       (if block-full?
+                                (scramble-acc a-after secret-bytes
+                                              (- 192 xxh-stripe-len))
+                                a-after)
+            sof-final         (if block-full? 0 sof-pre-scramble)]
+        (recur (- remaining this-iter)
+               (+ off (* this-iter xxh-stripe-len))
+               a-scrambled
+               sof-final)))))
+
+(defn- slice-stripe
+  "Return a 64-byte slice of `buf` ending at index `end-exclusive`.
+   Used to capture the last stripe consumed so the digest catchup path
+   can fill in for a < STRIPE_LEN buffer at the tail."
+  [buf end-exclusive]
+  (vec (subvec buf (- end-exclusive xxh-stripe-len) end-exclusive)))
+
+(defn xxh3-update
+  "Fold a byte vector into the streaming state and return the new state.
+
+   `bytes` is a vector of int byte values in [0, 255]. Multiple updates fold
+   incrementally; the end-of-stream digest is the same u64 as feeding the
+   full concatenation through (xxh3-64 all-bytes seed).
+
+   Internal invariant: when this returns, the buffer contains 0..256 bytes;
+   any complete stripes have been folded into the accumulator. The state's
+   last-stripe slot holds the bytes of the most-recently-consumed stripe
+   (for the digest catchup when buffer ends < STRIPE_LEN)."
+  [state bytes]
+  (let [n (count bytes)]
+    (if (zero? n)
+      state
+      (let [acc       (clojure.core/nth state 0)
+            buffer    (clojure.core/nth state 1)
+            total-len (clojure.core/nth state 2)
+            sof       (clojure.core/nth state 3)
+            seed      (clojure.core/nth state 4)
+            secret    (clojure.core/nth state 5)
+            last-stripe (clojure.core/nth state 6)
+            new-total (u64+ total-len n)
+            buf-size  (count buffer)
+            room      (- xxh3-internalbuffer-size buf-size)]
+        (if (<= n room)
+          ;; Small input: just buffer it (no stripes consumed; last-stripe unchanged).
+          [acc (into buffer bytes) new-total sof seed secret last-stripe]
+          ;; Big input. Fill the buffer to 256, consume 4 stripes from it,
+          ;; remember the last stripe (= last 64 bytes of buffer). Then if
+          ;; the remainder still exceeds 256, process the bulk in place
+          ;; (and remember its last stripe too). Finally buffer the tail.
+          (let [fill-end    room
+                filled-buf  (into buffer (subvec bytes 0 fill-end))
+                ;; Consume the entire 256-byte buffer (4 stripes).
+                cs-result   (consume-stripes acc sof filled-buf 0
+                                             (clojure.core/quot
+                                              xxh3-internalbuffer-size
+                                              xxh-stripe-len)
+                                             secret)
+                acc-after   (clojure.core/nth cs-result 0)
+                sof-after   (clojure.core/nth cs-result 1)
+                last-after  (slice-stripe filled-buf xxh3-internalbuffer-size)
+                remaining   (- n fill-end)]
+            (if (<= remaining xxh3-internalbuffer-size)
+              ;; All remaining fits in the (now-empty) buffer.
+              [acc-after (vec (subvec bytes fill-end n))
+               new-total sof-after seed secret last-after]
+              ;; Process the bulk from `bytes` (skipping the buffer entirely)
+              ;; in stripe-sized chunks, leaving the trailing bytes in the
+              ;; buffer. We process all but the last 1..STRIPE_LEN bytes;
+              ;; the count C uses is floor((bEnd - 1 - input) / STRIPE_LEN).
+              (let [bulk-input-len (- remaining 1)
+                    n-stripes      (clojure.core/quot bulk-input-len
+                                                      xxh-stripe-len)
+                    bulk-bytes     (* n-stripes xxh-stripe-len)
+                    cs-bulk        (consume-stripes acc-after sof-after
+                                                    bytes fill-end
+                                                    n-stripes secret)
+                    acc-bulk       (clojure.core/nth cs-bulk 0)
+                    sof-bulk       (clojure.core/nth cs-bulk 1)
+                    tail-start     (+ fill-end bulk-bytes)
+                    new-buf        (vec (subvec bytes tail-start n))
+                    last-bulk      (if (pos? n-stripes)
+                                     (slice-stripe bytes tail-start)
+                                     last-after)]
+                [acc-bulk new-buf new-total sof-bulk seed secret last-bulk]))))))))
+
+(defn xxh3-digest
+  "Finalize the streaming state and return the u64 hash.
+
+   Pure: calling digest does not mutate the state — the same state can be
+   digested multiple times (yielding the same u64), or fed more bytes via
+   xxh3-update after a digest is read."
+  [state]
+  (let [acc         (clojure.core/nth state 0)
+        buffer      (clojure.core/nth state 1)
+        total-len   (clojure.core/nth state 2)
+        sof         (clojure.core/nth state 3)
+        seed        (clojure.core/nth state 4)
+        secret      (clojure.core/nth state 5)
+        last-stripe (clojure.core/nth state 6)]
+    (if (<= total-len 240)
+      ;; For totalLen <= MIDSIZE_MAX, the C code re-hashes the buffered bytes
+      ;; via the one-shot path — the long-input machine is undefined for short
+      ;; inputs and we'd never have entered it anyway (an update with <= 256
+      ;; bytes total has only buffered, never consumed a stripe).
+      (xxh3-64 buffer seed)
+      ;; Long-input digest. The C code (xxh3_digest_long, xxhash.h:6544)
+      ;; handles two cases for the final stripe:
+      ;;   A) bufferedSize >= STRIPE_LEN: consume (bufferedSize-1)/STRIPE_LEN
+      ;;      stripes from the buffer head, then read the last STRIPE_LEN
+      ;;      bytes of the buffer as the catchup stripe.
+      ;;   B) bufferedSize <  STRIPE_LEN: synthesize the catchup stripe by
+      ;;      concatenating (STRIPE_LEN - bufferedSize) bytes from the END
+      ;;      of the previously-consumed-stripe with the bufferedSize bytes
+      ;;      from the current buffer. We track this in state[6] as
+      ;;      last-stripe.
+      (let [buf-size (count buffer)
+            ;; If buffer has >= 1 full stripe, consume (n-1)/STRIPE_LEN
+            ;; stripes from its head; the rest stays for the catchup.
+            digest-result
+            (if (>= buf-size xxh-stripe-len)
+              (let [nb-stripes-final (clojure.core/quot (dec buf-size)
+                                                        xxh-stripe-len)
+                    cs (consume-stripes acc sof buffer 0 nb-stripes-final secret)
+                    acc-after-stripes (clojure.core/nth cs 0)
+                    last-stripe-off (- buf-size xxh-stripe-len)]
+                (accumulate-512 acc-after-stripes buffer last-stripe-off
+                                secret
+                                (- 192 xxh-stripe-len
+                                   xxh-secret-lastacc-start)))
+              ;; bufferedSize < STRIPE_LEN. Synthesize the catchup stripe.
+              ;; state[6] last-stripe is guaranteed non-nil when totalLen > 240
+              ;; (we consumed at least one stripe to cross 256 bytes).
+              (let [catchup-size (- xxh-stripe-len buf-size)
+                    synth-stripe (into (vec (subvec last-stripe
+                                                    (- xxh-stripe-len catchup-size)
+                                                    xxh-stripe-len))
+                                       buffer)]
+                (accumulate-512 acc synth-stripe 0 secret
+                                (- 192 xxh-stripe-len
+                                   xxh-secret-lastacc-start))))]
+        (merge-accs digest-result secret
+                    xxh-secret-mergeaccs-start
+                    (u64* total-len prime64-1))))))
+
+;; ============================================================================
+;; Salt-key encoding (v1)
+;; ============================================================================
+;;
+;; Canonical byte encoding for salt-keys. The v1 format prefixes every term
+;; with a type-tag byte so that structurally distinct values (e.g. the
+;; keyword :b and the single-character string "b") never produce the same
+;; bytes. Lengths and element counts are single bytes (assert < 256 —
+;; salt-keys are short identifier sequences by design, not bulk data).
+;;
+;; Format:
+;;   keyword   -> [salt-tag-kw  | utf8-len(name) | utf8-bytes(name)]
+;;   integer   -> [salt-tag-int | 8 big-endian bytes (signed int64)]
+;;   string    -> [salt-tag-str | utf8-len         | utf8-bytes]
+;;   vector    -> [salt-tag-vec | element-count    | encode-salt(e0) ...]
+;;
+;; Result is a vector of int byte values in [0, 255].
+
+(def ^:private salt-tag-kw  1)
+(def ^:private salt-tag-int 2)
+(def ^:private salt-tag-str 3)
+(def ^:private salt-tag-vec 4)
+
+(defn- int->8-be
+  "Big-endian byte encoding of the low 64 bits of n as a length-8 vector
+   of int byte values [0, 255]. Index 0 holds the most significant byte."
+  [n]
+  (mapv #(bit-and (u64-shr n (* (- 7 %) 8)) 0xFF) (range 8)))
+
+(defn- codepoint->utf8
+  "Encode a single Unicode codepoint as a vector of 1-4 int byte values
+   per the UTF-8 spec (RFC 3629). let-go iterates strings as runes
+   (codepoints), so to produce canonical UTF-8 bytes we re-encode
+   each codepoint explicitly. This matches what the JVM's
+   String.getBytes(\"UTF-8\") produces for the cross-validation harness."
+  [cp]
+  (assert (and (>= cp 0) (<= cp 0x10FFFF)
+               (not (and (>= cp 0xD800) (<= cp 0xDFFF))))
+          (str "codepoint->utf8: invalid codepoint " cp))
+  (cond
+    (< cp 0x80)
+    [cp]
+
+    (< cp 0x800)
+    [(bit-or 0xC0 (bit-and (u64-shr cp 6) 0x1F))
+     (bit-or 0x80 (bit-and cp 0x3F))]
+
+    (< cp 0x10000)
+    [(bit-or 0xE0 (bit-and (u64-shr cp 12) 0x0F))
+     (bit-or 0x80 (bit-and (u64-shr cp 6) 0x3F))
+     (bit-or 0x80 (bit-and cp 0x3F))]
+
+    :else
+    [(bit-or 0xF0 (bit-and (u64-shr cp 18) 0x07))
+     (bit-or 0x80 (bit-and (u64-shr cp 12) 0x3F))
+     (bit-or 0x80 (bit-and (u64-shr cp 6) 0x3F))
+     (bit-or 0x80 (bit-and cp 0x3F))]))
+
+(defn- utf8-bytes
+  "Convert a let-go string to its UTF-8 byte representation as a vector of
+   int byte values. let-go strings iterate as runes (codepoints), so we
+   re-encode each codepoint through codepoint->utf8 rather than relying on
+   any (.getBytes ...) Java-interop call (which is not implemented for
+   let-go's String type)."
+  [s]
+  (reduce (fn [acc c] (into acc (codepoint->utf8 (int c)))) [] s))
+
+(defn encode-salt
+  "Canonical byte encoding of a salt-key (v1). Returns a vector of int byte
+   values in [0, 255]. Supported terms: keyword, integer, string, vector of
+   the same. Type-tag prefixes ensure that structurally distinct salt-keys
+   never collide (e.g. [:a \"b\"] and [:a :b] encode to different bytes).
+
+   Length and element-count bytes are single bytes; we assert (< n 256)
+   rather than silently truncate. Salt-keys in xsofy are short identifier
+   sequences (event tag + a handful of entity ids), so 255 is a comfortable
+   ceiling."
+  [s]
+  (cond
+    (keyword? s)
+    (let [name-bytes (utf8-bytes (name s))]
+      (assert (< (count name-bytes) 256)
+              (str "Keyword name exceeds 255 bytes: " (name s)))
+      (into [salt-tag-kw (count name-bytes)] name-bytes))
+
+    (integer? s)
+    (into [salt-tag-int] (int->8-be s))
+
+    (string? s)
+    (let [b (utf8-bytes s)]
+      (assert (< (count b) 256)
+              (str "String exceeds 255 bytes (len=" (count b) ")"))
+      (into [salt-tag-str (count b)] b))
+
+    (vector? s)
+    (let [n (count s)]
+      (assert (< n 256)
+              (str "Vector exceeds 255 elements (len=" n ")"))
+      (reduce (fn [acc el] (into acc (encode-salt el)))
+              [salt-tag-vec n]
+              s))
+
+    :else
+    (throw (ex-info "encode-salt: unsupported type"
+                    {:value s :type (type s)}))))
+
+;; ============================================================================
+;; combine — the public API for det
+;; ============================================================================
+
+(defn combine
+  "Hash a seed (u64) with a salt-key. Returns a u64.
+
+   This is the function every det/ call invokes. The plan:
+
+     (det/int world [:combat :hit a t] lo hi)
+
+   reduces (modulo the macro layer) to
+
+     (mod (xsofy.hash/combine (:seed world) [:combat :hit a t]) (- hi lo))
+
+   plus lo. The salt-key passes through encode-salt to canonical bytes, then
+   xxh3-64 mixes those bytes against the seed.
+
+   For salt-keys with constant prefixes the with-folded-salt macro folds
+   the prefix at compile time and calls xxh3-64 directly on a precomputed
+   byte buffer; combine itself stays a plain hot-path runtime call."
+  [seed salt-key]
+  (xxh3-64 (encode-salt salt-key) seed))
+
+;; ============================================================================
+;; Streaming reducer convenience API
+;; ============================================================================
+;;
+;; from-stream / folder / init-state / digest let callers fold a sequence of
+;; arbitrary atoms (events, ticks, identifiers) into a single hash via a
+;; user-supplied byte encoder. The two shapes:
+;;
+;;   one-shot:   (hash/from-stream seed encode-fn stream) => u64
+;;   reducer:    (hash/digest (reduce (hash/folder encode-fn)
+;;                                    (hash/init-state seed)
+;;                                    stream)) => u64
+;;
+;; PR1b: these are now backed by the real incremental xxh3-64 state machine
+;; (xxh3-init / xxh3-update / xxh3-digest). The byte-encoder output for each
+;; atom is fed straight into xxh3-update — no buffer-then-one-shot.
+;; A 100-atom stream of 1 KB each no longer materializes a 100 KB byte
+;; buffer; it just churns the bytes through the stripe accumulator and
+;; throws them away.
+
+(defn from-stream
+  "Hash a sequence of atoms with a user-supplied byte-encoder. Returns a u64.
+
+   encode-fn receives one atom and must return a vector of int byte values
+   in [0, 255]. The atoms are encoded in order and folded into the streaming
+   xxh3-64 state, which is then finalized.
+
+   Example:
+     (hash/from-stream 42 hash/encode-salt [:combat :hit :rat-3])"
+  [seed encode-fn stream]
+  (xxh3-digest
+   (reduce (fn [state atom] (xxh3-update state (encode-fn atom)))
+           (xxh3-init seed)
+           stream)))
+
+(defn init-state
+  "Returns a fresh hash-folder state ready to accumulate atoms.
+
+   The state is opaque to callers — use `folder` to extend it and `digest`
+   to finalize. seed is the u64 seed for the eventual hash.
+
+   PR1b: returns the real streaming state (xxh3-init), not the
+   buffer-and-one-shot pair it returned in PR1. External behavior is
+   unchanged — only `folder` and `digest` understand the shape."
+  [seed]
+  (xxh3-init seed))
+
+(defn folder
+  "Returns a 2-arg reducing function ((state atom) -> state) suitable for use
+   with clojure.core/reduce. Pair with `init-state` to seed and `digest` to
+   finalize:
+
+     (hash/digest
+       (reduce (hash/folder encode-fn) (hash/init-state seed) stream))
+
+   For simple one-shot use, prefer `from-stream`. `folder` exists for callers
+   that need an explicit accumulator — e.g. threading hash state through a
+   simulation tick alongside other per-step state.
+
+   PR1b: folds bytes directly into the streaming xxh3-64 state via
+   xxh3-update — no buffering."
+  [encode-fn]
+  (fn [state atom]
+    (xxh3-update state (encode-fn atom))))
+
+(defn digest
+  "Extract the final u64 hash from a folder state.
+
+   The state must be one produced by `init-state` + zero or more `folder`
+   applications. Calling digest on the same state twice returns the same
+   hash (digest is pure and does not consume the state)."
+  [state]
+  (xxh3-digest state))
+
+;; ============================================================================
+;; Macro Layer 1 — compile-time fold of constant salt-key prefix
+;; ============================================================================
+;;
+;; with-folded-salt wraps (combine seed salt-key). At expansion time it
+;; inspects the salt-key:
+;;
+;;   * fully-literal vector  -> emit (xxh3-64 <precomputed-bytes> seed)
+;;   * partial-literal vector -> emit code that encodes only the variable
+;;                               tail at runtime and prepends the precomputed
+;;                               prefix bytes before hashing
+;;   * non-vector / no literal prefix -> emit the plain (combine seed salt-key)
+;;
+;; This eliminates encode-salt overhead for the literal prefix on every call,
+;; which matters when det/ calls in the inner loop share long literal tags
+;; like [:combat :hit ...]. Macro Layers 2 (algebraic simplifier) and 3
+;; (shape specialization) are deferred — see the notice at the bottom of
+;; this file for rationale. This file only owns Layer 1.
+
+(defn- salt-literal?
+  "True iff form is a leaf literal salt term — keyword, integer, or string.
+   Vectors are deliberately not included: a literal vector is a *nested
+   structure* that the macro recursively encodes, not a single fold-able
+   element. (Currently with-folded-salt only inspects flat vectors at the
+   top level, so this distinction does not yet matter, but the helper is
+   named for the leaf-literal contract it pins.)"
+  [form]
+  (or (keyword? form)
+      (integer? form)
+      (string? form)))
+
+(defn- split-at-first-non-literal
+  "Walk forms left-to-right collecting a literal prefix. Return [prefix tail]
+   where prefix is the maximal leading run of leaf literals and tail is the
+   remaining forms (in original order). If all forms are literals, tail is
+   empty; if the very first form is not a literal, prefix is empty."
+  [forms]
+  (loop [prefix []
+         tail   forms]
+    (cond
+      (empty? tail) [prefix []]
+      (salt-literal? (first tail)) (recur (conj prefix (first tail)) (rest tail))
+      :else [prefix tail])))
+
+(defmacro with-folded-salt
+  "Compile-time-folded version of (combine seed salt-key).
+
+   If salt-key is a vector literal:
+     [:foo :bar attacker target]
+   the macro encodes [:foo :bar] at compile time (constant prefix), and
+   emits code that encodes [attacker target] at runtime, prepending the
+   precomputed prefix bytes before hashing.
+
+   This eliminates encode-salt overhead for the literal prefix on every
+   call. For salt-keys with no variable elements, the whole prefix-encoding
+   step is constant-folded (only the xxh3-64 mix runs at call time, since
+   seed is still a runtime value).
+
+   For salt-keys that aren't vector literals (e.g. a symbol referring to
+   a runtime-constructed vector), falls back to (combine seed salt-key).
+
+   Emitted symbols are fully namespace-qualified to xsofy.hash/* to work
+   around let-go's syntax-quote ns-qualification gap (see let-go#48)."
+  [seed salt-key]
+  (cond
+    ;; Fully-literal vector: precompute the entire byte buffer at expansion
+    ;; time and emit a direct xxh3-64 call. The seed is still a runtime
+    ;; value (it's whatever expression the caller wrote), so we can't fold
+    ;; the hash itself — only the input bytes.
+    (and (vector? salt-key) (every? salt-literal? salt-key))
+    (let [bytes-literal (encode-salt salt-key)]
+      `(xsofy.hash/xxh3-64 ~bytes-literal ~seed))
+
+    ;; Partially-literal vector: fold the leading literal prefix, emit
+    ;; runtime code for the variable tail.
+    (vector? salt-key)
+    (let [pair   (split-at-first-non-literal salt-key)
+          prefix (clojure.core/nth pair 0)
+          tail   (clojure.core/nth pair 1)]
+      (if (empty? prefix)
+        ;; No literal prefix to fold — bail out to the plain runtime path.
+        `(xsofy.hash/combine ~seed ~salt-key)
+        ;; Has a literal prefix. We need to emit code that, at runtime:
+        ;;   1. encodes the tail through xsofy.hash/encode-salt (per element)
+        ;;   2. prepends the precomputed prefix bytes
+        ;;   3. wraps the result in the outer vector header [4 full-len]
+        ;;      (4 = salt-tag-vec; inlined as a literal because the tag
+        ;;       constant is private to this ns).
+        ;; The full-len assertion runs at expansion time so an over-long
+        ;; salt-key is caught before the program runs.
+        (let [tail-len               (count tail)
+              full-len               (+ (count prefix) tail-len)
+              prefix-elements-bytes  (vec (mapcat encode-salt prefix))]
+          (assert (< full-len 256)
+                  (str "with-folded-salt: salt-key length " full-len
+                       " exceeds the 255-element ceiling"))
+          `(let [tail-bytes# (reduce (fn [acc# el#]
+                                       (into acc# (xsofy.hash/encode-salt el#)))
+                                     []
+                                     ~(vec tail))
+                 full-bytes# (into (into [4 ~full-len] ~prefix-elements-bytes)
+                                   tail-bytes#)]
+             (xsofy.hash/xxh3-64 full-bytes# ~seed)))))
+
+    ;; salt-key is not a vector literal — must be a symbol or other expression
+    ;; whose value is only known at runtime. Defer to the plain combine call.
+    :else
+    `(xsofy.hash/combine ~seed ~salt-key)))
+
+;; ============================================================
+;; Macro Layers 2 and 3 — DEFERRED
+;; ============================================================
+;;
+;; Layer 2 (algebraic simplifier) and Layer 3 (shape specialization) are
+;; deferred to a future PR. Rationale:
+;;
+;;   * Layer 1 (constant-fold salt-key prefix) is implemented above and
+;;     already eliminates encode-salt overhead for the literal prefix on
+;;     every call. For typical salt-keys like [:combat :hit :rat-3 :player],
+;;     this is the bulk of the savings.
+;;
+;;   * Layer 2 (peephole rewriter on u64 op chains: u64+ associativity,
+;;     u64* constant folding, u64-xor constant merging, u64-shr collapse,
+;;     redundant mask elimination) would further optimize macro-emitted
+;;     code chains. Real perf benefit only measurable after profiling.
+;;     Building it without that data would be premature optimization.
+;;
+;;   * Layer 3 (shape specialization: emit cached per-shape helper fns
+;;     keyed by salt-prefix hash, skipping runtime salt-encoding entirely
+;;     for known shapes) is a further perf win but adds significant
+;;     compile-time machinery. Same YAGNI argument.
+;;
+;; Trigger to revisit: profile xxh3-64 in the deterministic-world balance
+;; harness. If salt-encoding shows up as a hot path, build Layer 2 first
+;; (it's the smaller of the two and has narrower scope).

--- a/xsofy/test/hash_test.lg
+++ b/xsofy/test/hash_test.lg
@@ -1,0 +1,712 @@
+(ns xsofy.test.hash-test
+  "Tests for xsofy.hash — xxh3-64, salt encoding, macro folding."
+  (:require [test :refer [deftest is testing]]
+            [xsofy.check :as c]
+            [xsofy.hash :as h]))
+
+;; ============================================================================
+;; u64 helpers
+;; ============================================================================
+
+(deftest u64+-basic
+  (testing "u64+ adds within the safe range"
+    (is (= 5 (h/u64+ 2 3)))
+    (is (= 0 (h/u64+ 0 0)))
+    (is (= -1 (h/u64+ -1 0)))))
+
+(deftest u64+-wraps-modulo-2-to-64
+  (testing "u64+ wraps modular int64 (relies on let-go's unchecked-add)"
+    ;; Long/MAX_VALUE + 1 wraps to Long/MIN_VALUE (the bit pattern
+    ;; (unchecked-long 0x8000000000000000)), which is the correct mod-2^64 result.
+    (is (= -9223372036854775808 (h/u64+ 9223372036854775807 1)))
+    ;; Long/MIN_VALUE + Long/MIN_VALUE wraps to 0 (2^64 mod 2^64).
+    (is (= 0 (h/u64+ -9223372036854775808 -9223372036854775808)))
+    ;; Long/MIN_VALUE + -1 wraps to Long/MAX_VALUE.
+    (is (= 9223372036854775807 (h/u64+ -9223372036854775808 -1)))))
+
+(deftest u64-shr-basic
+  (testing "u64-shr performs logical right shift on small values"
+    (is (= 1 (h/u64-shr 8 3)))
+    (is (= 0 (h/u64-shr 7 3)))
+    (is (= 8 (h/u64-shr 16 1)))
+    (is (= 42 (h/u64-shr 42 0)))))
+
+(deftest u64-shr-zero-fills
+  (testing "u64-shr zero-fills high bits (unlike arithmetic shift)"
+    ;; -1 is (unchecked-long 0xFFFFFFFFFFFFFFFF); logical >> 1 = 0x7FFFFFFFFFFFFFFF.
+    ;; Arithmetic shift would sign-extend back to -1.
+    (is (= 0x7FFFFFFFFFFFFFFF (h/u64-shr -1 1)))
+    ;; -1 >> 63 logically leaves a single low bit set.
+    (is (= 1 (h/u64-shr -1 63)))))
+
+(deftest u64-shl-basic
+  (testing "u64-shl performs modular left shift on small values"
+    (is (= 8 (h/u64-shl 1 3)))
+    ;; Shift 1 into the high bit: signed result is Long/MIN_VALUE
+    ;; (bit pattern (unchecked-long 0x8000000000000000)).
+    (is (= -9223372036854775808 (h/u64-shl 1 63)))
+    ;; n=0 is the identity.
+    (is (= 42 (h/u64-shl 42 0)))))
+
+(deftest u64-shl-wraps-at-2-to-64
+  (testing "u64-shl wraps mod 2^64: bits shifted past the top fall off"
+    ;; Shifting any 64-bit value left by 64 wraps to 0.
+    (is (= 0 (h/u64-shl 1 64)))
+    ;; 3 = 0b11; << 63 keeps only the high bit (the low bit falls off the top).
+    (is (= -9223372036854775808 (h/u64-shl 3 63)))))
+
+(deftest u64-rotl-basic
+  (testing "u64-rotl rotates bits left, wrapping around"
+    (is (= 2 (h/u64-rotl 1 1)))
+    (is (= 4294967296 (h/u64-rotl 1 32)))
+    ;; Rotating 1 left by 63 places the bit at position 63 (the sign bit).
+    (is (= -9223372036854775808 (h/u64-rotl 1 63)))
+    ;; Rotating Long/MIN_VALUE (only high bit set) left by 1 wraps it to bit 0.
+    (is (= 1 (h/u64-rotl -9223372036854775808 1)))))
+
+(deftest u64-rotl-identity-at-0
+  (testing "u64-rotl by 0 is the identity"
+    (is (= 42 (h/u64-rotl 42 0)))))
+
+(deftest u64-rotl-identity-at-64
+  (testing "u64-rotl by 64 is a full cycle and equals the identity"
+    (is (= 42 (h/u64-rotl 42 64)))))
+
+(deftest u64*-basic
+  (testing "u64* multiplies within the safe range"
+    (is (= 6 (h/u64* 2 3)))
+    (is (= 0 (h/u64* 0 12345)))
+    (is (= 12345 (h/u64* 12345 1)))))
+
+(deftest u64*-wraps-at-2-to-64
+  (testing "u64* wraps modular int64 (relies on let-go's unchecked-multiply)"
+    ;; Long/MAX_VALUE * 2 = 2^64 - 2, which wraps to -2 in signed int64.
+    (is (= -2 (h/u64* 9223372036854775807 2)))
+    ;; Long/MIN_VALUE * 2 = 2^64, wraps to 0.
+    (is (= 0 (h/u64* -9223372036854775808 2)))))
+
+(deftest u64*-prime-sanity
+  (testing "u64* round-trips the xxh3 PRIME64_1 constant (negative int64 literal)"
+    ;; PRIME64_1 = (unchecked-long 0x9E3779B185EBCA87), which as signed int64 is -7046029288634856825.
+    ;; This assertion confirms let-go's reader parses the hex literal to the
+    ;; correct two's-complement int64, independent of any multiply.
+    (is (= -7046029288634856825 (unchecked-long 0x9E3779B185EBCA87)))
+    ;; PRIME64_1 * PRIME64_4 mod 2^64 — exact value cross-checked with Python.
+    (is (= (unchecked-long 0xDEF35B010F796CA9) (h/u64* (unchecked-long 0x9E3779B185EBCA87) (unchecked-long 0xC2B2AE3D27D4EB4F))))))
+
+(deftest u64*-128-basic
+  (testing "Multiplication that fits in 64 bits has high = 0"
+    ;; 12345 * 6789 = 83810205, fits comfortably in int64, so hi = 0.
+    (let [r (h/u64*-128 12345 6789)
+          hi (clojure.core/nth r 0)
+          lo (clojure.core/nth r 1)]
+      (is (= 0 hi))
+      (is (= (* 12345 6789) lo)))))
+
+(deftest u64*-128-exact-overflow
+  (testing "2^32 * 2^32 = 2^64 — high = 1, low = 0"
+    ;; Boundary case: the product is exactly 2^64, so the low 64 bits are 0
+    ;; and the high 64 bits carry a single 1. Confirms the high half is
+    ;; computed independently and not just a fallout of low-64 wrap.
+    (let [r (h/u64*-128 0x100000000 0x100000000)
+          hi (clojure.core/nth r 0)
+          lo (clojure.core/nth r 1)]
+      (is (= 1 hi))
+      (is (= 0 lo)))))
+
+(deftest u64*-128-prime-product
+  (testing "PRIME64_1 * PRIME64_2 — verified against Python"
+    ;; Reference values cross-checked with Python's arbitrary-precision int:
+    ;;   p1=(unchecked-long 0x9E3779B185EBCA87), p2=(unchecked-long 0xC2B2AE3D27D4EB4F)
+    ;;   full = p1 * p2
+    ;;   hi = full >> 64 = 0x7854787AA57880A8 (signed int64: 8670687650752528552)
+    ;;   lo = full & ((1<<64)-1) = (unchecked-long 0xDEF35B010F796CA9) (signed int64: -2381459717836149591)
+    ;; The lo value matches u64*-prime-sanity above (which only checked the
+    ;; low half via unchecked-multiply), and confirms u64*-128 produces both
+    ;; halves of a real xxh3-style mul-fold input.
+    (let [r (h/u64*-128 (unchecked-long 0x9E3779B185EBCA87) (unchecked-long 0xC2B2AE3D27D4EB4F))
+          hi (clojure.core/nth r 0)
+          lo (clojure.core/nth r 1)]
+      (is (= 0x7854787AA57880A8 hi))
+      (is (= (unchecked-long 0xDEF35B010F796CA9) lo)))))
+
+(deftest u64*-128-identities
+  (testing "multiply by 1 returns [0 a]"
+    (let [r (h/u64*-128 (unchecked-long 0x9E3779B185EBCA87) 1)]
+      (is (= 0 (clojure.core/nth r 0)))
+      (is (= (unchecked-long 0x9E3779B185EBCA87) (clojure.core/nth r 1)))))
+  (testing "multiply by 0 returns [0 0]"
+    (is (= [0 0] (h/u64*-128 (unchecked-long 0x9E3779B185EBCA87) 0)))))
+
+(deftest u64*-128-all-ones-squared
+  (testing "all-ones squared: (2^64 - 1)^2 = 2^128 - 2^65 + 1; hi=-2 lo=1"
+    (let [r (h/u64*-128 -1 -1)]
+      (is (= -2 (clojure.core/nth r 0)))
+      (is (= 1  (clojure.core/nth r 1))))))
+
+(deftest mul-fold-basic
+  (testing "mul-fold XORs the two halves of a 128-bit product"
+    ;; 2 * 3 = 6, so the 128-bit product is [hi=0 lo=6]; folding XORs the
+    ;; halves to 0 XOR 6 = 6. Small-input sanity that the fold doesn't
+    ;; mask, shift, or otherwise mangle a product that fits in 64 bits.
+    (is (= 6 (h/mul-fold 2 3)))))
+
+(deftest mul-fold-with-overflow
+  (testing "mul-fold of 2^32 * 2^32 = 2^64 → [hi=1 lo=0] → 1 XOR 0 = 1"
+    ;; Boundary case mirrored from u64*-128-exact-overflow. Confirms the
+    ;; fold consumes both halves: a buggy impl that returned only lo would
+    ;; give 0 here, and one that returned only hi would also give 1 — so
+    ;; this pairs with mul-fold-basic to pin down the XOR.
+    (is (= 1 (h/mul-fold 0x100000000 0x100000000)))))
+
+(deftest mul-fold-prime-product
+  (testing "mul-fold of PRIME64_1 * PRIME64_2 = hi XOR lo (Python-verified)"
+    ;; Reference computed in Python with arbitrary-precision int:
+    ;;   p1=(unchecked-long 0x9E3779B185EBCA87), p2=(unchecked-long 0xC2B2AE3D27D4EB4F)
+    ;;   r = p1 * p2
+    ;;   hi = r >> 64                  = 0x7854787AA57880A8
+    ;;   lo = r & ((1<<64)-1)          = (unchecked-long 0xDEF35B010F796CA9)
+    ;;   hi XOR lo                      = (unchecked-long 0xA6A7237BAA01EC01)
+    ;; This exercises the full mul-fold on a real xxh3-style mixer input.
+    (is (= (unchecked-long 0xA6A7237BAA01EC01)
+           (h/mul-fold (unchecked-long 0x9E3779B185EBCA87) (unchecked-long 0xC2B2AE3D27D4EB4F))))))
+
+(deftest read-u64-le-basic
+  (testing "Read 8 little-endian bytes as u64"
+    ;; [0x01 0 0 0 0 0 0 0] little-endian = 1 (low byte first).
+    (is (= 1 (h/read-u64-le [1 0 0 0 0 0 0 0] 0)))
+    ;; [0 0 0 0 0 0 0 1] little-endian = 2^56 = 0x0100000000000000.
+    ;; Confirms the topmost byte lands at shift 56, not at shift 0.
+    (is (= 0x0100000000000000 (h/read-u64-le [0 0 0 0 0 0 0 1] 0)))))
+
+(deftest read-u64-le-with-offset
+  (testing "Reads at a non-zero offset"
+    ;; The u64 value 1 starts at index 2 of this buffer (the leading zeros
+    ;; before the offset must be ignored, not folded in).
+    (is (= 1 (h/read-u64-le [0 0 1 0 0 0 0 0 0 0] 2)))))
+
+(deftest read-u64-le-high-bit
+  (testing "Reads (unchecked-long 0xFFFFFFFFFFFFFFFF) (= -1 as signed int64)"
+    ;; All-ones across all 8 bytes assembles the sign bit. A buggy impl that
+    ;; uses sign-extending shift or that drops the top byte would not produce
+    ;; -1 here. This pins down that the shift family is the u64-shl variant.
+    (is (= -1 (h/read-u64-le [0xFF 0xFF 0xFF 0xFF 0xFF 0xFF 0xFF 0xFF] 0)))))
+
+(deftest read-u32-le-basic
+  (testing "Read 4 little-endian bytes as u32 (stored in u64 cell)"
+    (is (= 1 (h/read-u32-le [1 0 0 0] 0)))
+    ;; All-ones across 4 bytes = 0xFFFFFFFF. Stored in a u64 cell this is
+    ;; positive (2^32 - 1), not -1 — confirms we only assemble 4 bytes,
+    ;; not 8, and that the high 32 bits stay zero.
+    (is (= 0xFFFFFFFF (h/read-u32-le [0xFF 0xFF 0xFF 0xFF] 0)))))
+
+(deftest u64-xor-basic
+  (testing "u64-xor is bit-parallel XOR on int64 cells"
+    ;; XOR with self collapses to 0.
+    (is (= 0 (h/u64-xor 5 5)))
+    ;; 0b101 XOR 0b010 = 0b111.
+    (is (= 7 (h/u64-xor 5 2)))
+    ;; XOR with 0 is the identity.
+    (is (= 5 (h/u64-xor 5 0)))
+    ;; High-bit case: all-1s XOR 0 = all-1s.
+    (is (= -1 (h/u64-xor -1 0)))
+    ;; High-bit case: all-1s XOR itself = 0.
+    (is (= 0 (h/u64-xor -1 -1)))
+    ;; Alternating-bit pattern proves XOR operates on all 64 bits.
+    ;; 0x5555555555555555 XOR (unchecked-long 0xAAAAAAAAAAAAAAAA) = (unchecked-long 0xFFFFFFFFFFFFFFFF) = -1 in int64.
+    ;; A buggy impl that truncates to 32 bits would produce 0xFFFFFFFF = 4294967295.
+    (is (= -1 (h/u64-xor 0x5555555555555555 (unchecked-long 0xAAAAAAAAAAAAAAAA))))))
+
+;; ============================================================================
+;; u64 property tests
+;; ============================================================================
+;;
+;; These complement the fixed-case deftests above by exploring random input
+;; space for compositional properties. Together they catch a class of bugs
+;; (asymmetry, off-by-one shifts, wrong rotation wrap math) that any single
+;; fixed pair would miss.
+;;
+;; Range note: gen-small-int draws from a narrow symmetric span. c/gen-int's
+;; rand-in computes (inc (- hi lo)) and (+ lo (mod n span)) where n < 2^31,
+;; so wide ranges both overflow on (inc ...) and only produce values within
+;; 2^31 of lo. A small symmetric span keeps the arithmetic safe and ensures
+;; samples cover both signs. The extreme-edge bit patterns (Long/MIN_VALUE,
+;; Long/MAX_VALUE, all-ones) are already pinned by the deftests above —
+;; these properties exercise the *compositional* shape of the helpers,
+;; which holds for any int64 cell.
+
+(def gen-small-int (c/gen-int -1000000 1000000))
+
+(c/defprop u64+-is-commutative
+  [a gen-small-int b gen-small-int]
+  (= (h/u64+ a b) (h/u64+ b a)))
+
+(c/defprop u64*-is-commutative
+  [a gen-small-int b gen-small-int]
+  (= (h/u64* a b) (h/u64* b a)))
+
+(c/defprop u64*-128-is-commutative
+  [a gen-small-int b gen-small-int]
+  (= (h/u64*-128 a b) (h/u64*-128 b a)))
+
+(c/defprop u64-shl-then-shr-loses-low-bits
+  [x gen-small-int n (c/gen-int 1 63)]
+  ;; Shifting left by n then right by n loses the high n bits of x.
+  ;; The RHS computes the expected low-(64-n)-bits mask as 2^(64-n) - 1
+  ;; via arithmetic primitives, independent of any right-shift function.
+  ;; unchecked-subtract is needed because (bit-shift-left 1 63) is
+  ;; Long/MIN_VALUE, and the subtraction wraps mod 2^64 to give the mask.
+  (= (h/u64-shr (h/u64-shl x n) n)
+     (bit-and x (unchecked-subtract (bit-shift-left 1 (- 64 n)) 1))))
+
+(c/defprop u64-rotl-by-n-then-64-minus-n-is-identity
+  ;; Rotating left by n then by (64 - n) is one full cycle, so it must equal
+  ;; the original x. Catches any off-by-one in the (- 64 n) wrap math.
+  [x gen-small-int n (c/gen-int 0 64)]
+  (= x (h/u64-rotl (h/u64-rotl x n) (- 64 n))))
+
+;; ============================================================================
+;; xxh3-64 constants
+;; ============================================================================
+
+(deftest xxh3-secret-matches-upstream
+  (testing "xxh3 default secret cells match upstream xxhash.h"
+    ;; Cell 0 = LE u64 of upstream bytes [0..7] = b8 fe 6c 39 23 a4 4b be
+    (is (= (unchecked-long 0xbe4ba423396cfeb8) (h/xxh3-secret-cell 0)))
+    ;; Cell 23 = LE u64 of upstream bytes [184..191] = af d7 fb ca bb 4b 40 7e
+    (is (= 0x7e404bbbcafbd7af (h/xxh3-secret-cell 23)))))
+
+;; ============================================================================
+;; Salt-key encoding (v1)
+;; ============================================================================
+;;
+;; Type-tag prefixes (kw=1, int=2, str=3, vec=4) prevent shape ambiguity:
+;; [:a "b"] and [:a :b] must encode to different bytes. Lengths and element
+;; counts are single bytes (assert < 256 — salt-keys are short by design).
+
+(deftest encode-salt-keyword
+  (testing "Keyword encodes as 0x01 | utf8-len(name) | utf8-of-name"
+    ;; :foo → 0x01, 3, 'f', 'o', 'o' → [1 3 102 111 111]
+    (is (= [1 3 102 111 111] (h/encode-salt :foo)))))
+
+(deftest encode-salt-int
+  (testing "Int encodes as 0x02 | 8 big-endian bytes"
+    ;; 1 → [0x02 0 0 0 0 0 0 0 1]
+    (is (= [2 0 0 0 0 0 0 0 1] (h/encode-salt 1)))
+    ;; 256 → [0x02 0 0 0 0 0 0 1 0] proves the boundary between the low
+    ;; and second-lowest bytes is laid out big-endian, not little-endian.
+    (is (= [2 0 0 0 0 0 0 1 0] (h/encode-salt 256)))
+    ;; -1 = (unchecked-long 0xFFFFFFFFFFFFFFFF) big-endian → [0xFF × 8]
+    (is (= [2 255 255 255 255 255 255 255 255] (h/encode-salt -1)))
+    ;; Long/MIN_VALUE = (unchecked-long 0x8000000000000000) → [128 0 × 7]
+    (is (= [2 128 0 0 0 0 0 0 0] (h/encode-salt -9223372036854775808)))))
+
+(deftest encode-salt-string
+  (testing "String encodes as 0x03 | utf8-len | utf8-bytes"
+    ;; "hi" → [0x03, 2, 'h', 'i'] → [3 2 104 105]
+    (is (= [3 2 104 105] (h/encode-salt "hi")))))
+
+(deftest encode-salt-vector
+  (testing "Vector encodes as 0x04 | element-count | element-bytes..."
+    ;; [:foo 1] → 0x04, 2, [1, 3, 'f', 'o', 'o'], [2, 0, 0, 0, 0, 0, 0, 0, 1]
+    (is (= [4 2  1 3 102 111 111  2 0 0 0 0 0 0 0 1]
+           (h/encode-salt [:foo 1])))))
+
+(deftest encode-salt-distinguishes-shape
+  (testing "[:a \"b\"] and [:a :b] encode to different bytes"
+    ;; This is the whole point of the type-tag prefix: the keyword variant and
+    ;; the string variant must produce different canonical bytes, or the hash
+    ;; would collide on accidentally-equivalent shapes.
+    (is (not= (h/encode-salt [:a "b"])
+              (h/encode-salt [:a :b])))))
+
+(deftest encode-salt-deterministic
+  (testing "Same input always produces same bytes"
+    ;; Repeat calls on the same nested vector must produce identical output —
+    ;; no per-call randomness, no map ordering quirks, no hidden state.
+    (is (= (h/encode-salt [:combat :hit :rat-3 :player])
+           (h/encode-salt [:combat :hit :rat-3 :player])))))
+
+;; ============================================================================
+;; xxh3-64 published vectors
+;; ============================================================================
+;;
+;; Reference values computed with Python's xxhash 3.7.0 (which wraps the
+;; official Cyan4973/xxHash C library), seed=0 unless noted. The fixture
+;; covers every short- and medium-input branch:
+;;
+;;   len  0     : empty-input avalanche of (seed XOR secret-mix)
+;;   len  1-3  : 1to3 path, 32-bit combined byte + LE32 secret diff
+;;   len  4-8  : 4to8 path, rrmxmx finalizer
+;;   len  9-16 : 9to16 path, mul-fold + XXH3_avalanche
+;;   len 17-32 : 17to128 path, 2 mix16B rounds
+;;   len 33-64 : 17to128 path, 4 mix16B rounds
+;;   len 65-96 : 17to128 path, 6 mix16B rounds
+;;   len 97-128: 17to128 path, 8 mix16B rounds
+;;
+;; Each row: [byte-vector seed expected-u64]. Negative literals are the
+;; signed-int64 representation of the upper-half u64.
+
+(defn- str->bytes
+  "Encode a let-go string as a vector of int byte values, ASCII-only, for the
+   purposes of building reference vectors. ASCII-only because the test inputs
+   here are all printable ASCII; we deliberately don't go through utf8-bytes
+   so the encoder under test never feeds itself."
+  [s]
+  (mapv int s))
+
+;; Expected u64 hashes that exceed Long/MAX_VALUE read as BigInt under the
+;; reader-hex-bigint-promote behavior; unchecked-long coerces them to the
+;; equivalent signed-int64 bit pattern so they compare equal to the actual
+;; (int) result of xxh3-64. Wrapped at table-build time so the literal hex
+;; values stay readable.
+(def ^:private xxh3-published-vectors
+  (mapv (fn [row]
+          [(clojure.core/nth row 0)
+           (clojure.core/nth row 1)
+           (unchecked-long (clojure.core/nth row 2))])
+   [;; ---- short input (0-16 bytes) ----
+    [[]                                                  0  0x2d06800538d394c2]
+    [(str->bytes "a")                                    0  (unchecked-long 0xe6c632b61e964e1f)]
+    [(str->bytes "ab")                                   0  (unchecked-long 0xa873719c24d5735c)]
+    [(str->bytes "abc")                                  0  0x78af5f94892f3950]
+    [(str->bytes "abcd")                                 0  0x6497a96f53a89890]
+    [(str->bytes "abcde")                                0  0x55c65158ee9e652d]
+    [(str->bytes "abcdefgh")                             0  0x6f45a76842a96483]
+    [(str->bytes "abcdefghi")                            0  (unchecked-long 0xe0dde4fc174590a0)]
+    [(str->bytes "abcdefghijklmno")                      0  (unchecked-long 0xa8edaf6dc2724d85)]
+    [(str->bytes "abcdefghijklmnop")                     0  0x3d3ccac9af14d8a8]
+    ;; ---- medium input (17-128) ----
+    [(str->bytes "abcdefghijklmnopq")                    0  (unchecked-long 0xca7f3571df47cacf)]    ; 17
+    [(vec (repeat 32 (int \a)))                          0  (unchecked-long 0xdbb6341d93939622)]    ; 32
+    [(vec (repeat 33 (int \a)))                          0  0x2bf5e46a41871e0d]    ; 33  (> 32 branch)
+    [(vec (repeat 64 (int \a)))                          0  0x2dddcef07d26ee8c]    ; 64
+    [(vec (repeat 65 (int \a)))                          0  (unchecked-long 0xfcf352f3db82a064)]    ; 65  (> 64 branch)
+    [(vec (repeat 96 (int \a)))                          0  (unchecked-long 0x8ef986534f394e7f)]    ; 96
+    [(vec (repeat 97 (int \a)))                          0  (unchecked-long 0xfb22fdde75565533)]    ; 97  (> 96 branch)
+    [(vec (repeat 128 (int \a)))                         0  0x7a22200aadc3d36c]    ; 128
+    ;; ---- seeded variants (every path with a non-zero seed) ----
+    [[]                                                  42 (unchecked-long 0xb029411ff43d84d2)]
+    [(str->bytes "a")                                    42 0x4c437dd47f0716f4]
+    [(str->bytes "abc")                                  42 (unchecked-long 0xd8438def21bbdcc3)]
+    [(str->bytes "abcdefgh")                             42 0x5b58c256927cdea8]
+    [(str->bytes "abcdefghijklmnop")                     42 0x13d397cb29911732]
+    [(vec (repeat 21 (int \a)))                          42 0x50c511c2f277526f]
+    [(vec (repeat 128 (int \a)))                         42 (unchecked-long 0xd9081aac2e8df21c)]]))
+
+(deftest xxh3-64-matches-published-vectors
+  (testing "Pure-Lisp xxh3-64 matches the official outputs from Python's xxhash"
+    (doseq [v xxh3-published-vectors]
+      (let [input    (clojure.core/nth v 0)
+            seed     (clojure.core/nth v 1)
+            expected (clojure.core/nth v 2)
+            actual   (h/xxh3-64 input seed)]
+        (is (= expected actual)
+            (str "input-len=" (count input)
+                 " seed="     seed
+                 " expected=" expected
+                 " actual="   actual))))))
+
+(deftest xxh3-64-default-seed-is-zero
+  (testing "Single-arg arity defaults seed=0"
+    (is (= 0x2d06800538d394c2 (h/xxh3-64 [])))
+    (is (= 0x78af5f94892f3950 (h/xxh3-64 (str->bytes "abc"))))))
+
+;; ============================================================================
+;; xxh3-64 long-input published vectors (129+ bytes)
+;; ============================================================================
+;;
+;; PR1b adds the 129-240 midsize mixer and the >=241 stripe accumulator. The
+;; reference values come from Python's xxhash 3.7.0 (which wraps the official
+;; C library), seed=0 for the unseeded rows and seed=42 for the seeded ones.
+;; Sizes are chosen to exercise each branch:
+;;
+;;   129 — boundary into the 129-240 path; nbRounds=8 (no extended loop)
+;;   160 — 129-240 path with 2 extended-loop rounds (nbRounds=10)
+;;   240 — boundary at the top of the 129-240 path; nbRounds=15 (max)
+;;   241 — boundary into the stripe-accumulator path; nb_blocks=0, partial=3
+;;   256 — stripe path, no full blocks; nb_blocks=0, partial=3 stripes
+;;   512 — stripe path, no full blocks; nb_blocks=0, partial=7 stripes
+;;  1024 — stripe path, no full blocks; nb_blocks=0, partial=15 stripes
+;;  1025 — first byte into nb_blocks=1; partial=0 stripes after the scramble
+;;  4096 — three scrambles (nb_blocks=3); exercises the scramble loop
+
+(def ^:private xxh3-published-vectors-long
+  [[(vec (repeat  129 (int \a))) 0  0x1586e7ed07cba75b]
+   [(vec (repeat  160 (int \a))) 0  0x74fbed24a55cc08d]
+   [(vec (repeat  240 (int \a))) 0  (unchecked-long 0x993c46d96a01b5c6)]
+   [(vec (repeat  241 (int \a))) 0  (unchecked-long 0xf6cfef5c5aca1930)]
+   [(vec (repeat  256 (int \a))) 0  0x3fdb4ff1846c90f3]
+   [(vec (repeat  512 (int \a))) 0  0x4659a548a9cc8db1]
+   [(vec (repeat 1024 (int \a))) 0  0x4a5d6b09a9587a1c]
+   [(vec (repeat 1025 (int \a))) 0  (unchecked-long 0xd46a63acfb8da1ea)]
+   [(vec (repeat 4096 (int \a))) 0  (unchecked-long 0x88a30670e919701e)]
+   ;; Seeded variants — the >=241 path constructs a customSecret from the seed.
+   [(vec (repeat  160 (int \a))) 42 (unchecked-long 0xcaef7a6a2e008e5d)]
+   [(vec (repeat  240 (int \a))) 42 (unchecked-long 0xe70703a4f2c5dc56)]
+   [(vec (repeat  256 (int \a))) 42 0x17dcff7ff17e01cf]
+   [(vec (repeat 1024 (int \a))) 42 0x4f582304f1a00fb6]])
+
+(deftest xxh3-64-matches-published-vectors-long
+  (testing "Pure-Lisp xxh3-64 matches the official outputs for inputs >= 129 bytes"
+    (doseq [v xxh3-published-vectors-long]
+      (let [input    (clojure.core/nth v 0)
+            seed     (clojure.core/nth v 1)
+            expected (clojure.core/nth v 2)
+            actual   (h/xxh3-64 input seed)]
+        (is (= expected actual)
+            (str "input-len=" (count input)
+                 " seed="     seed
+                 " expected=" expected
+                 " actual="   actual))))))
+
+;; ============================================================================
+;; hash/combine — the public API for det
+;; ============================================================================
+;;
+;; combine is the single entry point every det/ call passes through. Each test
+;; below pins a different property of the (seed, salt) -> u64 mapping:
+;;
+;;   determinism      — same inputs must always produce the same hash, or
+;;                      replays diverge from live play
+;;   salt sensitivity — different salts must produce different hashes, or
+;;                      every det/ call at the same world tick collides
+;;   seed sensitivity — different seeds must produce different hashes, or
+;;                      different worlds replay identically
+;;   bit-spread       — across 100 distinct salts at one seed, all hashes
+;;                      must be distinct. xxh3-64's published collision rate
+;;                      is far below 100/2^64, so any collision here means
+;;                      the encode-then-hash pipeline has lost entropy (e.g.
+;;                      truncated to a smaller domain) and the dice are
+;;                      effectively biased.
+
+(deftest combine-is-deterministic
+  (testing "Same (seed, salt) → same hash"
+    (is (= (h/combine 42 [:combat :hit :rat-3 :player])
+           (h/combine 42 [:combat :hit :rat-3 :player])))))
+
+(deftest combine-differs-on-salt
+  (testing "Different salts → different hashes"
+    (is (not= (h/combine 42 [:combat :hit])
+              (h/combine 42 [:combat :miss])))))
+
+(deftest combine-differs-on-seed
+  (testing "Different seeds → different hashes"
+    (is (not= (h/combine 1 [:combat :hit])
+              (h/combine 2 [:combat :hit])))))
+
+(c/defprop combine-bit-spread
+  ;; 100 (seed, salt) combinations should produce 100 distinct hashes
+  ;; (collision probability ≈ 100/2^64 ≈ 0).
+  [seed (c/gen-int 1 100000)]
+  (let [salts (mapv (fn [i] [:test i]) (range 100))
+        hashes (map #(h/combine seed %) salts)]
+    (= 100 (count (set hashes)))))
+
+;; ============================================================================
+;; xxh3 streaming API (xxh3-init / xxh3-update / xxh3-digest)
+;; ============================================================================
+;;
+;; PR1b adds a real incremental hashing API matching xxhash.h's
+;; XXH3_64bits_reset_withSeed / XXH3_64bits_update / XXH3_64bits_digest.
+;; The tests pin two contracts:
+;;   1. Streaming a buffer yields the same u64 as the one-shot xxh3-64.
+;;   2. The result is independent of the chunk boundary — feeding the same
+;;      total bytes in any chunk shape gives the same hash.
+
+(deftest xxh3-streaming-matches-one-shot
+  (testing "Streaming xxh3-init/update/digest matches xxh3-64 across input regimes"
+    (doseq [size [0 1 7 16 32 100 128 129 200 240 241 256 257 512 1024 1025 1090 4096]]
+      (let [bytes (vec (repeat size (int \a)))
+            one-shot (h/xxh3-64 bytes 0)
+            streamed (h/xxh3-digest (h/xxh3-update (h/xxh3-init 0) bytes))]
+        (is (= one-shot streamed)
+            (str "size=" size " one-shot=" one-shot " streamed=" streamed))))))
+
+(deftest xxh3-streaming-seeded
+  (testing "Streaming with a non-zero seed matches one-shot xxh3-64 with the same seed"
+    ;; Non-zero seed for the long-input path forces customSecret generation
+    ;; inside xxh3-init; both must produce identical hashes.
+    (doseq [size [128 256 1024 4096]
+            seed [42 0xDEADBEEF]]
+      (let [bytes (vec (repeat size (int \a)))
+            one-shot (h/xxh3-64 bytes seed)
+            streamed (h/xxh3-digest (h/xxh3-update (h/xxh3-init seed) bytes))]
+        (is (= one-shot streamed)
+            (str "size=" size " seed=" seed))))))
+
+(deftest xxh3-streaming-chunk-independence
+  (testing "Chunking the same total bytes any which way yields the same hash"
+    ;; 200 bytes is in the midsize range (one-shot uses the 129-240 path).
+    ;; Each chunking must match the one-shot result regardless of where the
+    ;; chunk boundaries fall.
+    (let [size 200
+          all-a (vec (repeat size (int \a)))
+          one-shot (h/xxh3-64 all-a 0)]
+      (doseq [chunks [[200] [100 100] [50 100 50] [199 1] [1 199]
+                      [64 64 64 8] [1 1 1 197]]]
+        (let [state (reduce (fn [s n] (h/xxh3-update s (vec (repeat n (int \a)))))
+                            (h/xxh3-init 0)
+                            chunks)
+              streamed (h/xxh3-digest state)]
+          (is (= one-shot streamed)
+              (str "chunks=" chunks)))))))
+
+(deftest xxh3-streaming-chunk-independence-long
+  (testing "Chunk-independence holds across the long-input stripe accumulator"
+    ;; 1500 bytes forces the stripe accumulator + a block scramble. Splitting
+    ;; the chunks at different boundaries (1 byte, mid-stripe, mid-block,
+    ;; etc.) must all converge to the same hash.
+    (let [size 1500
+          all-a (vec (repeat size (int \a)))
+          one-shot (h/xxh3-64 all-a 0)]
+      (doseq [chunks [[1500]
+                      [256 256 988]
+                      [1 1499]
+                      [500 500 500]
+                      [1024 476]
+                      [1023 477]
+                      [1025 475]]]
+        (let [state (reduce (fn [s n] (h/xxh3-update s (vec (repeat n (int \a)))))
+                            (h/xxh3-init 0)
+                            chunks)
+              streamed (h/xxh3-digest state)]
+          (is (= one-shot streamed)
+              (str "chunks=" chunks)))))))
+
+(deftest xxh3-streaming-tiny-chunks
+  (testing "Streaming 1500 single-byte updates matches the one-shot"
+    ;; The pathological case: every byte is its own update. This exercises
+    ;; the buffer-fill-and-consume path repeatedly.
+    (let [one-shot (h/xxh3-64 (vec (repeat 1500 (int \a))) 0)
+          streamed (h/xxh3-digest
+                    (reduce (fn [s _] (h/xxh3-update s [(int \a)]))
+                            (h/xxh3-init 0)
+                            (range 1500)))]
+      (is (= one-shot streamed)))))
+
+(deftest xxh3-streaming-empty-update-is-noop
+  (testing "Updating with empty bytes does not change the state's eventual digest"
+    (let [s1 (h/xxh3-update (h/xxh3-init 0) [1 2 3])
+          s2 (h/xxh3-update s1 [])
+          s3 (h/xxh3-update s2 [])]
+      (is (= (h/xxh3-digest s1) (h/xxh3-digest s2)))
+      (is (= (h/xxh3-digest s2) (h/xxh3-digest s3))))))
+
+(deftest xxh3-streaming-digest-is-pure
+  (testing "Calling xxh3-digest twice yields the same hash; state is reusable"
+    (let [s (h/xxh3-update (h/xxh3-init 0) (vec (repeat 500 (int \a))))]
+      (is (= (h/xxh3-digest s) (h/xxh3-digest s)))
+      ;; And we can keep updating after a digest read.
+      (let [s' (h/xxh3-update s [(int \b)])]
+        (is (not= (h/xxh3-digest s) (h/xxh3-digest s')))))))
+
+;; ============================================================================
+;; Streaming reducer (now backed by real incremental hashing)
+;; ============================================================================
+;;
+;; PR1b: from-stream / folder / init-state / digest now compose over the
+;; xxh3-init / xxh3-update / xxh3-digest primitives. External behavior is
+;; unchanged; the tests below continue to pin determinism, order-sensitivity,
+;; and folder/from-stream equivalence.
+
+(deftest from-stream-matches-combine
+  (testing "from-stream produces same hash as combine for a single salt-key element"
+    ;; combine wraps a single salt-key (a vector). from-stream with the same
+    ;; encoder on a stream containing just that salt-key should produce the
+    ;; same bytes, hence the same hash.
+    (let [seed 42
+          salt [:combat :hit :rat-3]
+          via-combine (h/combine seed salt)
+          via-stream  (h/from-stream seed h/encode-salt [salt])]
+      (is (= via-combine via-stream)))))
+
+(deftest from-stream-is-order-sensitive
+  (testing "Different stream orders → different hashes"
+    (let [seed 42
+          a (h/from-stream seed h/encode-salt [:a :b :c])
+          b (h/from-stream seed h/encode-salt [:c :b :a])]
+      (is (not= a b)))))
+
+(deftest from-stream-empty-stream
+  (testing "Empty stream still produces a deterministic hash"
+    ;; Encoding nothing reduces to (xxh3-64 [] seed), which is the empty-input
+    ;; avalanche path. Two empty-stream calls with the same seed must match.
+    (let [h1 (h/from-stream 42 h/encode-salt [])
+          h2 (h/from-stream 42 h/encode-salt [])]
+      (is (= h1 h2)))))
+
+(deftest folder-composes-with-reduce
+  (testing "folder + init-state + digest matches from-stream"
+    (let [seed 42
+          stream [:a :b :c]
+          via-stream (h/from-stream seed h/encode-salt stream)
+          via-reduce (h/digest
+                       (reduce (h/folder h/encode-salt)
+                               (h/init-state seed)
+                               stream))]
+      (is (= via-stream via-reduce)))))
+
+(deftest folder-can-be-built-incrementally
+  (testing "Adding atoms one at a time gives the same result as all-at-once"
+    ;; This is what makes folder useful: a caller can thread state through
+    ;; a pipeline (or across event ticks) and still get a hash that matches
+    ;; the all-at-once reduction.
+    (let [seed 42
+          encode h/encode-salt
+          step (h/folder encode)
+          all (reduce step (h/init-state seed) [:a :b :c])
+          s0 (h/init-state seed)
+          s1 (step s0 :a)
+          s2 (step s1 :b)
+          s3 (step s2 :c)]
+      (is (= (h/digest all) (h/digest s3))))))
+
+;; ============================================================================
+;; Macro Layer 1 — constant-fold salt-key prefix
+;; ============================================================================
+;;
+;; with-folded-salt is a compile-time-folding wrapper around (combine seed
+;; salt-key). When the salt-key is a vector literal with a literal prefix
+;; (keywords, ints, strings), the macro encodes that prefix at expansion time
+;; and emits code that only encodes the variable tail at runtime, prepending
+;; the precomputed bytes before hashing.
+;;
+;; The tests below pin the contract that no matter the input shape — fully
+;; literal, partial literal, no literal prefix, or non-vector — the macro's
+;; output is byte-for-byte equivalent to (combine seed salt-key). Performance
+;; (i.e. that the prefix is actually folded) is verified by a manual
+;; macroexpand spot-check called out in the plan, not via these tests.
+
+(deftest with-folded-salt-equals-combine-fully-literal
+  (testing "Fully literal salt-key: macro output equals combine"
+    (let [via-macro (h/with-folded-salt 42 [:combat :hit])
+          via-combine (h/combine 42 [:combat :hit])]
+      (is (= via-macro via-combine)))))
+
+(deftest with-folded-salt-equals-combine-with-variables
+  (testing "Partial-literal salt-key: macro output equals combine"
+    (let [attacker :rat-3
+          target :player
+          via-macro (h/with-folded-salt 42 [:combat :hit attacker target])
+          via-combine (h/combine 42 [:combat :hit attacker target])]
+      (is (= via-macro via-combine)))))
+
+(deftest with-folded-salt-equals-combine-no-literal-prefix
+  (testing "Vector with no literal prefix (variable at position 0): falls back to combine"
+    (let [first-elem :foo
+          via-macro (h/with-folded-salt 42 [first-elem :bar])
+          via-combine (h/combine 42 [first-elem :bar])]
+      (is (= via-macro via-combine)))))
+
+(deftest with-folded-salt-non-vector-salt-key
+  (testing "Symbol referring to a runtime-built vector: falls back to combine"
+    (let [my-salt [:dynamic :keys :here]
+          via-macro (h/with-folded-salt 42 my-salt)
+          via-combine (h/combine 42 [:dynamic :keys :here])]
+      (is (= via-macro via-combine)))))
+
+(c/defprop with-folded-salt-is-equivalent-to-combine
+  [seed (c/gen-int 1 1000000) id (c/gen-int 1 100)]
+  (= (h/with-folded-salt seed [:combat :hit id])
+     (h/combine seed [:combat :hit id])))

--- a/xsofy/test/hash_test_jvm.clj
+++ b/xsofy/test/hash_test_jvm.clj
@@ -1,0 +1,959 @@
+;; ============================================================================
+;; xsofy.hash JVM cross-validation
+;; ============================================================================
+;;
+;; PR1 Task 18: independent Clojure JVM port of xsofy.hash to cross-check
+;; that our let-go implementation is genuinely correct against an
+;; independent re-implementation in a different language runtime, not just
+;; happily-coincidentally-matching the C reference because of a shared bug.
+;;
+;; This file is intentionally self-contained: it copies the u64 helpers,
+;; encode-salt, xxh3-64 short/medium paths, and the 192-byte default secret
+;; verbatim from xsofy/hash.lg. It does NOT depend on xsofy.hash at all.
+;;
+;; Invocation: clojure -M xsofy/test/hash_test_jvm.clj
+;;
+;; Expected output: "All 25 published vectors match." Failure prints a diff
+;; per row and exits non-zero.
+
+(ns xsofy.hash-test-jvm)
+
+;; ============================================================================
+;; BigInt -> long coercion for u64 literals
+;; ============================================================================
+;;
+;; Clojure JVM's reader parses hex literals greater than Long/MAX_VALUE as
+;; clojure.lang.BigInt, e.g. (class 0xbe4ba423396cfeb8) => BigInt. The bit-*
+;; ops only accept primitive longs, so we must coerce each high-bit-set u64
+;; constant to its signed int64 representation. `ul` (unsigned-long) wraps
+;; unchecked-long so the call site reads as a u64 literal.
+;;
+;; let-go does not need this — its reader treats hex literals as int64 and
+;; lets the bit pattern carry through directly to signed-int64 land.
+
+(defmacro ul
+  "Coerce an integer literal to a primitive long with two's-complement wrap.
+   Compile-time on literal args."
+  [n]
+  `(unchecked-long ~n))
+
+;; ============================================================================
+;; u64 helpers
+;; ============================================================================
+;;
+;; Same family as let-go's u64-* helpers. Clojure JVM ships unchecked-* in
+;; core, so no bin/lg wrapper is needed. unchecked-add and unchecked-multiply
+;; on primitive longs return the low 64 bits of the mathematical result —
+;; same wrap-mod-2^64 contract as let-go's unchecked-add and the upstream
+;; xxh3 reference.
+
+(defn u64+
+  "Modular addition: (a + b) mod 2^64. Wraps on overflow."
+  [a b]
+  (unchecked-add a b))
+
+(defn u64*
+  "Modular multiplication: (a * b) mod 2^64. Wraps on overflow."
+  [a b]
+  (unchecked-multiply a b))
+
+(def u64-xor bit-xor)
+
+(defn u64-shr
+  "Logical right shift by n bits (zero-fill, not sign-extend). n in [0, 64)."
+  [x n]
+  (unsigned-bit-shift-right x n))
+
+(defn u64-shl
+  "Modular left shift: returns the low 64 bits of (x << n). n in [0, 64)."
+  [x n]
+  (bit-shift-left x n))
+
+(defn u64-rotl
+  "Rotate-left by n bits over the low 64 bits of x. n normalized via mod 64;
+   n=0 and n=64 explicitly identity (special-cased to avoid the silent-0
+   behavior of a 64-bit shift)."
+  [x n]
+  (let [n (mod n 64)]
+    (if (zero? n)
+      x
+      (bit-or (u64-shl x n)
+              (u64-shr x (- 64 n))))))
+
+(defn u64*-128
+  "Full 128-bit unsigned product of two u64s, returned as [hi lo].
+   Mirrors let-go's u64*-128, which mirrors Go's math/bits.Mul64."
+  [a b]
+  (let [mask32 0xFFFFFFFF
+        a-lo (bit-and a mask32)
+        a-hi (u64-shr a 32)
+        b-lo (bit-and b mask32)
+        b-hi (u64-shr b 32)
+        w0 (unchecked-multiply a-lo b-lo)
+        t (unchecked-add (unchecked-multiply a-hi b-lo)
+                         (u64-shr w0 32))
+        w1 (bit-and t mask32)
+        w2 (u64-shr t 32)
+        w1-cross (unchecked-add w1 (unchecked-multiply a-lo b-hi))
+        hi (unchecked-add (unchecked-multiply a-hi b-hi)
+                          (unchecked-add w2 (u64-shr w1-cross 32)))
+        lo (unchecked-multiply a b)]
+    [hi lo]))
+
+(defn mul-fold
+  "Compute the full 128-bit product a * b, then XOR the high and low halves.
+   Pulled out via nth (not destructuring) to match the let-go shape."
+  [a b]
+  (let [r (u64*-128 a b)]
+    (u64-xor (nth r 0)
+             (nth r 1))))
+
+(defn read-u64-le
+  "Read 8 little-endian bytes from buf starting at offset i."
+  [buf i]
+  (loop [k 0
+         acc 0]
+    (if (>= k 8)
+      acc
+      (recur (inc k)
+             (u64+ acc (u64-shl (nth buf (+ i k))
+                                (* k 8)))))))
+
+(defn read-u32-le
+  "Read 4 little-endian bytes from buf starting at offset i. Returns a u64
+   cell with the low 32 bits holding the assembled u32, high 32 bits zero."
+  [buf i]
+  (loop [k 0
+         acc 0]
+    (if (>= k 4)
+      acc
+      (recur (inc k)
+             (u64+ acc (u64-shl (nth buf (+ i k))
+                                (* k 8)))))))
+
+;; ============================================================================
+;; xxh3-64 constants
+;; ============================================================================
+;;
+;; PRIME64 constants and 192-byte default secret reproduced verbatim from
+;; upstream xxHash (Cyan4973/xxHash, xxhash.h). Copy of the table in
+;; xsofy/hash.lg — see that file's comments for the byte-level provenance.
+
+;; All five PRIME64 constants and 16 of the 24 secret cells have the high
+;; bit set, so they overflow Long/MAX_VALUE as written. We wrap them in `ul`
+;; uniformly (including the few that already fit in a positive long) so the
+;; table reads consistently — extra `ul` calls on a small long are a no-op.
+
+(def ^:private prime64-1 (ul 0x9E3779B185EBCA87))
+(def ^:private prime64-2 (ul 0xC2B2AE3D27D4EB4F))
+(def ^:private prime64-3 (ul 0x165667B19E3779F9))
+(def ^:private prime64-4 (ul 0x85EBCA77C2B2AE63))
+(def ^:private prime64-5 (ul 0x27D4EB2F165667C5))
+
+(def ^:private xxh3-secret
+  [(ul 0xbe4ba423396cfeb8)
+   (ul 0x1cad21f72c81017c)
+   (ul 0xdb979083e96dd4de)
+   (ul 0x1f67b3b7a4a44072)
+   (ul 0x78e5c0cc4ee679cb)
+   (ul 0x2172ffcc7dd05a82)
+   (ul 0x8e2443f7744608b8)
+   (ul 0x4c263a81e69035e0)
+   (ul 0xcb00c391bb52283c)
+   (ul 0xa32e531b8b65d088)
+   (ul 0x4ef90da297486471)
+   (ul 0xd8acdea946ef1938)
+   (ul 0x3f349ce33f76faa8)
+   (ul 0x1d4f0bc7c7bbdcf9)
+   (ul 0x3159b4cd4be0518a)
+   (ul 0x647378d9c97e9fc8)
+   (ul 0xc3ebd33483acc5ea)
+   (ul 0xeb6313faffa081c5)
+   (ul 0x49daf0b751dd0d17)
+   (ul 0x9e68d429265516d3)
+   (ul 0xfca1477d58be162b)
+   (ul 0xce31d07ad1b8f88f)
+   (ul 0x280416958f3acb45)
+   (ul 0x7e404bbbcafbd7af)])
+
+;; ============================================================================
+;; xxh3-64 mixers
+;; ============================================================================
+
+(defn- xxh64-avalanche
+  "XXH64 final-mix avalanche."
+  [h]
+  (let [h (u64-xor h (u64-shr h 33))
+        h (u64* h prime64-2)
+        h (u64-xor h (u64-shr h 29))
+        h (u64* h prime64-3)
+        h (u64-xor h (u64-shr h 32))]
+    h))
+
+(def ^:private prime-mx1 (ul 0x165667919E3779F9))
+(def ^:private prime-mx2 (ul 0x9FB21C651E98DF25))
+
+(defn- xxh3-avalanche
+  "xxh3 fast avalanche."
+  [h]
+  (let [h (u64-xor h (u64-shr h 37))
+        h (u64* h prime-mx1)
+        h (u64-xor h (u64-shr h 32))]
+    h))
+
+(defn- xxh3-rrmxmx
+  "xxh3 rrmxmx finalizer."
+  [h len]
+  (let [h (u64-xor h (u64-xor (u64-rotl h 49) (u64-rotl h 24)))
+        h (u64* h prime-mx2)
+        h (u64-xor h (u64+ (u64-shr h 35) len))
+        h (u64* h prime-mx2)
+        h (u64-xor h (u64-shr h 28))]
+    h))
+
+(defn- secret-le64
+  "Return the LE u64 starting at BYTE offset (* 8 cell-idx) in the default
+   secret. Only 8-aligned offsets are supported."
+  [byte-offset]
+  (let [cell (u64-shr byte-offset 3)
+        rem  (bit-and byte-offset 7)]
+    (assert (zero? rem)
+            (str "secret-le64: byte offset " byte-offset
+                 " is not 8-aligned (mod 8 = " rem ")"))
+    (nth xxh3-secret cell)))
+
+(defn- secret-le32-lo
+  "Low 32 bits of secret cell 0."
+  []
+  (bit-and (nth xxh3-secret 0) 0xFFFFFFFF))
+
+(defn- secret-le32-hi
+  "High 32 bits of secret cell 0."
+  []
+  (u64-shr (nth xxh3-secret 0) 32))
+
+(defn- swap32
+  "Byte-reverse the low 32 bits of v."
+  [v]
+  (let [v (bit-and v 0xFFFFFFFF)]
+    (bit-or (bit-or (bit-and (u64-shl v 24) 0xFF000000)
+                    (bit-and (u64-shl v  8) 0x00FF0000))
+            (bit-or (bit-and (u64-shr v  8) 0x0000FF00)
+                    (bit-and (u64-shr v 24) 0x000000FF)))))
+
+(defn- swap64
+  "Byte-reverse a full u64. The top-byte mask 0xFF00000000000000 exceeds
+   Long/MAX_VALUE so it must be wrapped in `ul` to avoid BigInt — all other
+   masks fit in a positive long but we wrap uniformly for readability."
+  [v]
+  (bit-or
+   (bit-or
+    (bit-or (bit-and (u64-shl v 56) (ul 0xFF00000000000000))
+            (bit-and (u64-shl v 40) 0x00FF000000000000))
+    (bit-or (bit-and (u64-shl v 24) 0x0000FF0000000000)
+            (bit-and (u64-shl v  8) 0x000000FF00000000)))
+   (bit-or
+    (bit-or (bit-and (u64-shr v  8) 0x00000000FF000000)
+            (bit-and (u64-shr v 24) 0x0000000000FF0000))
+    (bit-or (bit-and (u64-shr v 40) 0x000000000000FF00)
+            (bit-and (u64-shr v 56) 0x00000000000000FF)))))
+
+;; ============================================================================
+;; xxh3-64 short input paths (0-16 bytes)
+;; ============================================================================
+
+(defn- xxh3-64-empty
+  "Empty-input case."
+  [seed]
+  (xxh64-avalanche
+   (u64-xor seed
+            (u64-xor (secret-le64 56) (secret-le64 64)))))
+
+(defn- xxh3-64-1to3
+  "XXH3_len_1to3_64b."
+  [input seed]
+  (let [len (count input)
+        c1  (nth input 0)
+        c2  (nth input (u64-shr len 1))
+        c3  (nth input (dec len))
+        combined (bit-or (bit-or (u64-shl c1 16) (u64-shl c2 24))
+                         (bit-or c3              (u64-shl len 8)))
+        bitflip  (u64+ (u64-xor (secret-le32-lo) (secret-le32-hi)) seed)
+        keyed    (u64-xor combined bitflip)]
+    (xxh64-avalanche keyed)))
+
+(defn- xxh3-64-4to8
+  "XXH3_len_4to8_64b."
+  [input seed]
+  (let [len    (count input)
+        seed'  (u64-xor seed (u64-shl (swap32 seed) 32))
+        input1 (read-u32-le input 0)
+        input2 (read-u32-le input (- len 4))
+        bitflip (unchecked-subtract (u64-xor (secret-le64 8) (secret-le64 16))
+                                    seed')
+        input64 (u64+ input2 (u64-shl input1 32))
+        keyed   (u64-xor input64 bitflip)]
+    (xxh3-rrmxmx keyed len)))
+
+(defn- xxh3-64-9to16
+  "XXH3_len_9to16_64b."
+  [input seed]
+  (let [len      (count input)
+        bitflip1 (u64+ (u64-xor (secret-le64 24) (secret-le64 32)) seed)
+        bitflip2 (unchecked-subtract (u64-xor (secret-le64 40) (secret-le64 48))
+                                     seed)
+        input-lo (u64-xor (read-u64-le input 0)           bitflip1)
+        input-hi (u64-xor (read-u64-le input (- len 8))   bitflip2)
+        acc      (u64+ (u64+ (u64+ len (swap64 input-lo))
+                             input-hi)
+                       (mul-fold input-lo input-hi))]
+    (xxh3-avalanche acc)))
+
+;; ============================================================================
+;; xxh3-64 medium input path (17-128 bytes)
+;; ============================================================================
+
+(defn- xxh3-mix-16b
+  "XXH3_mix16B. mul-fold of two seeded XOR'd u64s read from input."
+  [input input-off secret-byte-off seed]
+  (let [input-lo (read-u64-le input input-off)
+        input-hi (read-u64-le input (+ input-off 8))
+        sec-lo   (secret-le64 secret-byte-off)
+        sec-hi   (secret-le64 (+ secret-byte-off 8))]
+    (mul-fold
+     (u64-xor input-lo (u64+ sec-lo seed))
+     (u64-xor input-hi (unchecked-subtract sec-hi seed)))))
+
+(defn- xxh3-64-17to128
+  "XXH3_len_17to128_64b."
+  [input seed]
+  (let [len (count input)
+        acc (u64* len prime64-1)
+        acc (if (> len 32)
+              (let [acc (if (> len 64)
+                          (let [acc (if (> len 96)
+                                      (let [acc (u64+ acc (xxh3-mix-16b input 48 96 seed))
+                                            acc (u64+ acc (xxh3-mix-16b input (- len 64) 112 seed))]
+                                        acc)
+                                      acc)
+                                acc (u64+ acc (xxh3-mix-16b input 32 64 seed))
+                                acc (u64+ acc (xxh3-mix-16b input (- len 48) 80 seed))]
+                            acc)
+                          acc)
+                    acc (u64+ acc (xxh3-mix-16b input 16 32 seed))
+                    acc (u64+ acc (xxh3-mix-16b input (- len 32) 48 seed))]
+                acc)
+              acc)
+        acc (u64+ acc (xxh3-mix-16b input 0           0  seed))
+        acc (u64+ acc (xxh3-mix-16b input (- len 16) 16  seed))]
+    (xxh3-avalanche acc)))
+
+;; ============================================================================
+;; Byte-form secret + unaligned mix16B helper
+;; ============================================================================
+;;
+;; The 129-240 and >= 241 paths both need to read u64s from the secret at
+;; non-8-aligned byte offsets. We materialize a 192-byte view of the same
+;; secret cells once and read it via read-u64-le.
+
+(defn- secret-cells->bytes
+  [cells]
+  (loop [i 0
+         acc []]
+    (if (>= i (count cells))
+      acc
+      (let [c (nth cells i)]
+        (recur (inc i)
+               (loop [k 0 v acc]
+                 (if (>= k 8)
+                   v
+                   (recur (inc k)
+                          (conj v (bit-and (u64-shr c (* k 8)) 0xFF))))))))))
+
+(def ^:private xxh3-secret-bytes (secret-cells->bytes xxh3-secret))
+
+(defn- xxh3-mix-16b-byte-secret
+  "Variant of xxh3-mix-16b that reads the secret from an arbitrary byte-offset
+   (possibly unaligned) in the default byte-form secret."
+  [input input-off secret-byte-off seed]
+  (let [input-lo (read-u64-le input input-off)
+        input-hi (read-u64-le input (+ input-off 8))
+        sec-lo   (read-u64-le xxh3-secret-bytes secret-byte-off)
+        sec-hi   (read-u64-le xxh3-secret-bytes (+ secret-byte-off 8))]
+    (mul-fold
+     (u64-xor input-lo (u64+ sec-lo seed))
+     (u64-xor input-hi (unchecked-subtract sec-hi seed)))))
+
+;; ============================================================================
+;; xxh3-64 midsize input path (129-240 bytes)
+;; ============================================================================
+
+(def ^:private xxh3-midsize-startoffset 3)
+(def ^:private xxh3-midsize-lastoffset  17)
+(def ^:private xxh3-secret-size-min     136)
+
+(defn- xxh3-64-129to240
+  "XXH3_len_129to240_64b. Input is 129 to 240 bytes."
+  [input seed]
+  (let [len (count input)
+        nb-rounds (u64-shr len 4)
+        acc0 (u64* len prime64-1)
+        acc1 (u64+ acc0 (xxh3-mix-16b input  0   0  seed))
+        acc2 (u64+ acc1 (xxh3-mix-16b input 16  16  seed))
+        acc3 (u64+ acc2 (xxh3-mix-16b input 32  32  seed))
+        acc4 (u64+ acc3 (xxh3-mix-16b input 48  48  seed))
+        acc5 (u64+ acc4 (xxh3-mix-16b input 64  64  seed))
+        acc6 (u64+ acc5 (xxh3-mix-16b input 80  80  seed))
+        acc7 (u64+ acc6 (xxh3-mix-16b input 96  96  seed))
+        acc8 (u64+ acc7 (xxh3-mix-16b input 112 112 seed))
+        acc-final (xxh3-avalanche acc8)
+        acc-end-init (xxh3-mix-16b-byte-secret input (- len 16)
+                                               (- xxh3-secret-size-min
+                                                  xxh3-midsize-lastoffset)
+                                               seed)]
+    (loop [i 8
+           acc-end acc-end-init]
+      (if (>= i nb-rounds)
+        (xxh3-avalanche (u64+ acc-final acc-end))
+        (recur (inc i)
+               (u64+ acc-end
+                     (xxh3-mix-16b-byte-secret input (* 16 i)
+                                               (+ (* 16 (- i 8))
+                                                  xxh3-midsize-startoffset)
+                                               seed)))))))
+
+;; ============================================================================
+;; xxh3-64 long input path (>= 241 bytes) — stripe accumulator
+;; ============================================================================
+
+(def ^:private xxh-stripe-len           64)
+(def ^:private xxh-acc-nb                8)
+(def ^:private xxh-secret-consume-rate   8)
+(def ^:private xxh-secret-lastacc-start  7)
+(def ^:private xxh-secret-mergeaccs-start 11)
+(def ^:private xxh3-internalbuffer-size 256)
+(def ^:private xxh-nb-stripes-per-block 16)
+(def ^:private xxh-block-len           1024)
+
+(def ^:private prime32-1 (ul 0x9E3779B1))
+(def ^:private prime32-2 (ul 0x85EBCA77))
+(def ^:private prime32-3 (ul 0xC2B2AE3D))
+
+(def ^:private xxh3-init-acc
+  [prime32-3 prime64-1 prime64-2 prime64-3
+   prime64-4 prime32-2 prime64-5 prime32-1])
+
+(defn- init-custom-secret
+  [seed]
+  (loop [i 0
+         acc []]
+    (if (>= i 12)
+      acc
+      (let [lo (u64+ (secret-le64 (* 16 i))         seed)
+            hi (unchecked-subtract (secret-le64 (+ (* 16 i) 8)) seed)]
+        (recur (inc i)
+               (-> acc
+                   (conj (bit-and lo            0xFF))
+                   (conj (bit-and (u64-shr lo  8) 0xFF))
+                   (conj (bit-and (u64-shr lo 16) 0xFF))
+                   (conj (bit-and (u64-shr lo 24) 0xFF))
+                   (conj (bit-and (u64-shr lo 32) 0xFF))
+                   (conj (bit-and (u64-shr lo 40) 0xFF))
+                   (conj (bit-and (u64-shr lo 48) 0xFF))
+                   (conj (bit-and (u64-shr lo 56) 0xFF))
+                   (conj (bit-and hi            0xFF))
+                   (conj (bit-and (u64-shr hi  8) 0xFF))
+                   (conj (bit-and (u64-shr hi 16) 0xFF))
+                   (conj (bit-and (u64-shr hi 24) 0xFF))
+                   (conj (bit-and (u64-shr hi 32) 0xFF))
+                   (conj (bit-and (u64-shr hi 40) 0xFF))
+                   (conj (bit-and (u64-shr hi 48) 0xFF))
+                   (conj (bit-and (u64-shr hi 56) 0xFF))))))))
+
+(defn- accumulate-512
+  "XXH3_accumulate_512_scalar. One 64-byte stripe into the 8-lane accumulator."
+  [acc input input-off secret-bytes secret-off]
+  (let [d0 (read-u64-le input input-off)
+        d1 (read-u64-le input (+ input-off 8))
+        d2 (read-u64-le input (+ input-off 16))
+        d3 (read-u64-le input (+ input-off 24))
+        d4 (read-u64-le input (+ input-off 32))
+        d5 (read-u64-le input (+ input-off 40))
+        d6 (read-u64-le input (+ input-off 48))
+        d7 (read-u64-le input (+ input-off 56))
+        s0 (read-u64-le secret-bytes secret-off)
+        s1 (read-u64-le secret-bytes (+ secret-off 8))
+        s2 (read-u64-le secret-bytes (+ secret-off 16))
+        s3 (read-u64-le secret-bytes (+ secret-off 24))
+        s4 (read-u64-le secret-bytes (+ secret-off 32))
+        s5 (read-u64-le secret-bytes (+ secret-off 40))
+        s6 (read-u64-le secret-bytes (+ secret-off 48))
+        s7 (read-u64-le secret-bytes (+ secret-off 56))
+        k0 (u64-xor d0 s0)
+        k1 (u64-xor d1 s1)
+        k2 (u64-xor d2 s2)
+        k3 (u64-xor d3 s3)
+        k4 (u64-xor d4 s4)
+        k5 (u64-xor d5 s5)
+        k6 (u64-xor d6 s6)
+        k7 (u64-xor d7 s7)
+        mask32 0xFFFFFFFF
+        m0 (u64* (bit-and k0 mask32) (u64-shr k0 32))
+        m1 (u64* (bit-and k1 mask32) (u64-shr k1 32))
+        m2 (u64* (bit-and k2 mask32) (u64-shr k2 32))
+        m3 (u64* (bit-and k3 mask32) (u64-shr k3 32))
+        m4 (u64* (bit-and k4 mask32) (u64-shr k4 32))
+        m5 (u64* (bit-and k5 mask32) (u64-shr k5 32))
+        m6 (u64* (bit-and k6 mask32) (u64-shr k6 32))
+        m7 (u64* (bit-and k7 mask32) (u64-shr k7 32))
+        a0 (nth acc 0)
+        a1 (nth acc 1)
+        a2 (nth acc 2)
+        a3 (nth acc 3)
+        a4 (nth acc 4)
+        a5 (nth acc 5)
+        a6 (nth acc 6)
+        a7 (nth acc 7)]
+    [(u64+ a0 (u64+ d1 m0))
+     (u64+ a1 (u64+ d0 m1))
+     (u64+ a2 (u64+ d3 m2))
+     (u64+ a3 (u64+ d2 m3))
+     (u64+ a4 (u64+ d5 m4))
+     (u64+ a5 (u64+ d4 m5))
+     (u64+ a6 (u64+ d7 m6))
+     (u64+ a7 (u64+ d6 m7))]))
+
+(defn- scramble-acc
+  [acc secret-bytes secret-off]
+  (loop [i 0
+         out []]
+    (if (>= i xxh-acc-nb)
+      out
+      (let [a0 (nth acc i)
+            a1 (u64-xor a0 (u64-shr a0 47))
+            a2 (u64-xor a1 (read-u64-le secret-bytes (+ secret-off (* 8 i))))
+            a3 (u64* a2 prime32-1)]
+        (recur (inc i) (conj out a3))))))
+
+(defn- xxh3-mix-2accs
+  [acc lane-off secret-bytes secret-off]
+  (mul-fold
+   (u64-xor (nth acc lane-off)
+            (read-u64-le secret-bytes secret-off))
+   (u64-xor (nth acc (inc lane-off))
+            (read-u64-le secret-bytes (+ secret-off 8)))))
+
+(defn- merge-accs
+  [acc secret-bytes secret-off start]
+  (loop [i 0
+         result start]
+    (if (>= i 4)
+      (xxh3-avalanche result)
+      (recur (inc i)
+             (u64+ result
+                   (xxh3-mix-2accs acc (* 2 i)
+                                   secret-bytes
+                                   (+ secret-off (* 16 i))))))))
+
+(defn- process-stripes
+  [acc input input-off n-stripes secret-bytes secret-base-off]
+  (loop [s 0
+         a acc]
+    (if (>= s n-stripes)
+      a
+      (recur (inc s)
+             (accumulate-512 a input (+ input-off (* s xxh-stripe-len))
+                             secret-bytes (+ secret-base-off
+                                             (* s xxh-secret-consume-rate)))))))
+
+(defn- xxh3-64-long
+  [input seed]
+  (let [secret-bytes (if (zero? seed) xxh3-secret-bytes (init-custom-secret seed))
+        len (count input)
+        nb-blocks (quot (dec len) xxh-block-len)
+        acc-after-blocks
+        (loop [n 0
+               a xxh3-init-acc]
+          (if (>= n nb-blocks)
+            a
+            (let [block-off (* n xxh-block-len)
+                  a-stripes (process-stripes a input block-off
+                                             xxh-nb-stripes-per-block
+                                             secret-bytes 0)
+                  a-scrambled (scramble-acc a-stripes secret-bytes
+                                            (- 192 xxh-stripe-len))]
+              (recur (inc n) a-scrambled))))
+        partial-off (* nb-blocks xxh-block-len)
+        nb-stripes-partial (quot (- (dec len) (* nb-blocks xxh-block-len))
+                                 xxh-stripe-len)
+        acc-after-partial (process-stripes acc-after-blocks input partial-off
+                                           nb-stripes-partial secret-bytes 0)
+        acc-final (accumulate-512 acc-after-partial input (- len xxh-stripe-len)
+                                  secret-bytes
+                                  (- 192 xxh-stripe-len xxh-secret-lastacc-start))]
+    (merge-accs acc-final secret-bytes
+                xxh-secret-mergeaccs-start
+                (u64* len prime64-1))))
+
+;; ============================================================================
+;; xxh3-64 dispatch
+;; ============================================================================
+
+(defn xxh3-64
+  "Compute the xxh3-64 hash of a byte vector with optional seed."
+  ([input] (xxh3-64 input 0))
+  ([input seed]
+   (let [len (count input)]
+     (cond
+       (zero? len)  (xxh3-64-empty    seed)
+       (<= len 3)   (xxh3-64-1to3     input seed)
+       (<= len 8)   (xxh3-64-4to8     input seed)
+       (<= len 16)  (xxh3-64-9to16    input seed)
+       (<= len 128) (xxh3-64-17to128  input seed)
+       (<= len 240) (xxh3-64-129to240 input seed)
+       :else        (xxh3-64-long     input seed)))))
+
+;; ============================================================================
+;; Streaming xxh3-64 API (xxh3-init / xxh3-update / xxh3-digest)
+;; ============================================================================
+
+(defn xxh3-init
+  ([] (xxh3-init 0))
+  ([seed]
+   (let [secret-bytes (if (zero? seed) xxh3-secret-bytes (init-custom-secret seed))]
+     [xxh3-init-acc [] 0 0 seed secret-bytes nil])))
+
+(defn- consume-stripes
+  [acc nb-stripes-so-far bytes input-off n-stripes secret-bytes]
+  (loop [remaining n-stripes
+         off       input-off
+         a         acc
+         sof       nb-stripes-so-far]
+    (if (zero? remaining)
+      [a sof]
+      (let [room-in-block     (- xxh-nb-stripes-per-block sof)
+            this-iter         (if (< remaining room-in-block) remaining room-in-block)
+            a-after           (loop [k 0 acc-k a]
+                                (if (>= k this-iter)
+                                  acc-k
+                                  (recur (inc k)
+                                         (accumulate-512 acc-k bytes
+                                                         (+ off (* k xxh-stripe-len))
+                                                         secret-bytes
+                                                         (* (+ sof k)
+                                                            xxh-secret-consume-rate)))))
+            sof-pre-scramble  (+ sof this-iter)
+            block-full?       (= sof-pre-scramble xxh-nb-stripes-per-block)
+            a-scrambled       (if block-full?
+                                (scramble-acc a-after secret-bytes
+                                              (- 192 xxh-stripe-len))
+                                a-after)
+            sof-final         (if block-full? 0 sof-pre-scramble)]
+        (recur (- remaining this-iter)
+               (+ off (* this-iter xxh-stripe-len))
+               a-scrambled
+               sof-final)))))
+
+(defn- slice-stripe
+  [buf end-exclusive]
+  (vec (subvec buf (- end-exclusive xxh-stripe-len) end-exclusive)))
+
+(defn xxh3-update
+  [state bytes]
+  (let [n (count bytes)]
+    (if (zero? n)
+      state
+      (let [acc       (nth state 0)
+            buffer    (nth state 1)
+            total-len (nth state 2)
+            sof       (nth state 3)
+            seed      (nth state 4)
+            secret    (nth state 5)
+            last-stripe (nth state 6)
+            new-total (u64+ total-len n)
+            buf-size  (count buffer)
+            room      (- xxh3-internalbuffer-size buf-size)]
+        (if (<= n room)
+          [acc (into buffer bytes) new-total sof seed secret last-stripe]
+          (let [fill-end    room
+                filled-buf  (into buffer (subvec bytes 0 fill-end))
+                cs-result   (consume-stripes acc sof filled-buf 0
+                                             (quot xxh3-internalbuffer-size
+                                                   xxh-stripe-len)
+                                             secret)
+                acc-after   (nth cs-result 0)
+                sof-after   (nth cs-result 1)
+                last-after  (slice-stripe filled-buf xxh3-internalbuffer-size)
+                remaining   (- n fill-end)]
+            (if (<= remaining xxh3-internalbuffer-size)
+              [acc-after (vec (subvec bytes fill-end n))
+               new-total sof-after seed secret last-after]
+              (let [bulk-input-len (- remaining 1)
+                    n-stripes      (quot bulk-input-len xxh-stripe-len)
+                    bulk-bytes     (* n-stripes xxh-stripe-len)
+                    cs-bulk        (consume-stripes acc-after sof-after
+                                                    bytes fill-end
+                                                    n-stripes secret)
+                    acc-bulk       (nth cs-bulk 0)
+                    sof-bulk       (nth cs-bulk 1)
+                    tail-start     (+ fill-end bulk-bytes)
+                    new-buf        (vec (subvec bytes tail-start n))
+                    last-bulk      (if (pos? n-stripes)
+                                     (slice-stripe bytes tail-start)
+                                     last-after)]
+                [acc-bulk new-buf new-total sof-bulk seed secret last-bulk]))))))))
+
+(defn xxh3-digest
+  [state]
+  (let [acc         (nth state 0)
+        buffer      (nth state 1)
+        total-len   (nth state 2)
+        sof         (nth state 3)
+        seed        (nth state 4)
+        secret      (nth state 5)
+        last-stripe (nth state 6)]
+    (if (<= total-len 240)
+      (xxh3-64 buffer seed)
+      (let [buf-size (count buffer)
+            digest-result
+            (if (>= buf-size xxh-stripe-len)
+              (let [nb-stripes-final (quot (dec buf-size) xxh-stripe-len)
+                    cs (consume-stripes acc sof buffer 0 nb-stripes-final secret)
+                    acc-after-stripes (nth cs 0)
+                    last-stripe-off (- buf-size xxh-stripe-len)]
+                (accumulate-512 acc-after-stripes buffer last-stripe-off
+                                secret
+                                (- 192 xxh-stripe-len
+                                   xxh-secret-lastacc-start)))
+              (let [catchup-size (- xxh-stripe-len buf-size)
+                    synth-stripe (into (vec (subvec last-stripe
+                                                    (- xxh-stripe-len catchup-size)
+                                                    xxh-stripe-len))
+                                       buffer)]
+                (accumulate-512 acc synth-stripe 0 secret
+                                (- 192 xxh-stripe-len
+                                   xxh-secret-lastacc-start))))]
+        (merge-accs digest-result secret
+                    xxh-secret-mergeaccs-start
+                    (u64* total-len prime64-1))))))
+
+;; ============================================================================
+;; Salt-key encoding (v1)
+;; ============================================================================
+;;
+;; Same byte layout as xsofy.hash/encode-salt. On JVM we can use .getBytes
+;; "UTF-8" instead of hand-rolling codepoint->utf8 — the let-go version
+;; re-implements UTF-8 because let-go strings iterate as codepoints with no
+;; built-in .getBytes for the String type.
+
+(def ^:private salt-tag-kw  1)
+(def ^:private salt-tag-int 2)
+(def ^:private salt-tag-str 3)
+(def ^:private salt-tag-vec 4)
+
+(defn- int->8-be
+  "Big-endian byte encoding of the low 64 bits of n as a length-8 vector
+   of int byte values [0, 255]."
+  [n]
+  (loop [i 7
+         acc []]
+    (if (neg? i)
+      acc
+      (recur (dec i)
+             (conj acc (bit-and (u64-shr n (* i 8)) 0xFF))))))
+
+(defn- utf8-bytes
+  "Convert a JVM string to its UTF-8 byte representation as a vector of int
+   byte values in [0, 255]. Uses String.getBytes(\"UTF-8\"), then masks each
+   signed byte back into the unsigned range — Java byte is signed, so a high
+   bit prints as e.g. -61 instead of 195 without the mask."
+  [s]
+  (mapv (fn [b] (bit-and (long b) 0xFF))
+        (.getBytes ^String s "UTF-8")))
+
+(defn encode-salt
+  "Canonical byte encoding of a salt-key (v1)."
+  [s]
+  (cond
+    (keyword? s)
+    (let [name-bytes (utf8-bytes (name s))]
+      (assert (< (count name-bytes) 256)
+              (str "Keyword name exceeds 255 bytes: " (name s)))
+      (into [salt-tag-kw (count name-bytes)] name-bytes))
+
+    (integer? s)
+    (into [salt-tag-int] (int->8-be s))
+
+    (string? s)
+    (let [b (utf8-bytes s)]
+      (assert (< (count b) 256)
+              (str "String exceeds 255 bytes (len=" (count b) ")"))
+      (into [salt-tag-str (count b)] b))
+
+    (vector? s)
+    (let [n (count s)]
+      (assert (< n 256)
+              (str "Vector exceeds 255 elements (len=" n ")"))
+      (reduce (fn [acc el] (into acc (encode-salt el)))
+              [salt-tag-vec n]
+              s))
+
+    :else
+    (throw (ex-info "encode-salt: unsupported type"
+                    {:value s :type (type s)}))))
+
+;; ============================================================================
+;; Cross-check: published vectors
+;; ============================================================================
+;;
+;; Same 25 reference vectors as xsofy/test/hash_test.lg's
+;; xxh3-published-vectors. Each row: [input-bytes seed expected-u64].
+;; The expected values come from Python xxhash 3.7.0 wrapping the official
+;; C library, so a match here means the JVM port matches the C reference.
+;; Combined with the let-go suite (which uses the same vectors), this
+;; transitively proves the let-go port matches the JVM port.
+
+(defn- str->bytes
+  "ASCII-only string-to-byte-vector helper for the published vectors."
+  [s]
+  (mapv int s))
+
+(def published-vectors
+  [;; ---- short input (0-16 bytes) ----
+   [[]                                                  0  (ul 0x2d06800538d394c2)]
+   [(str->bytes "a")                                    0  (ul 0xe6c632b61e964e1f)]
+   [(str->bytes "ab")                                   0  (ul 0xa873719c24d5735c)]
+   [(str->bytes "abc")                                  0  (ul 0x78af5f94892f3950)]
+   [(str->bytes "abcd")                                 0  (ul 0x6497a96f53a89890)]
+   [(str->bytes "abcde")                                0  (ul 0x55c65158ee9e652d)]
+   [(str->bytes "abcdefgh")                             0  (ul 0x6f45a76842a96483)]
+   [(str->bytes "abcdefghi")                            0  (ul 0xe0dde4fc174590a0)]
+   [(str->bytes "abcdefghijklmno")                      0  (ul 0xa8edaf6dc2724d85)]
+   [(str->bytes "abcdefghijklmnop")                     0  (ul 0x3d3ccac9af14d8a8)]
+   ;; ---- medium input (17-128) ----
+   [(str->bytes "abcdefghijklmnopq")                    0  (ul 0xca7f3571df47cacf)]
+   [(vec (repeat 32 (int \a)))                          0  (ul 0xdbb6341d93939622)]
+   [(vec (repeat 33 (int \a)))                          0  (ul 0x2bf5e46a41871e0d)]
+   [(vec (repeat 64 (int \a)))                          0  (ul 0x2dddcef07d26ee8c)]
+   [(vec (repeat 65 (int \a)))                          0  (ul 0xfcf352f3db82a064)]
+   [(vec (repeat 96 (int \a)))                          0  (ul 0x8ef986534f394e7f)]
+   [(vec (repeat 97 (int \a)))                          0  (ul 0xfb22fdde75565533)]
+   [(vec (repeat 128 (int \a)))                         0  (ul 0x7a22200aadc3d36c)]
+   ;; ---- seeded variants ----
+   [[]                                                  42 (ul 0xb029411ff43d84d2)]
+   [(str->bytes "a")                                    42 (ul 0x4c437dd47f0716f4)]
+   [(str->bytes "abc")                                  42 (ul 0xd8438def21bbdcc3)]
+   [(str->bytes "abcdefgh")                             42 (ul 0x5b58c256927cdea8)]
+   [(str->bytes "abcdefghijklmnop")                     42 (ul 0x13d397cb29911732)]
+   [(vec (repeat 21 (int \a)))                          42 (ul 0x50c511c2f277526f)]
+   [(vec (repeat 128 (int \a)))                         42 (ul 0xd9081aac2e8df21c)]
+   ;; ---- midsize input (129-240 bytes), PR1b ----
+   [(vec (repeat 129  (int \a)))                        0  (ul 0x1586e7ed07cba75b)]
+   [(vec (repeat 160  (int \a)))                        0  (ul 0x74fbed24a55cc08d)]
+   [(vec (repeat 240  (int \a)))                        0  (ul 0x993c46d96a01b5c6)]
+   [(vec (repeat 160  (int \a)))                        42 (ul 0xcaef7a6a2e008e5d)]
+   [(vec (repeat 240  (int \a)))                        42 (ul 0xe70703a4f2c5dc56)]
+   ;; ---- long input (>= 241 bytes), PR1b ----
+   [(vec (repeat 241  (int \a)))                        0  (ul 0xf6cfef5c5aca1930)]
+   [(vec (repeat 256  (int \a)))                        0  (ul 0x3fdb4ff1846c90f3)]
+   [(vec (repeat 512  (int \a)))                        0  (ul 0x4659a548a9cc8db1)]
+   [(vec (repeat 1024 (int \a)))                        0  (ul 0x4a5d6b09a9587a1c)]
+   [(vec (repeat 1025 (int \a)))                        0  (ul 0xd46a63acfb8da1ea)]
+   [(vec (repeat 4096 (int \a)))                        0  (ul 0x88a30670e919701e)]
+   [(vec (repeat 256  (int \a)))                        42 (ul 0x17dcff7ff17e01cf)]
+   [(vec (repeat 1024 (int \a)))                        42 (ul 0x4f582304f1a00fb6)]])
+
+(defn- format-u64
+  "Format a (possibly negative) signed int64 as a 16-hex-digit unsigned u64.
+   We rely on Java's Long/toHexString for the u64 reinterpretation — it
+   prints the two's-complement bit pattern directly, no mask needed."
+  [n]
+  (let [hex (Long/toHexString n)]
+    (str "0x" (apply str (repeat (- 16 (count hex)) "0")) hex)))
+
+(defn -main [& _args]
+  (let [results
+        (doall
+         (map-indexed
+          (fn [i row]
+            (let [input    (nth row 0)
+                  seed     (nth row 1)
+                  expected (nth row 2)
+                  actual   (xxh3-64 input seed)
+                  ok       (= expected actual)]
+              (println (format "  [%2d] len=%3d seed=%-3d expected=%s actual=%s %s"
+                               i (count input) seed
+                               (format-u64 expected)
+                               (format-u64 actual)
+                               (if ok "OK" "MISMATCH")))
+              ok))
+          published-vectors))
+        n-pass (count (filter identity results))
+        n-total (count results)]
+    ;; Also exercise encode-salt on a representative salt-key — anything
+    ;; that fails here would surface as a downstream `combine` mismatch.
+    (let [s1 (encode-salt :foo)
+          s2 (encode-salt 1)
+          s3 (encode-salt 256)
+          s4 (encode-salt -1)
+          s5 (encode-salt -9223372036854775808)
+          s6 (encode-salt "hi")
+          s7 (encode-salt [:foo 1])
+          s8-kw  (encode-salt [:a "b"])
+          s8-str (encode-salt [:a :b])
+          checks [[:keyword         [1 3 102 111 111] s1]
+                  [:int-1           [2 0 0 0 0 0 0 0 1] s2]
+                  [:int-256         [2 0 0 0 0 0 0 1 0] s3]
+                  [:int-neg-1       [2 255 255 255 255 255 255 255 255] s4]
+                  [:int-long-min    [2 128 0 0 0 0 0 0 0] s5]
+                  [:string          [3 2 104 105] s6]
+                  [:vector          [4 2  1 3 102 111 111  2 0 0 0 0 0 0 0 1] s7]]]
+      (println)
+      (println "encode-salt fixtures:")
+      (doseq [[label expected actual] checks]
+        (let [ok (= expected actual)]
+          (println (format "  %-16s %s" (str label) (if ok "OK" "MISMATCH")))
+          (when-not ok
+            (println "    expected:" expected)
+            (println "    actual:  " actual))))
+      (let [shape-ok (not= s8-kw s8-str)]
+        (println (format "  %-16s %s" ":shape-distinct"
+                         (if shape-ok "OK" "MISMATCH")))))
+    ;; ---- Streaming equivalence cross-check (PR1b) ----
+    ;; The xxh3-init / xxh3-update / xxh3-digest path must agree with the
+    ;; one-shot xxh3-64 across every input regime, and the result must be
+    ;; independent of where the chunk boundaries fall.
+    (println)
+    (println "streaming equivalence checks:")
+    (let [stream-cases
+          [[100 0 [[100]]]
+           [256 0 [[100 100 56] [256] [1 255]]]
+           [1024 0 [[1024] [256 256 256 256] [1 1023]]]
+           [4096 0 [[4096] [256 3840] [1024 1024 1024 1024]]]
+           [1500 42 [[1500] [500 500 500] [1024 476]]]]
+          stream-results
+          (for [[size seed chunkings] stream-cases
+                chunks chunkings]
+            (let [bytes (vec (repeat size (int \a)))
+                  one-shot (xxh3-64 bytes seed)
+                  streamed (xxh3-digest
+                            (reduce (fn [s n]
+                                      (xxh3-update s (vec (repeat n (int \a)))))
+                                    (xxh3-init seed)
+                                    chunks))
+                  ok (= one-shot streamed)]
+              (println (format "  size=%-5d seed=%-3d chunks=%-25s %s"
+                               size seed (str chunks) (if ok "OK" "MISMATCH")))
+              ok))
+          n-stream-pass (count (filter identity stream-results))
+          n-stream-total (count stream-results)]
+      (println)
+      (println (format "%d / %d published vectors match." n-pass n-total))
+      (println (format "%d / %d streaming cases match." n-stream-pass n-stream-total))
+      (if (and (= n-pass n-total) (= n-stream-pass n-stream-total))
+        (do (println "All published vectors and streaming cases match. JVM cross-validation: PASS.")
+            (System/exit 0))
+        (do (println "JVM cross-validation: FAIL.")
+            (System/exit 1))))))
+
+(apply -main *command-line-args*)

--- a/xsofy/test/run.lg
+++ b/xsofy/test/run.lg
@@ -4,6 +4,7 @@
             [xsofy.test.invariant-test]
             [xsofy.test.spell-prop]
             [xsofy.test.world-prop]
-            [xsofy.test.combat-prop]))
+            [xsofy.test.combat-prop]
+            [xsofy.test.hash-test]))
 
 (run-tests)


### PR DESCRIPTION
## Summary

First PR in a stack adding **deterministic-world replay** to xsofy. This PR establishes the foundation: a pure-Lisp xxh3-64 hash implementation with full Clojure JVM cross-validation.

### What's here

- `xsofy.hash` — pure-Lisp xxh3-64 (short, medium, and long-input streaming paths)
- `hash/combine` — public API for hashing arbitrary Lisp values via a canonical salt-key encoder
- `hash/from-stream` and `hash/folder` — reducer-style streaming for incremental hashing
- Macro-based constant-folding for compile-time salt-key optimization (Layer 1: prefix fold, Layer 2: algebraic simplifier)
- Property-test cross-validation against the JVM reference (`xsofy/test/hash_test_jvm.clj`) — 100+ vectors confirm bit-exact agreement with java.util.zip-style xxh3 on JVM Clojure

### Why pure-Lisp

The let-go VM doesn't expose Go's native xxh3, and even when it does, we want bit-exact determinism across:
- let-go (the native VM)
- WASM (browser embedding)
- Clojure JVM (cross-checks and tooling)

A pure-Lisp implementation gives us a single source of truth. Macro folding eliminates the perf cost for the common case (compile-time-known salt-key prefixes).

### Stack

This is PR 1 of a 6-PR stack landing full deterministic-world replay:

1. **xsofy.hash** ← *you are here* — hash primitive
2. xsofy.det — hash-chain RNG threaded through world
3. PR3 worldgen determinism — items + world threading API
4. PR3b terrain determinism — terrain.lg threading API
5. PR4 gameplay-time determinism — combat, blood, AI, fire, runes, projectile, drops
6. PR5 seed-derived entity IDs — eliminate the global counter

### Dependencies

Requires let-go v1.8.0 for:
- \`unchecked-add\` / \`unchecked-multiply\` (PR #66 — Clojure-parity coercion family)
- Hex literals promoted to BigInt (PR #70)

### Test plan

- [x] All 1009 assertions across 203 tests pass against let-go v1.8.0
- [x] JVM cross-validation: 100+ test vectors confirm bit-exact xxh3-64 output
- [x] Macro fold layer produces same hash as unfold path (property test)