### PR TITLE
world: rebase creature ticks on floor restore (#19)

### DIFF
--- a/xsofy/test/world_prop.lg
+++ b/xsofy/test/world_prop.lg
@@ -143,3 +143,46 @@
           restored (w/restore-floor saved 1 player items)]
       (is (= 4 (get-in saved [:floors 1 :fire-ttl [2 2]])))
       (is (= 4 (get-in restored [:fire-ttl [2 2]]))))))
+
+(deftest floor-restore-rebases-creature-ticks
+  (testing "nooga/xsofy#19 — change-floor resets player :ticks to 0 on
+            revisit, but creature :ticks come back from the saved
+            floor as-was. Without a rebase the player got many free
+            turns before next-actor would pick any creature. Items
+            (no :ai, nil :ticks) must not pin the min at 0 and skip
+            the rebase."
+    (let [world (-> (g/minimal-stone-room)
+                    (assoc :depth 1 :floors {} :turn 0 :log [])
+                    (assoc-in [:entities :player]
+                      {:id :player :template :player :pos [1 1]
+                       :ticks 0
+                       :body {:hp 30 :max-hp 30 :strength 2}
+                       :inventory []})
+                    (assoc-in [:entities :slime-1]
+                      {:id :slime-1 :template :slime :pos [4 4]
+                       :ticks 5000
+                       :ai {:state :hunt :speed 1 :behavior :hunter}
+                       :body {:hp 5 :max-hp 5}})
+                    (assoc-in [:entities :imp-1]
+                      {:id :imp-1 :template :fire-imp :pos [5 5]
+                       :ticks 5200
+                       :ai {:state :hunt :speed 1 :behavior :ranged}
+                       :body {:hp 8 :max-hp 8}})
+                    ;; Pre-fix: this item's nil :ticks made the rebase no-op.
+                    (assoc-in [:entities :sword-1]
+                      {:id :sword-1 :template :sword :pos [3 3]
+                       :entity-type :item}))
+          saved (w/save-current-floor world)
+          [player items] (w/extract-player-items saved)
+          ;; Mimic change-floor's player-ticks reset on revisit.
+          player (assoc player :ticks 0)
+          restored (w/restore-floor saved 1 player items)
+          slime-ticks (get-in restored [:entities :slime-1 :ticks])
+          imp-ticks   (get-in restored [:entities :imp-1 :ticks])]
+      ;; After rebase: lowest creature lands on 0 (= player), the gap
+      ;; between creatures (200) is preserved, and the player is no
+      ;; longer dozens of next-actor wins ahead.
+      (is (= 0 slime-ticks))
+      (is (= 200 imp-ticks))
+      ;; Item is untouched — no :ticks key materialized.
+      (is (nil? (get-in restored [:entities :sword-1 :ticks]))))))

--- a/xsofy/world.lg
+++ b/xsofy/world.lg
@@ -239,6 +239,35 @@
               (assoc-in w [:entities id] (assoc item :pos nil)))
             w items)))
 
+(defn rebase-creature-ticks [world]
+  "Shift every :ai-bearing entity's :ticks down so the lowest sits at 0
+   (= the player's post-restore :ticks). change-floor resets the
+   player to 0 on floor revisit, but creature :ticks come back from
+   the saved floor with whatever they had at exit — leaving the player
+   many ticks ahead in the next-actor scheduler and getting a long run
+   of free turns before any monster acts (nooga/xsofy#19). Only
+   entities with :ai participate; items have nil :ticks and would
+   otherwise pin the min at 0 and short-circuit the rebase."
+  (let [es (:entities world)
+        m (reduce (fn [acc [id e]]
+                    (if (or (= :player id) (nil? (:ai e)))
+                      acc
+                      (let [t (or (:ticks e) 0)]
+                        (if (or (nil? acc) (< t acc)) t acc))))
+                  nil
+                  (seq es))]
+    (if (or (nil? m) (<= m 0))
+      world
+      (update world :entities
+              (fn [es]
+                (reduce (fn [acc [id e]]
+                          (assoc acc id
+                                 (if (or (= :player id) (nil? (:ai e)))
+                                   e
+                                   (assoc e :ticks (- (or (:ticks e) 0) m)))))
+                        {}
+                        (seq es)))))))
+
 (defn restore-floor [world depth player items]
   "Restore a saved floor, placing player at stairs."
   (let [floor (get-in world [:floors depth])
@@ -265,7 +294,8 @@
          :floors (:floors world)
          :scheme (:scheme world)
          :running true}
-        (inject-player player items nil))))
+        (inject-player player items nil)
+        rebase-creature-ticks)))
 
 ;; --- Message Log ---
 


### PR DESCRIPTION
Closes #19.

## Bug

After descending to another floor and returning to a previously-visited one, monsters on the restored floor don't move for a stretch of player turns even when standing right next to the player. The player can attack adjacent creatures and they won't fight back. Eventually they "wake up" and behave normally. Reporter (`simon1tan1`) described running from a fire-imp, coming back, and finding the slimes and the imp standing still while attacked.

Reproduced naturally: descend → kill some time on floor 2 → ascend → wait 25 turns → descend → monsters that were chasing on floor 1 still react on the very next turn (post-fix). Pre-fix, you get ~25 free turns before any creature acts.

## Root cause

`change-floor` in `xsofy/world.lg` resets the player's `:ticks` to `0` on every floor change:

    player (assoc player :ticks 0)

For a newly-generated floor this is fine — spawned creatures also start at `:ticks 0`, so everyone is aligned. For a restored floor, `restore-floor` lays the saved `:entities` map back down with whatever `:ticks` each creature had when the player left. So now the player sits at `0` and the creatures sit at whatever the player's `:ticks` was at exit time (let's call it `T`).

`next-actor` picks the entity with the lowest `:ticks`. The player wins for the next `T / move-cost` turns — `move-cost` is 100, so a floor you spent 25 turns on gives you ~25 free actions on return before any monster gets a slot.

## Fix

A `rebase-creature-ticks` pass at the end of `restore-floor`. For every entity with `:ai`, subtract the lowest creature `:ticks` so the fastest creature on the floor lands at `0`, matching the just-reset player. Relative ordering between creatures is preserved (so a creature that was about to act when you left still acts first on return).

The `:ai` filter matters: a first attempt that walked every non-player entity treated items' nil `:ticks` as `0`, which pinned the min at `0` and silently skipped the rebase. A floor with even one dropped item would have re-triggered the bug. The regression test below explicitly stages an item to lock this case down.

## Tests

`xsofy/test/world_prop.lg` adds `floor-restore-rebases-creature-ticks`:
- Player at `[1 1]`, two creatures with `:ticks` 5000 and 5200, a sword (`:entity-type :item`, no `:ticks`).
- Round-trips through `save-current-floor` → `extract-player-items` → `restore-floor` with the player's `:ticks` re-zeroed (mirroring `change-floor`).
- Asserts the fastest creature lands at `0`, the slower one preserves the 200-tick gap, and the sword's `:ticks` key never materializes.

```
Finished running tests. Tests: 169 Pass: 325 Fail: 0 Error: 0
```

## Deterministic repro

To see the bug deterministically before pulling this PR, save as `tools/repro_issue_19.lg` and run `let-go tools/repro_issue_19.lg`. Drives just `next-actor` + `add-ticks` on a synthetic entity map with the player, two creatures, and a sword (the item presence is what tripped the early implementation up).

<details><summary>repro script</summary>

```clojure
;; tools/repro_issue_19.lg
;;
;; Hypothesis for nooga/xsofy#19 ("monsters don't move"):
;;
;; xsofy.world/change-floor resets player :ticks to 0 when restoring a
;; previously-visited floor, but creature :ticks are restored as-saved.
;; The scheduler in xsofy.world/next-actor picks the entity with the
;; lowest :ticks. So after a revisit, the player is many ticks ahead of
;; every creature and gets a long run of consecutive turns before any
;; monster acts — which looks exactly like "monsters don't move", and
;; explains why the player can attack a slime several times without it
;; fighting back.
;;
;; This script doesn't touch terrain or AI — it exercises only the
;; scheduler (next-actor + add-ticks) on a synthetic entity map.
;;
;; Run: lg tools/repro_issue_19.lg
;;
;; Exit code: 0 if the desync reproduces, 1 if it doesn't.

(ns tools.repro-issue-19
  (:require [xsofy.world :as w]))

(def move-cost w/move-cost)  ;; 100

(defn make-world [player-ticks creature-ticks]
  ;; Includes an :item entity (no :ai, nil :ticks). Earlier versions of
  ;; rebase-creature-ticks reduced over every non-player entity and
  ;; treated nil :ticks as 0, so any floor with a single dropped item
  ;; pinned the min at 0 and silently no-op'd the rebase. The fix is
  ;; gated on :ai presence; the item should NOT influence the min.
  {:entities {:player  {:id :player
                        :template :player
                        :pos [5 5]
                        :ticks player-ticks
                        :body {:hp 30 :max-hp 30}}
              :slime-1 {:id :slime-1
                        :template :slime
                        :pos [6 5]
                        :ticks creature-ticks
                        :ai {:state :hunt :speed 1 :behavior :hunter}
                        :body {:hp 5 :max-hp 5}}
              :imp-1   {:id :imp-1
                        :template :fire-imp
                        :pos [7 5]
                        :ticks creature-ticks
                        :ai {:state :hunt :speed 1 :behavior :ranged}
                        :body {:hp 8 :max-hp 8}}
              :sword-1 {:id :sword-1
                        :template :sword
                        :pos [4 5]
                        :entity-type :item}}})

(defn count-player-free-turns
  "Drive the scheduler by ticking whoever next-actor selects. Returns
   the number of consecutive :player picks before any creature gets one."
  [world]
  (loop [w world
         n 0
         safety 200]
    (if (<= safety 0)
      n
      (let [actor (w/next-actor w)]
        (cond
          (nil? actor) n
          (not= :player actor) n
          :else (recur (w/add-ticks w :player move-cost)
                       (inc n)
                       (dec safety)))))))

(def aligned  (make-world 0 0))
(def desynced (make-world 0 5000))  ;; player just stepped back onto a floor
                                    ;; where it had spent ~50 turns last visit
(def rebased  (w/rebase-creature-ticks desynced))  ;; post-fix world

(let [aligned-free  (count-player-free-turns aligned)
      desynced-free (count-player-free-turns desynced)
      rebased-free  (count-player-free-turns rebased)
      bug-present  (and (<= aligned-free 1)
                        (>= desynced-free 49))
      fix-works    (<= rebased-free 1)]
  (println "=== nooga/xsofy#19: floor-restore tick desync ===")
  (println)
  (println "Aligned ticks  (player=0, creatures=0):")
  (println (str "  player free turns before any creature acts: " aligned-free))
  (println)
  (println "Desynced ticks (player=0, creatures=5000 — raw restore):")
  (println (str "  player free turns before any creature acts: " desynced-free))
  (println)
  (println "Rebased ticks  (post-fix: rebase-creature-ticks applied):")
  (println (str "  player free turns before any creature acts: " rebased-free))
  (println)
  (cond
    (not bug-present)
    (do (println "Repro did not trigger — investigate.")
        (os/exit 1))
    (not fix-works)
    (do (println "Fix did not close the gap — investigate.")
        (os/exit 1))
    :else
    (do (println "Bug reproduces (raw restore: " desynced-free " free turns) and the fix")
        (println "brings the count back to " rebased-free " — same as a fresh, aligned floor.")
        (os/exit 0))))
```

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)