### PR TITLE
world: bump-attack creatures on hazard tiles (#28)

### DIFF
--- a/xsofy/test/world_prop.lg
+++ b/xsofy/test/world_prop.lg
@@ -86,6 +86,28 @@
 ;; Targeted regression tests (from property-discovered failures)
 ;; ============================================================================
 
+(deftest melee-attack-hits-creature-on-hazard-tile
+  (testing "nooga/xsofy#28 — wraith on a chasm should be melee-able with
+            bare hands instead of opening the leap-into-void prompt."
+    (let [base (g/minimal-stone-room)
+          _ (terrain/tset! (:terrain base) (:width base) 3 2 6)  ;; chasm
+          world (-> base
+                    (assoc-in [:entities :player]
+                      {:id :player :template :player :pos [2 2]
+                       :ticks 0 :status {} :statuses {} :inventory []
+                       :body {:hp 30 :max-hp 30 :strength 5 :armor 0}})
+                    (assoc-in [:entities :wraith-1]
+                      {:id :wraith-1 :template :wraith :pos [3 2]
+                       :ticks 0 :status {} :statuses {}
+                       :body {:hp 5 :max-hp 5 :strength 1 :armor 0}}))
+          w' (w/update-world world :right)]
+      ;; Attack and hazard-prompt branches are mutually exclusive: prompt
+      ;; freezes the turn pending y/n, attack ticks it. Hit/miss is RNG
+      ;; so we don't assert wraith HP.
+      (is (not= :confirm-hazard (:screen w')))
+      (is (< (:turn world) (:turn w')))
+      (is (= [2 2] (get-in w' [:entities :player :pos]))))))
+
 (deftest burning-low-hp-player-with-expiring-status-doesnt-resurrect
   (testing "Player dies from burning AND has a status about to expire on same tick.
             The remove-status of the expired one must not resurrect a dead player."

--- a/xsofy/world.lg
+++ b/xsofy/world.lg
@@ -1264,9 +1264,14 @@
               update-fov
               (log-msg "You open the door.")))
 
-      ;; walkable (or reach weapon can attack through walls)
+      ;; walkable, reach weapon, or a non-player creature on the
+      ;; destination cell — bumping a creature on a hazard tile (e.g.
+      ;; wraith over chasm) should attack, not open the leap prompt
+      ;; (nooga/xsofy#28).
       (or (terrain/walkable? terrain width height nx ny)
-          (= :reach (combat/get-attack-pattern world :player)))
+          (= :reach (combat/get-attack-pattern world :player))
+          (let [c (ent/creature-at world [nx ny])]
+            (and c (not= :player (:id c)))))
       (let [pattern (combat/get-attack-pattern world :player)
             wep (ent/get-weapon world :player)
             bump-target (ent/creature-at world [nx ny])


### PR DESCRIPTION
Closes #28.

## Bug

When a hostile creature stands on a hazard tile (e.g. a wraith floating over a chasm) and the player tries to bump-attack it, the leap-into-void prompt opens instead of an attack. Switching to a whip (`:reach` weapon) reaches the creature from the safe cell.

## Root cause

`player-move` in `xsofy/world.lg` has a `cond` that dispatches the destination tile to: closed-door | attack-or-walk | hazard | wall. The gate into the attack-or-walk branch was:

    (or (terrain/walkable? terrain width height nx ny)
        (= :reach (combat/get-attack-pattern world :player)))

For any non-walkable tile (void, lava, deep water) and a non-reach weapon, the gate failed, the cond fell through to the hazard branch, and `:screen` was set to `:confirm-hazard` — even when the destination cell held a hostile creature.

## Fix

Widen the gate so the attack branch also fires when there's a non-player creature on the destination cell. The existing target-resolution and attack pipeline runs regardless of tile walkability; only the gate needed updating.

```clojure
(or (terrain/walkable? terrain width height nx ny)
    (= :reach (combat/get-attack-pattern world :player))
    (let [c (ent/creature-at world [nx ny])]
      (and c (not= :player (:id c)))))
```

Hazard branch still fires when the destination is empty hazard terrain — no regression for the leap-into-void / dive / step-into-flames flows.

## Tests

`xsofy/test/world_prop.lg` adds `melee-attack-hits-creature-on-hazard-tile`: constructs a player at `[2 2]` next to a wraith at `[3 2]` on a chasm, calls `(update-world :right)`, asserts `:screen` is not `:confirm-hazard` and the turn advanced.

Verified deterministic regression coverage by temporarily reverting the gate to its pre-fix form — exactly this test's two relevant assertions fail (the third, player-position-unchanged, passes in both, defensive).

The three hazard tiles (chasm, lava, deep water) share the gate's code path and don't differentiate downstream; one fixture covers them.

```
Finished running tests. Tests: 163 Pass: 315 Fail: 0 Error: 0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)