### PR TITLE
render: dirty path now respects z-order on stacked entities (#30)

### DIFF
--- a/xsofy/render.lg
+++ b/xsofy/render.lg
@@ -133,6 +133,15 @@
               gas (when visible (get gases [x y]))]
           (render-map-tile r x y tile visible remembered lv stain gas))))))
 
+(defn entity-z-priority
+  "Z-order weight for entities sharing a cell — higher wins.
+   Player > creature > item. Mirrors render-map-entities' draw order."
+  [e]
+  (cond
+    (= :player (:id e))         3
+    (= :item (:entity-type e))  1
+    :else                       2))
+
 (defn render-entity [world r entity]
   (when-let [pos (:pos entity)]
     (let [{:keys [fov]} world
@@ -380,6 +389,23 @@
                     [])]
         (recur (rest events) (core/into dirty cells))))))
 
+(defn dirty-cell-entities
+  "Return {pos -> entity} for entities on dirty cells. When multiple
+   entities share a cell, the highest entity-z-priority wins
+   (nooga/xsofy#30)."
+  [entities dirty]
+  (core/reduce (fn [m [_ e]]
+                 (if (and (:pos e) (contains? dirty (:pos e)))
+                   (let [pos (:pos e)
+                         prev (get m pos)]
+                     (if (or (nil? prev)
+                             (< (entity-z-priority prev)
+                                (entity-z-priority e)))
+                       (assoc m pos e)
+                       m))
+                   m))
+               {} entities))
+
 (defn restore-dirty-cells!
   "Redraw only the given cells (map tile + any entity on them)."
   [world r dirty]
@@ -387,13 +413,7 @@
         lights (or (:lights world) [])
         stains (or (:stains world) {})
         gases (or (:gases world) {})
-        ents (:entities world)
-        ;; build pos->entity lookup for dirty cells only
-        pos-ent (core/reduce (fn [m [k e]]
-                               (if (and (:pos e) (contains? dirty (:pos e)))
-                                 (assoc m (:pos e) e)
-                                 m))
-                             {} ents)]
+        pos-ent (dirty-cell-entities (:entities world) dirty)]
     (doseq [[x y] dirty]
       (when (and (>= x 0) (< x (:w r)) (>= y 0) (< y (:h r)))
         (let [visible (contains? fov [x y])

--- a/xsofy/test/render_test.lg
+++ b/xsofy/test/render_test.lg
@@ -27,3 +27,47 @@
       (is (= [] (:entries window)))
       (is (= 0 (:count window)))
       (is (= 0 (:max-scroll window))))))
+
+;; nooga/xsofy#30 — stacked entities on a dirty cell.
+
+(deftest entity-z-priority-ranks-player-over-creature-over-item
+  (let [player  {:id :player :pos [1 1]}
+        monster {:id :goblin-1 :pos [1 1]}
+        item    {:id :sword-3 :entity-type :item :pos [1 1]}]
+    (is (> (render/entity-z-priority player) (render/entity-z-priority monster)))
+    (is (> (render/entity-z-priority monster) (render/entity-z-priority item)))))
+
+(deftest dirty-cell-entities-keeps-monster-when-item-iterates-last
+  ;; Vec of pairs forces deterministic order; item-last is the unhappy case.
+  (let [monster {:id :goblin-1 :pos [5 5]}
+        item    {:id :sword-3 :entity-type :item :pos [5 5]}
+        result  (render/dirty-cell-entities [[:goblin-1 monster]
+                                             [:sword-3 item]]
+                                            #{[5 5]})]
+    (is (= :goblin-1 (:id (get result [5 5]))))))
+
+(deftest dirty-cell-entities-keeps-monster-when-item-iterates-first
+  (let [monster {:id :goblin-1 :pos [5 5]}
+        item    {:id :sword-3 :entity-type :item :pos [5 5]}
+        result  (render/dirty-cell-entities [[:sword-3 item]
+                                             [:goblin-1 monster]]
+                                            #{[5 5]})]
+    (is (= :goblin-1 (:id (get result [5 5]))))))
+
+(deftest dirty-cell-entities-keeps-player-over-monster-and-item
+  (let [player  {:id :player :pos [5 5]}
+        monster {:id :goblin-1 :pos [5 5]}
+        item    {:id :sword-3 :entity-type :item :pos [5 5]}
+        result  (render/dirty-cell-entities [[:sword-3 item]
+                                             [:goblin-1 monster]
+                                             [:player player]]
+                                            #{[5 5]})]
+    (is (= :player (:id (get result [5 5]))))))
+
+(deftest dirty-cell-entities-skips-entities-outside-dirty-set
+  (let [item-a {:id :gold-1 :entity-type :item :pos [1 1]}
+        item-b {:id :gold-2 :entity-type :item :pos [5 5]}
+        result (render/dirty-cell-entities [[:gold-1 item-a] [:gold-2 item-b]]
+                                           #{[5 5]})]
+    (is (nil? (get result [1 1])))
+    (is (= :gold-2 (:id (get result [5 5]))))))


### PR DESCRIPTION
Closes #30.

## Bug

When a monster and item share a cell, `restore-dirty-cells!` (in `xsofy.render`) can render the item glyph on top of the monster on the next dirty redraw. The player attacks, the monster doesn't die, but the cell shows the item — they think they killed it.

## Root cause

`restore-dirty-cells!` built its pos→entity lookup via:

    (core/reduce (fn [m [_ e]] (assoc m (:pos e) e)) {} entities)

For multiple entities at the same `:pos`, `assoc` overwrites — and the winner depends on hash-map iteration order. In let-go's current small-map iteration this usually happens to favor monsters (items typically go into `:entities` at level-gen first, monsters second), so the bug is rare to trigger naturally. The reporter caught a real edge case.

`render-full`'s `render-map-entities` already does the right thing (items → creatures → player); only the dirty path was order-dependent.

## Fix

- Add `entity-z-priority` (player > creature > item — mirrors `render-map-entities`' draw order).
- Extract the pos→entity build as `dirty-cell-entities`, priority-aware.
- `restore-dirty-cells!` calls the helper.

## Tests

5 new assertions in `xsofy/test/render_test.lg`:

- `entity-z-priority-ranks-player-over-creature-over-item`
- `dirty-cell-entities-keeps-monster-when-item-iterates-last` — the unhappy ordering; this is the regression-catching test
- `dirty-cell-entities-keeps-monster-when-item-iterates-first` — happy ordering still works (guards against coincidence)
- `dirty-cell-entities-keeps-player-over-monster-and-item` — three-way stack
- `dirty-cell-entities-skips-entities-outside-dirty-set` — restricts to dirty set

Verified the unhappy-order test catches the bug: temporarily reverting `dirty-cell-entities` to last-wins makes exactly that test fail.

```
Finished running tests. Tests: 167 Pass: 319 Fail: 0 Error: 0
```

## Deterministic repro

To see the bug deterministically before pulling this PR, save as `tools/repro_issue_30.lg` and run `lg tools/repro_issue_30.lg`:

<details><summary>repro script (95 lines)</summary>

```clojure
;; tools/repro_issue_30.lg
;;
;; Deterministic reproduction of nooga/xsofy#30 — monster + item on
;; same cell, item hides monster.
;;
;; The pre-fix reduce in xsofy.render/restore-dirty-cells! relied on
;; hash-map iteration order to pick which entity to render. In practice
;; let-go's small-map iteration tends to favor monsters (level-gen
;; inserts items first, monsters after — and small maps iterate roughly
;; in insertion order), so the bug rarely triggers naturally. To
;; reproduce it deterministically, drive the same reduce shape with a
;; vector of [id entity] pairs in the unhappy order (item last).
;;
;; The post-fix reduce uses xsofy.render/entity-z-priority to keep the
;; highest-priority entity (player > creature > item), independent of
;; iteration order.
;;
;; Run: lg tools/repro_issue_30.lg
;;
;; Exit code: 0 if buggy-vs-fixed differ as expected; 1 otherwise.

(require '[xsofy.render :as render])

(def cell [5 5])

(def goblin
  {:id :goblin-1
   :pos cell
   :visual {:glyph "g" :color [200 60 60]}})

(def sword
  {:id :sword-3
   :entity-type :item
   :pos cell
   :visual {:glyph "|" :color [200 200 60]}})

;; Item appears LAST in the iteration — the order that triggers the bug.
;; Vector of pairs guarantees the iteration is deterministic regardless
;; of hash-map internals.
(def entities-pairs [[:goblin-1 goblin] [:sword-3 sword]])

(defn buggy-pick
  "Pre-fix reduce: last-wins by iteration order."
  [pairs cell]
  (let [m (reduce (fn [m [_ e]]
                    (if (= cell (:pos e))
                      (assoc m (:pos e) e)
                      m))
                  {} pairs)]
    (get m cell)))

(defn fixed-pick
  "Post-fix reduce: priority-aware via render/entity-z-priority."
  [pairs cell]
  (let [m (reduce (fn [m [_ e]]
                    (if (= cell (:pos e))
                      (let [prev (get m cell)]
                        (if (or (nil? prev)
                                (< (render/entity-z-priority prev)
                                   (render/entity-z-priority e)))
                          (assoc m cell e)
                          m))
                      m))
                  {} pairs)]
    (get m cell)))

(defn describe [e]
  (str (:id e)
       " glyph=" (get-in e [:visual :glyph])
       (if (= :item (:entity-type e)) " (item)" " (monster)")))

(let [buggy (buggy-pick entities-pairs cell)
      fixed (fixed-pick entities-pairs cell)
      ok    (and (= :item (:entity-type buggy))
                 (not= :item (:entity-type fixed)))]
  (println "=== nooga/xsofy#30 repro ===")
  (println)
  (println (str "Cell " cell " occupants (insertion order):"))
  (doseq [[id e] entities-pairs]
    (println (str "  " (describe e))))
  (println)
  (println (str "BUGGY  reduce picks: " (describe buggy)
                (if (= :item (:entity-type buggy))
                  "  <- item masks monster (#30)"
                  "  <- monster correctly visible")))
  (println (str "FIXED  reduce picks: " (describe fixed)
                (if (= :item (:entity-type fixed))
                  "  <- item STILL wins (regression!)"
                  "  <- monster correctly visible")))
  (println)
  (if ok
    (do (println "Fix confirmed: buggy reduce hides the monster; priority-aware reduce keeps it visible.")
        (os/exit 0))
    (do (println "Repro did not trigger as expected — investigate.")
        (os/exit 1))))
```

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)