### PR TITLE
tools: fix patch_wasm_coi splice on bundles with UTF-8 source

### DIFF
--- a/tools/patch_wasm_coi.lg
+++ b/tools/patch_wasm_coi.lg
@@ -91,14 +91,21 @@
            (nth end-parts 1)))))
 
 (defn replace-exact [s needle replacement]
-  (let [idx (str/index-of s needle)]
-    (if (nil? idx)
-      (if (str/includes? s replacement)
-        s
-        (abort! "missing main-thread entry guard"))
-      (str (subs s 0 idx)
-           replacement
-           (subs s (+ idx (count needle)))))))
+  ;; Use str/split + cardinality validation rather than (subs + index-of
+  ;; arithmetic): string/index-of returns a byte offset while subs is
+  ;; rune-indexed, so mixing them in (+ idx (count needle)) skews the
+  ;; slice point whenever the input has UTF-8 multibyte characters before
+  ;; the match. The generated WASM HTML contains non-ASCII in its inline
+  ;; template comments (em dashes etc.), so the old splice could land
+  ;; mid-content. This pattern mirrors replace-range above: split on the
+  ;; needle, require exactly one match, fail closed on duplicates.
+  (let [parts (vec (str/split s needle))]
+    (cond
+      (= 2 (count parts))  (str (nth parts 0) replacement (nth parts 1))
+      (= 1 (count parts))  (if (str/includes? s replacement)
+                             s    ;; already patched — idempotent re-run
+                             (abort! "missing main-thread entry guard"))
+      :else                (abort! "main-thread entry guard appears more than once"))))
 
 (let [html (slurp index-path)
       html (replace-range html coi-start-marker wasm-marker coi-block)


### PR DESCRIPTION

`replace-exact` in `tools/patch_wasm_coi.lg` passes a byte offset returned by `string/index-of` into the rune-indexed `subs`. The values agree for ASCII-only input but diverge as soon as the generated HTML has UTF-8 multibyte content before the entry-point guard, and the splice lands at the wrong rune boundary.

### Reproducer

```clojure
(let [s "ᚠabc"
      i (string/index-of s "a")]
  [(count s) i
   (str (subs s 0 i) "X" (subs s (+ i (count "a"))))])
;; => [4 3 "ᚠabX"]
;; Expected: "ᚠXbc"
```

`string/index-of` calls Go's `strings.Index` (byte offset) while `count` walks `[]rune`. `(+ idx (count needle))` therefore mixes units and the second `subs` call cuts at a rune index derived from a byte position.

### Where this trips in the patcher

The generated WASM HTML contains em dashes (`—`) in inline template comments before `startMainThreadMode` (visible in `wasm.go` at `v1.8.0`+). That's enough non-ASCII to skew the offset by a few runes, and the patcher splices the entry-after guard mid-`startMainThreadMode`, producing JS like:

```
} else {
  await startMa    } else if (!window.__lgCoiPending) {
```

The bundle parses as broken JavaScript; the page stays on its `loading...` status.

### Fix

Switch `replace-exact` to the same split-and-validate pattern `replace-range` directly above already uses:

```clojure
(defn replace-exact [s needle replacement]
  (let [parts (vec (str/split s needle))]
    (cond
      (= 2 (count parts))  (str (nth parts 0) replacement (nth parts 1))
      (= 1 (count parts))  (if (str/includes? s replacement)
                             s    ;; already patched — idempotent re-run
                             (abort! "missing main-thread entry guard"))
      :else                (abort! "main-thread entry guard appears more than once"))))
```

No offset arithmetic; fails closed if the guard ever appears more than once; preserves the prior idempotent-on-already-patched-input property.

### Note on root cause

This is a defensive fix in the patcher. The underlying let-go primitive mismatch (`string/index-of` byte-indexed vs `subs`/`count` rune-indexed) is a let-go concern best discussed separately — filed as [let-go issue #88](https://github.com/nooga/let-go/issues/88).

### Verification

- Repro above produces the broken slice on let-go `v1.8.0`+
- Running the patched `replace-exact` against a freshly-built `dist/index.html` produces clean output: the entry-after guard appears between `startWorkerMode();` and `} catch(err) {`, no truncated function names.
- `(str/includes? html "__lgCoiPending")` and `(str/includes? html "const WASM_EXEC_JS")` post-checks both pass (existing assertions at the bottom of the patcher).

