### PR TITLE
Cancel auto-action on queued keystroke (#16)

### DIFF
--- a/main.lg
+++ b/main.lg
@@ -481,17 +481,23 @@
 
          ;; default: game screen
          (let [;; determine auto-action or wait for input
-               auto-key (cond
-                          (:resting world) :wait
-                          (:running-dir world) (let [[dx dy] (:running-dir world)]
-                                                 (cond (and (= dx 0) (< dy 0)) :up
-                                                       (and (= dx 0) (> dy 0)) :down
-                                                       (and (< dx 0) (= dy 0)) :left
-                                                       (and (> dx 0) (= dy 0)) :right
-                                                       :else nil))
-                          (:autoexploring world) :autoexplore
-                          (:auto-target world) :auto-target-step
-                          :else nil)
+               auto-key0 (cond
+                           (:resting world) :wait
+                           (:running-dir world) (let [[dx dy] (:running-dir world)]
+                                                  (cond (and (= dx 0) (< dy 0)) :up
+                                                        (and (= dx 0) (> dy 0)) :down
+                                                        (and (< dx 0) (= dy 0)) :left
+                                                        (and (> dx 0) (= dy 0)) :right
+                                                        :else nil))
+                           (:autoexploring world) :autoexplore
+                           (:auto-target world) :auto-target-step
+                           :else nil)
+               ;; queued keystroke cancels in-flight auto-action
+               interrupting (and auto-key0 (term/key-pending?))
+               world (if interrupting
+                       (dissoc world :resting :running-dir :autoexploring :auto-target)
+                       world)
+               auto-key (when (not interrupting) auto-key0)
                key (or auto-key (input/parse-key (term/read-key)))
                new-world (world/update-world world key)
                ;; check if auto-mode should stop


### PR DESCRIPTION
## Summary

A queued keystroke now cancels `:autoexploring` / `:running-dir` / `:resting` / `:auto-target` before the next loop iteration enters the auto-action branch. The auto flags get dissoced, the key falls through to the normal `read-key` path, and dispatches as a real action that turn — so a manual direction key both stops a run and moves, a second `X` stops autoexplore, etc.

Addresses the "Should also be able to interrupt on key press" portion of #16.

## Why

Without this, the only way to break out of an auto-action was a natural stop — enemy spotted, inventory full, wall hit, finished resting. Players reasonably expect any keystroke to interrupt.

## Dependency

⚠️ This PR depends on the let-go primitive `term/key-pending?` being available — proposed in nooga/let-go#118. Until that lands and `go install ...@latest` picks it up, the compile-smoke job here fails with `Can't resolve term/key-pending?`. Holding as a draft until the let-go side merges.

## Implementation

`(term/key-pending?)` is a non-blocking peek at queued input — true if a key is waiting but `read-key` hasn't consumed it yet. The auto-action loop checks it once per iteration before deciding whether to skip `read-key`:

```clojure
interrupting (and auto-key0 (term/key-pending?))
world (if interrupting
        (dissoc world :resting :running-dir :autoexploring :auto-target)
        world)
auto-key (when (not interrupting) auto-key0)
key (or auto-key (input/parse-key (term/read-key)))
```

The interrupting key isn't consumed in the check — it stays queued and gets read by the same `read-key` that runs when `auto-key` is nil. So the keystroke both stops the auto-action AND dispatches as a real action that turn.

## Test plan

- [x] Test suite passes (`xsofy/test/run.lg`) — auto-action paths aren't directly exercised by tests, but no regression in invariants.
- [x] Native end-to-end (Darwin): `x` to autoexplore, press any key → stops on next turn. Same for `z` (rest) and run-direction keys.
- [x] WAS end-to-end (Chrome)
- [ ] CI passes on WASM path once let-go#118 is in `let-go@latest`.
