### PR TITLE
Deterministic seeding foundation (#18): det helpers, world-gen, gameplay rolls, entity IDs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,5 @@ debug.log
 xoy
 dist/
 .DS_Store
+run.py
+bin/lg

--- a/docs/spell-dsl.md
+++ b/docs/spell-dsl.md
@@ -1,4 +1,4 @@
-# Spell DSL Specification v2
+# Spell DSL Specification v3
 
 ## Overview
 
@@ -357,6 +357,152 @@ store X ... recall X
 ```
 
 This enables computed spells: store a damage amount, use it later for healing. Store the result of one effect, apply it to another. Turing complete? Maybe. That's fine.
+
+## Cost Economics — Enchantment Points + Mana
+
+*(Design direction recovered from 2026-05-17 sessions; not yet implemented.)*
+
+Every rune **evaluated** costs one point, drawn in cascade order:
+
+1. A point of the **item's enchantment level**, if any remains.
+2. A point of the caster's **mana**, once enchantment is exhausted.
+
+This unifies fuel/budget, per-rune evaluation cost, and cursed-item dynamics
+into a single resource model. Discovery is therefore an *economic* choice —
+you cannot observe the language for free.
+
+**Failed runes still cost.** Two models were weighed:
+
+| Model        | Rule                                   | Trade-off |
+|--------------|----------------------------------------|-----------|
+| **Full cost** *(preferred)* | 1 per failed step, same as success | Simple, unifies the cost model, punitive |
+| Fizzle tax   | Flat 1 HP regardless of steps failed   | Friendlier discovery, but a special case |
+
+## Discovery — Incomplete Spells Leak by Category
+
+*(Design direction recovered from 2026-05-17; not yet implemented.)*
+
+Incomplete or failed spells must **not** fail silently. Each failed rune emits
+**category-level** feedback — proportional but indistinct — so players can
+reverse-engineer the language by reading the runtime trace (the "isekai
+programmer discovers the compiler" framing). Crucially, leaks reveal the
+*category*, never the specific rune.
+
+| Category                              | Leak on failure                                   |
+|---------------------------------------|---------------------------------------------------|
+| Elemental (fire, ice, poison, arc)    | spark / frost / wisp / crackle VFX at cursor, no damage |
+| Damage / impact (damage, push, arc)   | 1 HP damage flash at target                       |
+| Heal / life                           | 1 HP heal with glow                               |
+| Mana / transfer (take, give, friend)  | 1 MP drain/grant between caster and target        |
+| Selectors (self, nearest, target)     | brief highlight of would-be cursor positions      |
+| Cursor modifiers (area, spread)       | highlight modified-area cells                     |
+| Math / structural (apply, mul, add, blank, result) | **no leak** (purely structural)      |
+| Time (future, past)                   | temporal shimmer at caster                        |
+
+This composes with the parser-leak guard below: leaks are *deliberate,
+categorical* signals; internal error-maps are not.
+
+### Parser-leak guard (property)
+
+The parser produces error-maps mid-stream
+(`{:reason :bad-argument :rune :add :args [nil nil] :error true}`). These must
+never reach the player. Target property:
+
+> For any parseable rune sequence, `format-sexp` returns a string containing no
+> `:error`, `:reason`, or other internal-shape markers.
+
+## The Five-Role Model
+
+*(Recovered from 2026-05-17. The positions-as-cursors decision is already live;
+the `:container` role is the main open gap — see below.)*
+
+Every spell resolves through five roles. Borrowed loosely from MTG's
+actor/subject framing:
+
+| Role            | In ctx       | Meaning                                              |
+|-----------------|--------------|------------------------------------------------------|
+| **Actor**       | `:caster`    | entity that initiated the spell                      |
+| **Subject**     | `:cursors`   | positions where effects apply (**positions, not entities**) |
+| **Container**   | `:container` *(planned)* | the item the runes fire from               |
+| **Action**      | each step    | the effect itself                                    |
+| **Environment** | `:world`     | shared world state all spells resolve into           |
+
+**Targets are positions, not entities** — intentional, so one spell can:
+damage whoever stands on a tile (now or after `:wait` steps), light empty tiles,
+push from vacated cells, freeze water, or transmute terrain.
+
+## Container-Aware Runes (the main open gap)
+
+*(Recovered from 2026-05-17 / 2026-05-20. Partially implemented.)*
+
+The source item is a first-class part of a spell's identity. Different
+container types fire on different triggers:
+
+| Container | Trigger        | Status                                            |
+|-----------|----------------|---------------------------------------------------|
+| Weapon    | on-hit (melee) | **Live** — `world.lg` melee-attack reads `(:runes wep)` |
+| (creature)| on-hit / on-shot | **Live** — falls back to `(:runes attacker)` / fires `(:spell-runes attacker)` at projectile impact |
+| Armor     | on-take-hit    | **Gap** — inscribable & stored, but never fired   |
+| Ring      | on-turn        | **Gap** — slot exists, nothing fires              |
+| Shield    | on-block       | **Gap** — not yet in slot system                  |
+| Wand/staff| on-use         | **Gap** — designed, unimplemented                 |
+
+Plan: add a `:container` field to ctx so runes can query their source item,
+behave by container type (e.g. "amplify if container is +3"), drain HP from
+cursed items, and restrict to slot types. **Design this as one unified
+container-rune system, not per-item patches** — armor (hit-triggered), ring
+(per-turn), shield (block-triggered), and wand (use-triggered) share the
+mechanism, differing only in trigger event.
+
+> Note: container-aware runes are *why armor can't be inscribed usefully today* —
+> inscription works, but `damage-entity` never reads `(:runes armor)` on the
+> defender, so the runes are dead data. The fix is the trigger layer, not the
+> parser.
+
+## Creature Abilities Are Rune Programs
+
+*(Recovered from 2026-05-17. Core mechanism is live; named signatures are the
+next layer.)*
+
+Creatures and players share **one evaluator** (`spell/eval-spell`). Monster
+abilities are not hardcoded — they are rune sequences inscribed on the creature
+entity, fired through the same pipeline:
+
+- Melee: `(:runes attacker)` fires on hit (`world.lg` melee-attack).
+- Ranged: `(:spell-runes attacker)` fires at projectile impact (`ranged-attack`).
+
+**Cones and breath are just cursor shapes.** Area/directional effects come from
+selector + modifier runes, not bespoke code:
+
+```clojure
+;; dragon fire breath — already live in bestiary.lg
+{:spell-runes [:apply :area 2 :fire]}    ; (area 2) fire
+
+;; ice cone
+{:spell-runes [:apply :area 1 :ice]}     ; (area 1) ice
+
+;; spider web-on-hit
+{:spell-runes [:web]}
+
+;; vampiric melee (fires via :runes on hit)
+{:runes [:apply :damage 2 :self :apply :heal 1]}
+```
+
+### Signature spells (planned)
+
+High-tier creatures ship pre-named, multi-rune programs as innate runes. The
+fire-imp's spell is bare `(fire)`; an elder fire-drake's
+`(area 5) (repeat 3) fire (push)` is **"Cinder Storm"** — the creature
+*announces* it, the spell takes 2–3 turns to wind up, and the player has time to
+retreat. Wind-up time scales with program length.
+
+### Magic resistance (planned)
+
+Unlike armor's flat reduction, magic resistance is **percentage-based**,
+enabling partial transfers rather than binary save-or-fail. A wraith with 50%
+resistance, drained for 4 MP, yields the caster 2 MP. Players learn how
+resistance varies across creatures by repeated experimentation — discovery
+gameplay.
 
 ## Implementation Notes
 

--- a/main.lg
+++ b/main.lg
@@ -1,3 +1,6 @@
+(require 'ir.passes.pipeline)
+;;;(alter-var-root #'*ir-compile* (constantly true))
+
 (ns xsofy.main
   (:require [term]
             [os]
@@ -10,6 +13,7 @@
             [xsofy.runes :as runes]
             [xsofy.title :as title]
             [xsofy.debug :as dbg]))
+
 
 (defn init-terminal []
   (when (nil? (term/size))

--- a/xsofy/ai.lg
+++ b/xsofy/ai.lg
@@ -5,6 +5,7 @@
             [xsofy.fire :as fire]
             [xsofy.status :as status]
             [xsofy.sound :as snd]
+            [xsofy.det :as det]
             [math]))
 
 ;; --- Spatial (delegated to util) ---
@@ -126,15 +127,19 @@
 
 (def cardinal-dirs u/dirs8)
 
-(defn random-step [world entity-id]
-  "Take a random walkable step."
+(defn random-step
+  "Take a random walkable step deterministically. Returns world'."
+  [world entity-id]
   (let [entity (get-in world [:entities entity-id])
         [ex ey] (:pos entity)
-        dirs (shuffle cardinal-dirs)
-        valid (first (filter (fn [[dx dy]] (can-move? world (+ ex dx) (+ ey dy) entity-id)) dirs))]
+        w-ctx (det/with-context world [:ai :random-step entity-id])
+        pair (det/permute w-ctx cardinal-dirs)
+        dirs (first pair)
+        w' (second pair)
+        valid (first (filter (fn [[dx dy]] (can-move? w' (+ ex dx) (+ ey dy) entity-id)) dirs))]
     (if valid
-      (try-move world entity-id (first valid) (second valid))
-      world)))
+      (try-move w' entity-id (first valid) (second valid))
+      w')))
 
 ;; --- Awareness ---
 
@@ -199,10 +204,15 @@
             (-> world
                 (assoc-in [:entities entity-id :ai :state] :hunt)
                 (assoc-in [:entities entity-id :ai :target] player-pos))
-            ;; random chance to start wandering
-            (< (rand-int 100) wander-chance)
-            (assoc-in world [:entities entity-id :ai :state] :wander)
-            :else world)
+            ;; random chance to start wandering — deterministic roll
+            :else
+            (let [w-ctx (det/with-context world [:ai :sleep-wake entity-id])
+                  pair (det/percent? w-ctx wander-chance)
+                  go-wander (first pair)
+                  w' (second pair)]
+              (if go-wander
+                (assoc-in w' [:entities entity-id :ai :state] :wander)
+                w')))
 
           ;; --- WANDER ---
           (= state :wander)
@@ -212,10 +222,15 @@
             (-> world
                 (assoc-in [:entities entity-id :ai :state] :hunt)
                 (assoc-in [:entities entity-id :ai :target] player-pos))
-            ;; random chance to go back to sleep
-            (< (rand-int 100) 10)
-            (assoc-in world [:entities entity-id :ai :state] :sleep)
-            :else world)
+            ;; random chance to go back to sleep — deterministic roll
+            :else
+            (let [w-ctx (det/with-context world [:ai :wander-sleep entity-id])
+                  pair (det/percent? w-ctx 10)
+                  go-sleep (first pair)
+                  w' (second pair)]
+              (if go-sleep
+                (assoc-in w' [:entities entity-id :ai :state] :sleep)
+                w')))
 
           ;; --- HUNT ---
           (= state :hunt)
@@ -278,7 +293,14 @@
 
 (defn hunt-ranged
   "Ranged hunt: maintain preferred distance. Shoot when in range + LOS.
-   Flee if too close, approach if too far, sidestep if no LOS."
+   Flee if too close, approach if too far, sidestep if no LOS.
+
+   The fire-chance roll fires deterministically whenever we evaluate the
+   shoot branch's gating condition (in-range + LOS). Even if the chance
+   check returns false and we fall through to another branch, the roll
+   has been consumed — this matches the original semantics: cond
+   short-circuits, so the rand-int only fired when the in-range+LOS
+   prerequisites were met."
   [world entity-id pos player-pos attack-fn ranged-attack-fn]
   (let [entity (get-in world [:entities entity-id])
         ai (:ai entity)
@@ -288,7 +310,20 @@
         dist (distance pos player-pos)
         [px py] player-pos
         [ex ey] pos
-        los (has-clear-line? world ex ey px py)]
+        los (has-clear-line? world ex ey px py)
+        too-close (< dist (- pref-range 1))
+        in-range-with-los (and (<= dist max-range) los)
+        ;; Pre-roll fire-chance only when the cond would have evaluated it.
+        ;; In the original, the rand-int was inside branch 2's predicate,
+        ;; which is only reached if branch 1 (too close) is false AND
+        ;; the and-clause short-circuits past the (<= dist max-range) and
+        ;; los checks. So we fire iff (not too-close) AND in-range-with-los.
+        fire-pair (if (and (not too-close) in-range-with-los)
+                    (det/percent? (det/with-context world [:ai :ranged-fire entity-id])
+                                  (or (:fire-chance spell-data) 100))
+                    [false world])
+        fires-now (first fire-pair)
+        world (second fire-pair)]
     (cond
       ;; too close — back away
       (< dist (- pref-range 1))
@@ -301,9 +336,8 @@
             w)
           w))
 
-      ;; in range and has LOS — shoot (with fire-chance if set)
-      (and (<= dist max-range) los
-           (< (rand-int 100) (or (:fire-chance spell-data) 100)))
+      ;; in range and has LOS and rolled to fire — shoot
+      (and in-range-with-los fires-now)
       (ranged-attack-fn world entity-id :player)
 
       ;; in range but no LOS — approach to get angle

--- a/xsofy/combat.lg
+++ b/xsofy/combat.lg
@@ -19,13 +19,8 @@
 
 ;; --- Damage Roll ---
 
-(defn roll-damage [min-dmg max-dmg net-enchant]
-  (let [base (+ min-dmg (rand-int (max 1 (inc (- max-dmg min-dmg)))))
-        scale (enchant-scale net-enchant)]
-    (max 1 (int (* base scale)))))
-
 (defn roll-damage-det
-  "Deterministic variant of roll-damage. Takes world, returns [damage world']."
+  "Rolls damage deterministically. Takes world, returns [damage world']."
   [world min-dmg max-dmg net-enchant]
   (let [span (max 1 (inc (- max-dmg min-dmg)))
         roll-pair (det/int-in world 0 span)
@@ -41,11 +36,8 @@
   (let [chance (* accuracy (math/pow 0.987 (float defense)))]
     (max 0 (min 100 (int chance)))))
 
-(defn hit? [accuracy defense]
-  (< (rand-int 100) (hit-chance accuracy defense)))
-
 (defn hit-det?
-  "Deterministic variant of hit?. Takes world, returns [bool world']."
+  "Deterministic hit check. Takes world, returns [bool world']."
   [world accuracy defense]
   (let [pct (hit-chance accuracy defense)
         pair (det/percent? world pct)
@@ -117,27 +109,8 @@
 
 ;; --- Full Attack Resolution ---
 
-(defn resolve-attack [world attacker-id target-id]
-  (let [attacker (get-in world [:entities attacker-id])
-        target (get-in world [:entities target-id])]
-    (when (and attacker target)
-      (let [atk (attacker-stats world attacker-id)
-            def_ (defender-stats world target-id)
-            net-enchant (+ (:enchant atk) (strength-modifier (:str atk) (:str-req atk)))
-            sneak (= (:ai-state def_) :sleep)
-            did-hit (or sneak (hit? (:accuracy atk) (:defense def_)))
-            raw-dmg (if did-hit (roll-damage (:min-dmg atk) (:max-dmg atk) net-enchant) 0)
-            sneak-mult (if (and did-hit sneak) (sneak-multiplier (:weapon atk)) 1)
-            final-dmg (if did-hit (max 1 (* raw-dmg sneak-mult)) 0)
-            speed (attack-speed (:weapon atk) did-hit)]
-        {:hit did-hit
-         :damage final-dmg
-         :speed speed
-         :sneak (and did-hit sneak (> sneak-mult 1))
-         :net-enchant net-enchant}))))
-
 (defn resolve-attack-det
-  "Deterministic variant of resolve-attack. Takes world, returns [result world']
+  "Full attack resolution. Takes world, returns [result world']
    where result is {:hit :damage :speed :sneak :net-enchant} or nil if either
    entity is missing."
   [world attacker-id target-id]

--- a/xsofy/combat.lg
+++ b/xsofy/combat.lg
@@ -1,6 +1,7 @@
 (ns xsofy.combat
   (:require [xsofy.entities :as ent]
             [xsofy.terrain :as terrain]
+            [xsofy.det :as det]
             [math]))
 
 ;; --- Strength Modifier ---
@@ -23,6 +24,17 @@
         scale (enchant-scale net-enchant)]
     (max 1 (int (* base scale)))))
 
+(defn roll-damage-det
+  "Deterministic variant of roll-damage. Takes world, returns [damage world']."
+  [world min-dmg max-dmg net-enchant]
+  (let [span (max 1 (inc (- max-dmg min-dmg)))
+        roll-pair (det/int-in world 0 span)
+        roll (first roll-pair)
+        w' (second roll-pair)
+        base (+ min-dmg roll)
+        scale (enchant-scale net-enchant)]
+    [(max 1 (int (* base scale))) w']))
+
 ;; --- Hit Chance ---
 
 (defn hit-chance [accuracy defense]
@@ -31,6 +43,15 @@
 
 (defn hit? [accuracy defense]
   (< (rand-int 100) (hit-chance accuracy defense)))
+
+(defn hit-det?
+  "Deterministic variant of hit?. Takes world, returns [bool world']."
+  [world accuracy defense]
+  (let [pct (hit-chance accuracy defense)
+        pair (det/percent? world pct)
+        b (first pair)
+        w' (second pair)]
+    [b w']))
 
 ;; --- Attack Speed ---
 
@@ -114,6 +135,40 @@
          :speed speed
          :sneak (and did-hit sneak (> sneak-mult 1))
          :net-enchant net-enchant}))))
+
+(defn resolve-attack-det
+  "Deterministic variant of resolve-attack. Takes world, returns [result world']
+   where result is {:hit :damage :speed :sneak :net-enchant} or nil if either
+   entity is missing."
+  [world attacker-id target-id]
+  (let [attacker (get-in world [:entities attacker-id])
+        target (get-in world [:entities target-id])]
+    (if-not (and attacker target)
+      [nil world]
+      (let [w-ctx (det/with-context world [:combat attacker-id target-id])
+            atk (attacker-stats w-ctx attacker-id)
+            def_ (defender-stats w-ctx target-id)
+            net-enchant (+ (:enchant atk) (strength-modifier (:str atk) (:str-req atk)))
+            sneak (= (:ai-state def_) :sleep)
+            ;; Hit check: sneak bypass OR det/percent? for accuracy
+            hit-pair (if sneak [true w-ctx] (hit-det? w-ctx (:accuracy atk) (:defense def_)))
+            did-hit (first hit-pair)
+            w-after-hit (second hit-pair)
+            ;; Damage roll only if hit
+            dmg-pair (if did-hit
+                       (roll-damage-det w-after-hit (:min-dmg atk) (:max-dmg atk) net-enchant)
+                       [0 w-after-hit])
+            raw-dmg (first dmg-pair)
+            w-after-dmg (second dmg-pair)
+            sneak-mult (if (and did-hit sneak) (sneak-multiplier (:weapon atk)) 1)
+            final-dmg (if did-hit (max 1 (* raw-dmg sneak-mult)) 0)
+            speed (attack-speed (:weapon atk) did-hit)]
+        [{:hit did-hit
+          :damage final-dmg
+          :speed speed
+          :sneak (and did-hit sneak (> sneak-mult 1))
+          :net-enchant net-enchant}
+         w-after-dmg]))))
 
 ;; --- Attack Patterns ---
 ;; Given attacker position, direction, and weapon, compute which positions to attack.

--- a/xsofy/det.lg
+++ b/xsofy/det.lg
@@ -1,0 +1,150 @@
+(ns xsofy.det
+  "Deterministic randomness via a rolling hash chain over world :seed.
+
+   Model: the world IS the RNG state. Every det/* helper:
+     1. Folds the operation's signature into (:seed world) via xxh3-64,
+        producing a new seed.
+     2. Derives a return value from the new seed.
+     3. Returns [value world'] where world' has :seed advanced.
+
+   This unifies the spec's earlier 'salt' and 'action' concepts: both are
+   just bytes that get hashed into the seed. The dispatcher's per-action
+   advance and a within-action roll's advance are the same primitive.
+
+   Independence: two consecutive rolls produce different values because
+   the first one mutated :seed. No explicit salt-key parameter is needed
+   for disambiguation.
+
+   Refactor stability: rolls are stable so long as the call sequence
+   doesn't change. If you reorder rolls, downstream values shift. To
+   bind a phase of rolls to a stable identifier (e.g. so renaming the
+   surrounding code doesn't shift the chain), use det/with-context to
+   fold an explicit anchor in first.
+
+   Naming: every helper avoids shadowing clojure.core. det/int-in,
+   det/pick, det/unit, det/permute (not int, nth, float, shuffle). The
+   destructure macro in let-go expands to unqualified nth; shadowing it
+   from this ns silently breaks destructuring in any namespace that
+   requires xsofy.det. (See det/pick docstring.)"
+  (:require [xsofy.hash :as h]))
+
+;; -------------------------------------------------------------------------
+;; Primitive
+;; -------------------------------------------------------------------------
+
+(defn advance
+  "Fold contextual into world's :seed and return the new world. The
+   contextual can be any value the salt encoder accepts (keyword, int,
+   string, vector, map). This is the single mutation primitive; every
+   higher-level helper is built on it.
+
+   Defaults :seed to 0 if missing, so worlds constructed without an
+   explicit seed still hash consistently."
+  [world contextual]
+  (let [old-seed (or (:seed world) 0)
+        new-seed (h/combine old-seed contextual)]
+    (assoc world :seed new-seed)))
+
+(defn with-context
+  "Anchor subsequent rolls under an explicit identifier. Equivalent to
+   advance, but expresses intent: 'all rolls from here forward in this
+   phase are tagged by this context.' Useful for refactor stability —
+   if you wrap a phase like (with-context world [:worldgen :phase :rooms]),
+   reorderings of work outside that phase don't shift the rolls inside."
+  [world context]
+  (advance world context))
+
+(defn- step
+  "Internal: advance world by op-signature, return [seed' world']."
+  [world op-signature]
+  (let [w' (advance world op-signature)]
+    [(:seed w') w']))
+
+;; -------------------------------------------------------------------------
+;; Helpers — each returns [value world'] with seed advanced
+;; -------------------------------------------------------------------------
+
+(defn int-in
+  "Integer in [lo, hi). Returns [lo world] if hi <= lo.
+
+   Maps a u64 hash to the requested span via (mod h span). For non-power-of-2
+   spans this is slightly biased, which is fine for game randomness — the bias
+   is bounded by span / 2^64 and invisible at the scale of die rolls.
+
+   Relies on let-go's `mod` returning non-negative for positive divisor
+   (Clojure parity): (mod -5 7) = 2, not -5."
+  [world lo hi]
+  (if (<= hi lo)
+    [lo world]
+    (let [[seed w'] (step world [:int-in lo hi])
+          span (unchecked-subtract hi lo)]
+      [(unchecked-add lo (mod seed span)) w'])))
+
+(defn pick
+  "Pick an element from coll. Returns [nil world] if coll is empty.
+
+   Named pick (not nth) to avoid shadowing clojure.core/nth — the
+   destructure macro expands to unqualified `nth`, and a same-named def
+   here would silently break destructuring in downstream code."
+  [world coll]
+  (let [v (vec coll)
+        n (count v)]
+    (if (zero? n)
+      [nil world]
+      (let [[i w'] (int-in world 0 n)]
+        [(nth v i) w']))))
+
+(defn percent?
+  "True with probability chance/100, where chance is an int in [0, 100].
+   Returns [bool world']."
+  [world chance]
+  (let [[i w'] (int-in world 0 100)]
+    [(< i chance) w']))
+
+(defn unit
+  "Float in [0.0, 1.0). Returns [float world'].
+
+   Implementation: take the advanced u64 mod 1_000_000 then divide by
+   1_000_000.0. Six digits of precision; sidesteps subtle u64-to-double
+   conversion edge cases.
+
+   Named unit (not float) to avoid shadowing clojure.core/float. The
+   'unit' refers to the unit interval [0, 1)."
+  [world]
+  (let [[seed w'] (step world [:unit])]
+    [(/ (mod seed 1000000) 1000000.0) w']))
+
+(defn permute
+  "Permute coll. Returns [vector world'].
+
+   Fisher-Yates: each swap step advances the chain, naturally producing
+   independent indices.
+
+   Named permute (not shuffle) to avoid shadowing clojure.core/shuffle."
+  [world coll]
+  (let [v (vec coll)
+        n (count v)]
+    (if (<= n 1)
+      [v world]
+      (loop [arr v
+             i (dec n)
+             w world]
+        (if (<= i 0)
+          [arr w]
+          (let [[j w'] (int-in w 0 (inc i))
+                a (nth arr i)
+                b (nth arr j)]
+            (recur (assoc (assoc arr i b) j a)
+                   (dec i)
+                   w')))))))
+
+(defn next-id
+  "Generate a fresh entity id keyed by prefix (a keyword).
+   Returns [id world'] with :next-id incremented.
+
+   Unlike the other helpers, this is a pure counter increment — no
+   hash-chain involvement. The counter is independent of :seed."
+  [world prefix]
+  (let [n  (inc (or (:next-id world) 0))
+        id (keyword (str (name prefix) "-" n))]
+    [id (assoc world :next-id n)]))

--- a/xsofy/effects.lg
+++ b/xsofy/effects.lg
@@ -20,12 +20,6 @@
         new-intensity (min 5 (+ old-int intensity))]
     (assoc world :stains (assoc stains [x y] {:type stype :intensity new-intensity}))))
 
-(defn blood-drop [world cx cy]
-  "Single blood drop at or near position."
-  (let [dx (- (rand-int 3) 1)
-        dy (- (rand-int 3) 1)]
-    (add-stain world (+ cx dx) (+ cy dy) :blood 1)))
-
 (defn blood-drop-det
   "Deterministic blood drop. Returns world'."
   [world cx cy]
@@ -35,16 +29,6 @@
         dx (- px 1)
         dy (- py 1)]
     (add-stain w (+ cx dx) (+ cy dy) :blood 1)))
-
-(defn blood-puddle [world cx cy]
-  "Big puddle — center + random neighbors."
-  (let [w (add-stain world cx cy :blood 4)]
-    (reduce (fn [w [dx dy]]
-              (if (< (rand-int 3) 2)
-                (add-stain w (+ cx dx) (+ cy dy) :blood (+ 1 (rand-int 3)))
-                w))
-            w
-            u/dirs8)))
 
 (defn blood-puddle-det
   "Deterministic blood puddle. Returns world'."
@@ -56,36 +40,6 @@
                 (if (< r1 2)
                   (let [[r2 w] (det/int-in w 0 3)]
                     (add-stain w (+ cx dx) (+ cy dy) :blood (+ 1 r2)))
-                  w)))
-            w-ctx
-            u/dirs8)))
-
-(defn splatter [world cx cy stype intensity radius]
-  "Generic splatter."
-  (let [w (add-stain world cx cy stype intensity)]
-    (reduce (fn [w [dx dy]]
-              (let [nx (+ cx dx) ny (+ cy dy)]
-                (if (and (<= (+ (* dx dx) (* dy dy)) (* radius radius))
-                         (< (rand-int 3) intensity))
-                  (add-stain w nx ny stype (max 1 (dec intensity)))
-                  w)))
-            w
-            u/dirs8)))
-
-(defn splatter-det
-  "Deterministic splatter. Returns world'."
-  [world cx cy stype intensity radius]
-  (let [w0 (add-stain world cx cy stype intensity)
-        w-ctx (det/with-context w0 [:fx :splatter stype cx cy])]
-    (reduce (fn [w [dx dy]]
-              (let [nx (+ cx dx) ny (+ cy dy)]
-                (if (<= (+ (* dx dx) (* dy dy)) (* radius radius))
-                  (let [pair (det/int-in w 0 3)
-                        keep? (< (first pair) intensity)
-                        w' (second pair)]
-                    (if keep?
-                      (add-stain w' nx ny stype (max 1 (dec intensity)))
-                      w'))
                   w)))
             w-ctx
             u/dirs8)))

--- a/xsofy/effects.lg
+++ b/xsofy/effects.lg
@@ -1,6 +1,7 @@
 (ns xsofy.effects
   (:require [xsofy.terrain :as terrain]
-            [xsofy.util :as u]))
+            [xsofy.util :as u]
+            [xsofy.det :as det]))
 
 ;; --- Effects Layer ---
 ;; Two sparse persistent maps on the world:
@@ -25,6 +26,16 @@
         dy (- (rand-int 3) 1)]
     (add-stain world (+ cx dx) (+ cy dy) :blood 1)))
 
+(defn blood-drop-det
+  "Deterministic blood drop. Returns world'."
+  [world cx cy]
+  (let [w (det/with-context world [:fx :blood-drop cx cy])
+        [px w] (det/int-in w 0 3)
+        [py w] (det/int-in w 0 3)
+        dx (- px 1)
+        dy (- py 1)]
+    (add-stain w (+ cx dx) (+ cy dy) :blood 1)))
+
 (defn blood-puddle [world cx cy]
   "Big puddle — center + random neighbors."
   (let [w (add-stain world cx cy :blood 4)]
@@ -33,6 +44,20 @@
                 (add-stain w (+ cx dx) (+ cy dy) :blood (+ 1 (rand-int 3)))
                 w))
             w
+            u/dirs8)))
+
+(defn blood-puddle-det
+  "Deterministic blood puddle. Returns world'."
+  [world cx cy]
+  (let [w0 (add-stain world cx cy :blood 4)
+        w-ctx (det/with-context w0 [:fx :blood-puddle cx cy])]
+    (reduce (fn [w [dx dy]]
+              (let [[r1 w] (det/int-in w 0 3)]
+                (if (< r1 2)
+                  (let [[r2 w] (det/int-in w 0 3)]
+                    (add-stain w (+ cx dx) (+ cy dy) :blood (+ 1 r2)))
+                  w)))
+            w-ctx
             u/dirs8)))
 
 (defn splatter [world cx cy stype intensity radius]
@@ -45,6 +70,24 @@
                   (add-stain w nx ny stype (max 1 (dec intensity)))
                   w)))
             w
+            u/dirs8)))
+
+(defn splatter-det
+  "Deterministic splatter. Returns world'."
+  [world cx cy stype intensity radius]
+  (let [w0 (add-stain world cx cy stype intensity)
+        w-ctx (det/with-context w0 [:fx :splatter stype cx cy])]
+    (reduce (fn [w [dx dy]]
+              (let [nx (+ cx dx) ny (+ cy dy)]
+                (if (<= (+ (* dx dx) (* dy dy)) (* radius radius))
+                  (let [pair (det/int-in w 0 3)
+                        keep? (< (first pair) intensity)
+                        w' (second pair)]
+                    (if keep?
+                      (add-stain w' nx ny stype (max 1 (dec intensity)))
+                      w'))
+                  w)))
+            w-ctx
             u/dirs8)))
 
 ;; --- Stain Colors ---

--- a/xsofy/entities.lg
+++ b/xsofy/entities.lg
@@ -1,4 +1,5 @@
-(ns xsofy.entities)
+(ns xsofy.entities
+  (:require [xsofy.det :as det]))
 
 ;; --- Registry ---
 
@@ -320,47 +321,57 @@
 
 (def split-walkable #{1 2 3 5 10 12 13 14 15 16 17 18})
 
-(defn find-split-pos [world pos]
-  "Find an adjacent walkable empty tile for the split spawn."
+(defn find-split-pos
+  "Find an adjacent walkable empty tile for the split spawn deterministically.
+   Returns [dir-or-nil world'] where dir is [dx dy]."
+  [world pos]
   (let [grid (:terrain world)
         w (:width world)
-        dirs (shuffle [[1 0] [-1 0] [0 1] [0 -1] [1 1] [1 -1] [-1 1] [-1 -1]])
-        [px py] pos]
-    (first (filter (fn [[dx dy]]
-                     (let [nx (+ px dx) ny (+ py dy)
-                           tile (aget grid (+ nx (* ny w)))]
-                       (and (contains? split-walkable tile)
-                            (nil? (creature-at world [nx ny])))))
-                   dirs))))
+        [px py] pos
+        w-ctx (det/with-context world [:entities :split-pos px py])
+        pair (det/permute w-ctx [[1 0] [-1 0] [0 1] [0 -1] [1 1] [1 -1] [-1 1] [-1 -1]])
+        dirs (first pair)
+        w' (second pair)
+        chosen (first (filter (fn [[dx dy]]
+                                (let [nx (+ px dx) ny (+ py dy)
+                                      tile (aget grid (+ nx (* ny w)))]
+                                  (and (contains? split-walkable tile)
+                                       (nil? (creature-at world [nx ny])))))
+                              dirs))]
+    [chosen w']))
 
 (defn try-split [world id new-hp]
-  "If entity splits on hit and has enough HP, spawn a clone at half HP."
+  "If entity splits on hit and has enough HP, spawn a clone at half HP.
+   Returns updated world or nil if no split happened."
   (let [entity (get-in world [:entities id])
         splits (get-in entity [:properties :splits-on-hit])
         pos (:pos entity)]
     (if (and splits (>= new-hp min-split-hp))
-      (when-let [dir (find-split-pos world pos)]
-        (let [half-hp (quot new-hp 2)
-              remain-hp (- new-hp half-hp)
-              [dx dy] dir
-              [px py] pos
-              clone-pos [(+ px dx) (+ py dy)]
-              species (:template entity)
-              ;; spawn clone and set its HP
-              w (spawn world species clone-pos)
-              ;; find the clone (last spawned entity of this species)
-              clone-id (last (filter (fn [k]
-                                       (and (= species (:template (get-in w [:entities k])))
-                                            (= clone-pos (:pos (get-in w [:entities k])))))
-                                     (keys (:entities w))))]
-          (when clone-id
-            (let [parent-ticks (or (:ticks entity) 0)]
-              (-> w
-                  (assoc-in [:entities id :body :hp] remain-hp)
-                  (assoc-in [:entities clone-id :body :hp] half-hp)
-                  (assoc-in [:entities clone-id :body :max-hp] half-hp)
-                  (assoc-in [:entities clone-id :ticks] parent-ticks)
-                  (assoc-in [:entities clone-id :ai :state] :hunt))))))
+      (let [split-pair (find-split-pos world pos)
+            dir (first split-pair)
+            world (second split-pair)]
+        (when dir
+          (let [half-hp (quot new-hp 2)
+                remain-hp (- new-hp half-hp)
+                [dx dy] dir
+                [px py] pos
+                clone-pos [(+ px dx) (+ py dy)]
+                species (:template entity)
+                ;; spawn clone and set its HP
+                w (spawn world species clone-pos)
+                ;; find the clone (last spawned entity of this species)
+                clone-id (last (filter (fn [k]
+                                         (and (= species (:template (get-in w [:entities k])))
+                                              (= clone-pos (:pos (get-in w [:entities k])))))
+                                       (keys (:entities w))))]
+            (when clone-id
+              (let [parent-ticks (or (:ticks entity) 0)]
+                (-> w
+                    (assoc-in [:entities id :body :hp] remain-hp)
+                    (assoc-in [:entities clone-id :body :hp] half-hp)
+                    (assoc-in [:entities clone-id :body :max-hp] half-hp)
+                    (assoc-in [:entities clone-id :ticks] parent-ticks)
+                    (assoc-in [:entities clone-id :ai :state] :hunt)))))))
       nil)))
 
 (defn damage-entity [world id amount]

--- a/xsofy/entities.lg
+++ b/xsofy/entities.lg
@@ -4,11 +4,23 @@
 ;; --- Registry ---
 
 (def templates (atom {}))
-(def id-counter (atom 0))
 
-(defn next-id [prefix]
-  (let [n (swap! id-counter inc)]
-    (keyword (str (name prefix) "-" n))))
+(defn next-id
+  "Allocate a fresh entity ID by rolling a 31-bit int from the world's seed
+   chain. Returns [id world'] where world's :seed is advanced by one step
+   and the id is :prefix-N where N is the rolled int.
+
+   No global counter — this is purely a function of the world's current
+   seed. Two replays from the same seed allocate identical IDs in the
+   same order.
+
+   Collision-resistant: 31-bit space (~2.1B values). Per-floor entity
+   counts are O(10), so collision odds are negligible (~10^-9 per pair)."
+  [world prefix]
+  (let [pair (det/int-in world 0 2147483647)
+        n (first pair)
+        w' (second pair)]
+    [(keyword (str (name prefix) "-" n)) w']))
 
 ;; --- Deep Merge ---
 
@@ -132,7 +144,9 @@
 (defn spawn [world species pos]
   (let [template (get @templates species)
         _ (when (nil? template) (throw (str "Unknown species: " species)))
-        id (next-id species)
+        id-pair (next-id world species)
+        id (first id-pair)
+        world (second id-pair)
         body (:body template)
         instance (-> template
                      (assoc :id id
@@ -147,7 +161,9 @@
 (defn spawn-item [world species pos]
   (let [template (get @templates species)
         _ (when (nil? template) (throw (str "Unknown item: " species)))
-        id (next-id species)
+        id-pair (next-id world species)
+        id (first id-pair)
+        world (second id-pair)
         instance (-> template
                      (assoc :id id
                             :template species
@@ -160,7 +176,9 @@
   (let [species (:template descriptor)
         template (get @templates species)
         _ (when (nil? template) (throw (str "Unknown item: " species)))
-        id (next-id species)
+        id-pair (next-id world species)
+        id (first id-pair)
+        world (second id-pair)
         enchant (or (:enchant descriptor) 0)
         runic (:runic descriptor)
         instance (-> template

--- a/xsofy/fire.lg
+++ b/xsofy/fire.lg
@@ -2,7 +2,8 @@
   (:require [xsofy.terrain :as terrain]
             [xsofy.entities :as ent]
             [xsofy.util :as u]
-            [xsofy.status :as status]))
+            [xsofy.status :as status]
+            [xsofy.det :as det]))
 
 ;; --- Fire System ---
 ;; Fire is terrain tile 15. TTL tracked in world :fire-ttl {[x y] turns-left}.
@@ -38,29 +39,47 @@
       (assoc-in world [:fire-ttl [x y]] ttl))))
 
 (defn step-fire [world]
-  "One tick of fire simulation. Spread, damage, burn out."
+  "One tick of fire simulation. Spread, damage, burn out.
+   Threads world through the spread rolls for replay determinism."
   (let [{:keys [terrain width height]} world
         fire-ttl (or (:fire-ttl world) {})
         new-fires (atom [])
-        new-ttl (atom {})]
-    ;; process each fire cell
-    (doseq [[[x y] ttl] fire-ttl]
-      (let [tile (terrain/tget terrain width x y)]
-        (when (= tile fire-tile)
-          (if (<= ttl 1)
-            ;; burn out → ash
-            (terrain/tset! terrain width x y ash-tile)
-            (do
-              ;; keep burning
-              (swap! new-ttl assoc [x y] (dec ttl))
-              ;; spread to adjacent flammable
-              (doseq [[dx dy] u/dirs8]
-                (let [nx (+ x dx) ny (+ y dy)]
-                  (when (and (>= nx 0) (< nx width) (>= ny 0) (< ny height))
-                    (let [ntile (terrain/tget terrain width nx ny)]
-                      (when (and (contains? terrain/flammable-tiles ntile)
-                                 (< (rand-int 100) fire-spread-chance))
-                        (swap! new-fires conj [nx ny])))))))))))
+        new-ttl (atom {})
+        w-ctx (det/with-context world [:fire :step])
+        ;; process each fire cell, threading world through spread rolls
+        w-after-rolls
+        (reduce
+          (fn [w [[x y] ttl]]
+            (let [tile (terrain/tget terrain width x y)]
+              (if (not= tile fire-tile)
+                w
+                (if (<= ttl 1)
+                  (do
+                    ;; burn out → ash
+                    (terrain/tset! terrain width x y ash-tile)
+                    w)
+                  (do
+                    ;; keep burning
+                    (swap! new-ttl assoc [x y] (dec ttl))
+                    ;; spread to adjacent flammable — threaded reduce
+                    (reduce
+                      (fn [w-inner [dx dy]]
+                        (let [nx (+ x dx) ny (+ y dy)]
+                          (if-not (and (>= nx 0) (< nx width) (>= ny 0) (< ny height))
+                            w-inner
+                            (let [ntile (terrain/tget terrain width nx ny)]
+                              (if-not (contains? terrain/flammable-tiles ntile)
+                                w-inner
+                                (let [pair (det/percent? w-inner fire-spread-chance)
+                                      spread? (first pair)
+                                      w-next (second pair)]
+                                  (when spread?
+                                    (swap! new-fires conj [nx ny]))
+                                  w-next))))))
+                      w
+                      u/dirs8))))))
+          w-ctx
+          (seq fire-ttl))]
     ;; ignite new fires
     (let [w (reduce (fn [w [x y]]
                       (let [t (terrain/tget (:terrain w) (:width w) x y)]
@@ -69,7 +88,7 @@
                               (swap! new-ttl assoc [x y] fire-default-ttl)
                               w)
                           w)))
-                    world @new-fires)]
+                    w-after-rolls @new-fires)]
       ;; damage entities standing in fire
       (let [w (reduce (fn [w [[x y] _]]
                         (let [targets (vec (filter

--- a/xsofy/hash.lg
+++ b/xsofy/hash.lg
@@ -1260,7 +1260,7 @@
 
    This is the function every det/ call invokes. The plan:
 
-     (det/int world [:combat :hit a t] lo hi)
+     (det/int-in world [:combat :hit a t] lo hi)
 
    reduces (modulo the macro layer) to
 

--- a/xsofy/items.lg
+++ b/xsofy/items.lg
@@ -1,6 +1,7 @@
 (ns xsofy.items
   (:require [xsofy.entities :refer [defitem visual weapon armor ring
                                      consumable item-name item-desc drops runes]]
+            [xsofy.det :as det]
             [math]))
 
 ;; --- Gold ---
@@ -252,31 +253,41 @@
 ;; --- Weighted random selection ---
 
 (defn weighted-pick
-  "Pick a random item from entries using :eff-weight. Returns the entry or nil."
-  [entries]
-  (when (seq entries)
+  "Pick an entry from a weighted entry list deterministically.
+   Returns [entry world'] (entry may be nil if list is empty or all-zero-weight)."
+  [world entries]
+  (if-not (seq entries)
+    [nil world]
     (let [total (reduce (fn [sum e] (+ sum (:eff-weight e))) 0.0 entries)]
-      (when (> total 0)
-        (let [roll (* (rand) total)]
+      (if-not (> total 0)
+        [nil world]
+        (let [[u world'] (det/unit world)
+              roll (* u total)]
           (loop [remaining entries acc 0.0]
-            (when (seq remaining)
+            (if-not (seq remaining)
+              [nil world']
               (let [e (first remaining)
                     acc (+ acc (:eff-weight e))]
                 (if (>= acc roll)
-                  e
+                  [e world']
                   (recur (rest remaining) acc))))))))))
 
 ;; --- Enchantment ---
 
-(defn roll-enchant [depth]
-  (let [;; base roll: heavily weighted toward 0
-        ;; roll two dice and take the one closer to 0
-        r1 (- (rand-int 3) 1)   ;; -1, 0, +1
-        r2 (- (rand-int 3) 1)
+(defn roll-enchant
+  "Roll an enchantment delta deterministically. Returns [delta world'].
+   Caller threads (depth, slot) via with-context to disambiguate items
+   on the same floor."
+  [world depth slot]
+  (let [world (det/with-context world [:itemgen :enchant depth slot])
+        [r1-raw world] (det/int-in world 0 3)
+        [r2-raw world] (det/int-in world 0 3)
+        r1 (- r1-raw 1)   ;; -1, 0, +1
+        r2 (- r2-raw 1)
         roll (if (<= (math/abs r1) (math/abs r2)) r1 r2)
         depth-bonus (quot depth 4)
         result (+ roll depth-bonus)]
-    (max -3 (min 5 result))))
+    [(max -3 (min 5 result)) world]))
 
 ;; --- Procedural Runics ---
 
@@ -291,70 +302,86 @@
   [{:effect :heal    :weight 15  :name "vampiric"}
    {:effect :damage  :weight 10  :name "volatile"}])
 
-(defn pick-effect [pool]
+(defn pick-effect
+  "Pick a weighted effect from pool deterministically. Returns [effect-map world']."
+  [world pool]
   (let [total (reduce (fn [s e] (+ s (:weight e))) 0 pool)
-        roll (rand-int total)]
+        [roll world'] (det/int-in world 0 total)]
     (loop [remaining pool acc 0]
-      (when (seq remaining)
+      (if-not (seq remaining)
+        [nil world']
         (let [e (first remaining)
               acc (+ acc (:weight e))]
           (if (>= acc roll)
-            e
+            [e world']
             (recur (rest remaining) acc)))))))
 
 ;; Runic templates by quality tier
-(defn generate-runic-program [depth tier]
-  (let [eff (pick-effect runic-effects)
-        param (+ 1 (rand-int (min 4 (+ 1 (quot depth 2)))))]
+(defn generate-runic-program
+  "Generate a runic program deterministically. Returns [program world']."
+  [world depth slot tier]
+  (let [world (det/with-context world [:itemgen :runic depth slot tier])
+        [eff world] (pick-effect world runic-effects)
+        [param-roll world] (det/int-in world 0 (min 4 (+ 1 (quot depth 2))))
+        param (+ 1 param-roll)]
     (case tier
       ;; useful: simple on-hit effects
       :useful
-      (let [shape (rand-int 3)]
+      (let [[shape world] (det/int-in world 0 3)]
         (case shape
-          0 {:runes [(:effect eff)]
-             :name (:name eff)}
-          1 {:runes [:apply (:effect eff) param]
-             :name (:name eff)}
-          2 (let [eff2 (pick-effect (vec (filter #(not= (:effect %) (:effect eff)) runic-effects)))]
-              {:runes [(:effect eff) (:effect eff2)]
-               :name (str (:name eff) " " (:name eff2))})))
+          0 [{:runes [(:effect eff)]
+              :name (:name eff)} world]
+          1 [{:runes [:apply (:effect eff) param]
+              :name (:name eff)} world]
+          2 (let [[eff2 world] (pick-effect
+                                world
+                                (vec (filter #(not= (:effect %) (:effect eff))
+                                             runic-effects)))]
+              [{:runes [(:effect eff) (:effect eff2)]
+                :name (str (:name eff) " " (:name eff2))} world])))
 
       ;; powerful: area, chain, vampiric
       :powerful
-      (let [shape (rand-int 3)
-            radius (+ 1 (rand-int 2))]
+      (let [[shape world] (det/int-in world 0 3)
+            [radius-roll world] (det/int-in world 0 2)
+            radius (+ 1 radius-roll)]
         (case shape
-          0 {:runes [:apply :area radius (:effect eff)]
-             :name (str "furious " (:name eff))}
-          1 {:runes [:arc :arc]
-             :name "thundering"}
-          2 (let [dmg (+ 1 (rand-int 3))
+          0 [{:runes [:apply :area radius (:effect eff)]
+              :name (str "furious " (:name eff))} world]
+          1 [{:runes [:arc :arc]
+              :name "thundering"} world]
+          2 (let [[dmg-roll world] (det/int-in world 0 3)
+                  dmg (+ 1 dmg-roll)
                   heal (max 1 (dec dmg))]
-              {:runes [:apply :damage dmg :self :apply :heal heal]
-               :name "vampiric"})))
+              [{:runes [:apply :damage dmg :self :apply :heal heal]
+                :name "vampiric"} world])))
 
       ;; dangerous: useful but with self-targeting twist
       :dangerous
-      (let [self-eff (pick-effect runic-self-effects)]
-        {:runes [(:effect eff) :self (:effect self-eff)]
-         :name (str (:name eff) " " (:name self-eff))})
+      (let [[self-eff world] (pick-effect world runic-self-effects)]
+        [{:runes [(:effect eff) :self (:effect self-eff)]
+          :name (str (:name eff) " " (:name self-eff))} world])
 
       ;; broken: inverted — hurts the wielder
       :broken
-      (let [shape (rand-int 2)]
+      (let [[shape world] (det/int-in world 0 2)]
         (case shape
-          0 {:runes [:self (:effect eff)]
-             :name (str "cursed " (:name eff))}
-          1 {:runes [:self :apply :damage param]
-             :name "self-destructive"})))))
+          0 [{:runes [:self (:effect eff)]
+              :name (str "cursed " (:name eff))} world]
+          1 [{:runes [:self :apply :damage param]
+              :name "self-destructive"} world])))))
 
-(defn roll-quality-tier []
-  (let [r (rand-int 100)]
-    (cond
-      (< r 55) :useful
-      (< r 80) :powerful
-      (< r 95) :dangerous
-      :else    :broken)))
+(defn roll-quality-tier
+  "Pick a quality tier deterministically. Returns [tier-keyword world']."
+  [world depth slot]
+  (let [world (det/with-context world [:itemgen :quality-tier depth slot])
+        [r world] (det/int-in world 0 100)]
+    [(cond
+       (< r 55) :useful
+       (< r 80) :powerful
+       (< r 95) :dangerous
+       :else    :broken)
+     world]))
 
 (defn runic-chance [depth]
   (cond
@@ -380,12 +407,18 @@
 ;; --- Floor Loot Generation ---
 
 (defn roll-floor-loot
-  "Generate a vector of item descriptors for a floor.
-   Each descriptor: {:template :key :enchant N :runic {:runes [...] :name str} or nil}"
-  [depth]
-  (let [budget (atom (+ 6 depth (rand-int 3)))
-        counts (atom {})  ;; category -> count
-        ;; compute effective weights
+  "Generate a vector of item descriptors for a floor deterministically.
+   Returns [items world'].
+   Each item: {:template :key :enchant N :runic {:runes [...] :name str} or nil}
+
+   Implementation note: atoms (budget, counts, items) handle in-iteration
+   accumulation cleanly. The world is threaded across iterations via the
+   outer loop's recur. Each iteration uses slot as a with-context anchor."
+  [world depth]
+  (let [w (det/with-context world [:itemgen :floor-loot depth])
+        [budget-roll w] (det/int-in w 0 3)
+        budget (atom (+ 6 depth budget-roll))
+        counts (atom {})
         weighted (vec (filter
                         #(> (:eff-weight %) 0.01)
                         (mapv (fn [entry]
@@ -394,40 +427,52 @@
                                           (depth-freq depth (:peak entry) (:spread entry)))))
                               loot-table)))
         items (atom [])]
-    (dotimes [_ 30]  ;; max 30 attempts
-      (when (> @budget 0)
-        (let [;; filter by budget and category caps
+    (loop [slot 0
+           w w]
+      (if (or (>= slot 30) (<= @budget 0))
+        [@items w]
+        (let [w (det/with-context w [:itemgen :floor-loot-slot depth slot])
               available (vec (filter
                               (fn [e]
                                 (and (<= (:cost e) @budget)
                                      (< (get @counts (:category e) 0)
                                         (get category-caps (:category e) 99))))
                               weighted))]
-          (when (seq available)
-            (when-let [pick (weighted-pick available)]
-              (let [cat (:category pick)
-                    tpl (:template pick)
-                    ;; roll enchant for weapons and armor
-                    enchant (if (or (= cat :weapon) (= cat :armor))
-                              (roll-enchant depth) 0)
-                    ;; roll runic for weapons and armor
-                    is-runic (and (or (= cat :weapon) (= cat :armor))
-                                  (< (rand) (runic-chance depth)))
-                    runic (when is-runic
-                            (generate-runic-program depth (roll-quality-tier)))
-                    cost (+ (:cost pick) (if is-runic 2 0))]
-                (when (<= cost @budget)
-                  (swap! budget - cost)
-                  (swap! counts update cat #(inc (or % 0)))
-                  (swap! items conj {:template tpl
-                                     :enchant enchant
-                                     :runic runic}))))))))
-    @items))
+          (if-not (seq available)
+            (recur (inc slot) w)
+            (let [[pick w] (weighted-pick w available)]
+              (if (nil? pick)
+                (recur (inc slot) w)
+                (let [cat (:category pick)
+                      tpl (:template pick)
+                      is-weapon-or-armor (or (= cat :weapon) (= cat :armor))
+                      [enchant w] (if is-weapon-or-armor
+                                    (roll-enchant w depth slot)
+                                    [0 w])
+                      [is-runic w] (if is-weapon-or-armor
+                                     (det/percent? w (int (* 100 (runic-chance depth))))
+                                     [false w])
+                      [runic w] (if is-runic
+                                  (let [[tier w] (roll-quality-tier w depth slot)]
+                                    (generate-runic-program w depth slot tier))
+                                  [nil w])
+                      cost (+ (:cost pick) (if is-runic 2 0))]
+                  (when (<= cost @budget)
+                    (swap! budget - cost)
+                    (swap! counts update cat #(inc (or % 0)))
+                    (swap! items conj {:template tpl
+                                       :enchant enchant
+                                       :runic runic}))
+                  (recur (inc slot) w))))))))))
+
 
 ;; --- Legacy API (still used by populate-room until world.lg is updated) ---
 
-(defn random-loot [depth]
-  (let [items (roll-floor-loot depth)]
+(defn random-loot
+  "Pick a single random item template deterministically. Returns [template world']."
+  [world depth]
+  (let [[items world] (roll-floor-loot world depth)]
     (if (seq items)
-      (:template (nth items (rand-int (count items))))
-      :health-potion)))
+      (let [[item world] (det/pick world items)]
+        [(:template item) world])
+      [:health-potion world])))

--- a/xsofy/runes.lg
+++ b/xsofy/runes.lg
@@ -1,4 +1,5 @@
-(ns xsofy.runes)
+(ns xsofy.runes
+  (:require [xsofy.det :as det]))
 
 ;; --- Rune System v2 ---
 ;; All primitives are arity-0 by default.
@@ -46,15 +47,19 @@
 
 ;; --- Rune Table ---
 
-(defn generate-rune-table []
-  (let [shuffled-glyphs (shuffle rune-glyphs)
-        shuffled-names (shuffle garbled-names)]
-    (reduce (fn [table i]
-              (let [rune (nth all-runes i)]
-                (assoc table rune {:glyph (nth shuffled-glyphs i)
-                                   :garbled (nth shuffled-names i)
-                                   :identified false})))
-            {} (range (count all-runes)))))
+(defn generate-rune-table
+  "Generate a rune table deterministically. Returns [table world']."
+  [world]
+  (let [w (det/with-context world [:runes :gen-table])
+        [shuffled-glyphs w] (det/permute w rune-glyphs)
+        [shuffled-names w] (det/permute w garbled-names)]
+    [(reduce (fn [table i]
+               (let [rune (nth all-runes i)]
+                 (assoc table rune {:glyph (nth shuffled-glyphs i)
+                                    :garbled (nth shuffled-names i)
+                                    :identified false})))
+             {} (range (count all-runes)))
+     w]))
 
 ;; --- Query ---
 
@@ -86,12 +91,19 @@
     (assoc-in rune-table [rune-key :identified] true)
     rune-table))
 
-(defn identify-random-rune [rune-table]
+(defn identify-random-rune
+  "Identify a random unidentified rune deterministically.
+   Returns [updated-table identified-rune-key-or-nil world']."
+  [world rune-table]
   (let [unidentified (vec (filter (fn [[k v]] (not (:identified v))) rune-table))]
     (if (empty? unidentified)
-      [rune-table nil]
-      (let [[rune-key _] (nth unidentified (rand-int (count unidentified)))]
-        [(identify-rune rune-table rune-key) rune-key]))))
+      [rune-table nil world]
+      (let [w-ctx (det/with-context world [:runes :identify-random])
+            pair (det/int-in w-ctx 0 (count unidentified))
+            idx (first pair)
+            w' (second pair)
+            [rune-key _] (nth unidentified idx)]
+        [(identify-rune rune-table rune-key) rune-key w']))))
 
 ;; --- Parser ---
 ;; Compiles flat rune sequence to pipeline steps.

--- a/xsofy/sound.lg
+++ b/xsofy/sound.lg
@@ -1,5 +1,6 @@
 (ns xsofy.sound
   (:require [xsofy.util :as u]
+            [xsofy.det :as det]
             [math]))
 
 ;; --- Sound System ---
@@ -84,12 +85,20 @@
        :msg-far  (or (:far d) nil)}
       (death-cry pos who))))
 
-(defn creature-idle [pos who sounds]
+(defn creature-idle-det
+  "Deterministic creature idle sound. Returns [sound-or-nil world']."
+  [world creature-id pos who sounds]
   (let [options (:idle sounds)]
-    (when (and options (seq options))
-      (let [pick (nth options (rand-int (count options)))]
-        (when (< (rand-int 100) (or (:chance pick) 5))
-          {:pos pos :radius (or (:radius pick) 10)
-           :msg-near (:near pick)
-           :msg-mid  (:mid pick)
-           :msg-far  (:far pick)})))))
+    (if-not (and options (seq options))
+      [nil world]
+      (let [w (det/with-context world [:fx :creature-idle creature-id])
+            [pick-idx w] (det/int-in w 0 (count options))
+            pick (nth options pick-idx)
+            [hit? w] (det/percent? w (or (:chance pick) 5))]
+        (if hit?
+          [{:pos pos :radius (or (:radius pick) 10)
+            :msg-near (:near pick)
+            :msg-mid  (:mid pick)
+            :msg-far  (:far pick)}
+           w]
+          [nil w])))))

--- a/xsofy/sound.lg
+++ b/xsofy/sound.lg
@@ -82,7 +82,7 @@
       {:pos pos :radius 20
        :msg-near (or (:near d) (str "The " who " dies."))
        :msg-mid  (or (:mid d) "You hear something die.")
-       :msg-far  (or (:far d) nil)}
+       :msg-far  (:far d)}
       (death-cry pos who))))
 
 (defn creature-idle-det

--- a/xsofy/spell.lg
+++ b/xsofy/spell.lg
@@ -114,35 +114,47 @@
 
 ;; --- Effect Primitives (do things at cursors) ---
 
+(defn reduce-cursor-targets
+  "Thread an accumulator through each cursor and the entities targeted there.
+   The accumulator's first slot is the current world so target lookup sees prior updates."
+  [ctx init targets-at-pos step]
+  (reduce
+    (fn [acc pos]
+      (let [world (first acc)
+            targets (targets-at-pos world pos)]
+        (reduce (fn [acc e] (step acc pos e))
+                acc
+                targets)))
+    init
+    (:cursors ctx)))
+
 (defn r-damage [ctx amount]
   (let [[w total new-hits]
-        (reduce
-          (fn [[world total hits] pos]
-            (let [targets (u/targets-at world pos (:caster ctx))]
-              (reduce (fn [[w total hits] e]
-                        (let [armor (get-in e [:body :armor] 0)
-                              actual (max 1 (- amount armor))]
-                          [(ent/damage-entity w (:id e) actual)
-                           (+ total actual)
-                           (conj hits (:id e))]))
-                      [world total hits]
-                      targets)))
+        (reduce-cursor-targets
+          ctx
           [(:world ctx) 0 (:hits ctx)]
-          (:cursors ctx))]
+          (fn [world pos]
+            (u/targets-at world pos (:caster ctx)))
+          (fn [[world total hits] _ e]
+            (let [armor (get-in e [:body :armor] 0)
+                  actual (max 1 (- amount armor))]
+              [(ent/damage-entity world (:id e) actual)
+               (+ total actual)
+               (conj hits (:id e))])))]
     (assoc ctx :world w :result total :hits new-hits)))
 
 (defn r-heal [ctx amount]
-  (let [w (reduce
-            (fn [world pos]
-              (let [targets (u/entities-at world pos)]
-                (reduce (fn [w e]
-                          (let [hp (get-in e [:body :hp] 0)
-                                max-hp (get-in e [:body :max-hp] hp)
-                                new-hp (min max-hp (+ hp amount))]
-                            (assoc-in w [:entities (:id e) :body :hp] new-hp)))
-                        world targets)))
-            (:world ctx)
-            (:cursors ctx))]
+  (let [[w]
+        (reduce-cursor-targets
+          ctx
+          [(:world ctx)]
+          (fn [world pos]
+            (u/entities-at world pos))
+          (fn [[world] _ e]
+            (let [hp (get-in e [:body :hp] 0)
+                  max-hp (get-in e [:body :max-hp] hp)
+                  new-hp (min max-hp (+ hp amount))]
+              [(assoc-in world [:entities (:id e) :body :hp] new-hp)])))]
     (assoc ctx :world w :result amount)))
 
 (defn r-fire
@@ -151,15 +163,16 @@
    (let [power (if (number? power) (max 1 power) 1)
          ttl (+ 3 power)
          burn-ttl (* 12 power)
-         w (reduce
-             (fn [world pos]
-               (let [[x y] pos
-                     world (fire/ignite-forced world x y ttl)
-                     targets (u/targets-at world pos nil)]
-                 (reduce (fn [w e] (status/apply-status w (:id e) :burning burn-ttl))
-                         world targets)))
-             (:world ctx)
-             (:cursors ctx))]
+         [w]
+         (reduce-cursor-targets
+           ctx
+           [(:world ctx)]
+           (fn [world pos]
+             (u/targets-at (fire/ignite-forced world (first pos) (second pos) ttl)
+                           pos nil))
+           (fn [[world] pos e]
+             (let [world (fire/ignite-forced world (first pos) (second pos) ttl)]
+               [(status/apply-status world (:id e) :burning burn-ttl)])))]
      (assoc ctx :world w))))
 
 (defn r-ice
@@ -167,15 +180,16 @@
   ([ctx power]
    (let [power (if (number? power) (max 1 power) 1)
          ttl (* 8 power)
-         w (reduce
-             (fn [world pos]
-               (let [[x y] pos
-                     world (fx/add-stain world x y :water 2)
-                     targets (u/targets-at world pos nil)]
-                 (reduce (fn [w e] (status/apply-status w (:id e) :frozen ttl))
-                         world targets)))
-             (:world ctx)
-             (:cursors ctx))]
+         [w]
+         (reduce-cursor-targets
+           ctx
+           [(:world ctx)]
+           (fn [world pos]
+             (u/targets-at (fx/add-stain world (first pos) (second pos) :water 2)
+                           pos nil))
+           (fn [[world] pos e]
+             (let [world (fx/add-stain world (first pos) (second pos) :water 2)]
+               [(status/apply-status world (:id e) :frozen ttl)])))]
      (assoc ctx :world w))))
 
 ;; Tiles you can be pushed into (walkable + hazards)
@@ -184,37 +198,38 @@
 (defn r-push [ctx]
   (let [origin (:origin ctx)
         {:keys [terrain width height]} (:world ctx)]
-    (let [w (reduce
-              (fn [world pos]
-                (let [targets (u/targets-at world pos (:caster ctx))]
-                  (reduce (fn [w e]
-                            (let [epos (:pos e)]
-                              (if (nil? epos) w
-                                (let [[ex ey] epos
-                                      [ox oy] origin
-                                      dx (- ex ox) dy (- ey oy)
-                                      len (max 1 (math/sqrt (+ (* dx dx) (* dy dy))))
-                                      ndx (int (/ dx len)) ndy (int (/ dy len))
-                                      nx (+ ex ndx) ny (+ ey ndy)
-                                      dest-tile (terrain/tget terrain width nx ny)
-                                      occupant (ent/creature-at w [nx ny])]
-                                  (cond
-                                    ;; occupied: both exchange hits (bump damage)
-                                    (and occupant (not= (:id occupant) (:id e)))
-                                    (let [w (ent/damage-entity w (:id e) 2)
-                                          w (if (get-in w [:entities (:id occupant)])
-                                              (ent/damage-entity w (:id occupant) 2)
-                                              w)]
-                                      w)
-                                    ;; pushable tile (walkable + hazards like lava/chasm/deep water)
-                                    (and (>= nx 0) (< nx width) (>= ny 0) (< ny height)
-                                         (contains? pushable-tiles dest-tile))
-                                    (assoc-in w [:entities (:id e) :pos] [nx ny])
-                                    ;; wall or void — can't push
-                                    :else w)))))
-                          world targets)))
-              (:world ctx)
-              (:cursors ctx))]
+    (let [[w]
+          (reduce-cursor-targets
+            ctx
+            [(:world ctx)]
+            (fn [world pos]
+              (u/targets-at world pos (:caster ctx)))
+            (fn [[world] _ e]
+              (let [epos (:pos e)]
+                (if (nil? epos)
+                  [world]
+                  (let [[ex ey] epos
+                        [ox oy] origin
+                        dx (- ex ox) dy (- ey oy)
+                        len (max 1 (math/sqrt (+ (* dx dx) (* dy dy))))
+                        ndx (int (/ dx len)) ndy (int (/ dy len))
+                        nx (+ ex ndx) ny (+ ey ndy)
+                        dest-tile (terrain/tget terrain width nx ny)
+                        occupant (ent/creature-at world [nx ny])]
+                    (cond
+                      ;; occupied: both exchange hits (bump damage)
+                      (and occupant (not= (:id occupant) (:id e)))
+                      (let [world (ent/damage-entity world (:id e) 2)
+                            world (if (get-in world [:entities (:id occupant)])
+                                    (ent/damage-entity world (:id occupant) 2)
+                                    world)]
+                        [world])
+                      ;; pushable tile (walkable + hazards like lava/chasm/deep water)
+                      (and (>= nx 0) (< nx width) (>= ny 0) (< ny height)
+                           (contains? pushable-tiles dest-tile))
+                      [(assoc-in world [:entities (:id e) :pos] [nx ny])]
+                      ;; wall or void — can't push
+                      :else [world]))))))]
       (assoc ctx :world w))))
 
 (def arc-range 6)

--- a/xsofy/spell.lg
+++ b/xsofy/spell.lg
@@ -115,21 +115,21 @@
 ;; --- Effect Primitives (do things at cursors) ---
 
 (defn r-damage [ctx amount]
-  (let [total (atom 0)
-        new-hits (atom (:hits ctx))
-        w (reduce
-            (fn [world pos]
-              (let [targets (u/targets-at world pos (:caster ctx))]
-                (reduce (fn [w e]
-                          (let [armor (get-in e [:body :armor] 0)
-                                actual (max 1 (- amount armor))]
-                            (swap! total + actual)
-                            (swap! new-hits conj (:id e))
-                            (ent/damage-entity w (:id e) actual)))
-                        world targets)))
-            (:world ctx)
-            (:cursors ctx))]
-    (assoc ctx :world w :result @total :hits @new-hits)))
+  (let [[w total new-hits]
+        (reduce
+          (fn [[world total hits] pos]
+            (let [targets (u/targets-at world pos (:caster ctx))]
+              (reduce (fn [[w total hits] e]
+                        (let [armor (get-in e [:body :armor] 0)
+                              actual (max 1 (- amount armor))]
+                          [(ent/damage-entity w (:id e) actual)
+                           (+ total actual)
+                           (conj hits (:id e))]))
+                      [world total hits]
+                      targets)))
+          [(:world ctx) 0 (:hits ctx)]
+          (:cursors ctx))]
+    (assoc ctx :world w :result total :hits new-hits)))
 
 (defn r-heal [ctx amount]
   (let [w (reduce

--- a/xsofy/terrain.lg
+++ b/xsofy/terrain.lg
@@ -1,4 +1,5 @@
-(ns xsofy.terrain)
+(ns xsofy.terrain
+  (:require [xsofy.det :as det]))
 
 ;; --- Tile Definitions ---
 
@@ -169,27 +170,38 @@
                 (recur (inc head) t (+ size added)))))))))
 
 (defn generate-blob
-  "Generate an organic blob via cellular automata.
-   Returns {:cells int-array :x :y :w :h} of bounding box, or nil if too small."
-  [bw bh seed-pct rounds birth survive min-w min-h]
-  (let [cells (atom (int-array (* bw bh)))]
-    ;; seed with random noise
-    (dotimes [i (* bw bh)]
-      (aset @cells i (if (< (rand-int 100) seed-pct) 1 0)))
-    ;; run CA rounds
+  "Generate an organic blob via cellular automata deterministically.
+   Returns [blob world'] where blob is {:cells int-array :x :y :w :h}
+   of bounding box (or nil if too small)."
+  [world bw bh seed-pct rounds birth survive min-w min-h]
+  (let [w-ctx (det/with-context world [:terrain :blob bw bh seed-pct rounds])
+        sz (* bw bh)
+        arr (int-array sz)
+        cells (atom arr)
+        ;; seed with deterministic noise — loop+recur threads world
+        w-after-seed
+        (loop [i 0 w w-ctx]
+          (if (>= i sz)
+            w
+            (let [p (det/int-in w 0 100)
+                  r (first p)
+                  w' (second p)]
+              (aset @cells i (if (< r seed-pct) 1 0))
+              (recur (inc i) w'))))]
+    ;; run CA rounds (deterministic, no rolls)
     (dotimes [_ rounds]
       (reset! cells (ca-step @cells bw bh birth survive)))
     ;; find largest connected blob via flood fill using array BFS
-    (let [labels (int-array (* bw bh))
+    (let [labels (int-array sz)
           final-cells @cells]
       (loop [label-id 1 best-label 0 best-size 0 y 0 x 0]
         (cond
           (>= y bh)
           ;; done scanning — extract best blob
-          (when (> best-size 0)
+          (if (> best-size 0)
             (let [min-x (atom bw) max-x (atom 0)
                   min-y (atom bh) max-y (atom 0)
-                  result (int-array (* bw bh))]
+                  result (int-array sz)]
               (dotimes [ry bh]
                 (dotimes [rx bw]
                   (when (= (aget labels (+ rx (* ry bw))) best-label)
@@ -200,9 +212,12 @@
                     (when (> ry @max-y) (reset! max-y ry)))))
               (let [rw (inc (- @max-x @min-x))
                     rh (inc (- @max-y @min-y))]
-                (when (and (>= rw min-w) (>= rh min-h))
-                  {:cells result :bw bw :bh bh
-                   :x @min-x :y @min-y :w rw :h rh}))))
+                (if (and (>= rw min-w) (>= rh min-h))
+                  [{:cells result :bw bw :bh bh
+                    :x @min-x :y @min-y :w rw :h rh}
+                   w-after-seed]
+                  [nil w-after-seed])))
+            [nil w-after-seed])
 
           (>= x bw)
           (recur label-id best-label best-size (inc y) 0)
@@ -239,17 +254,26 @@
 ;; --- Cave Rooms ---
 ;; Carve an organic cave shape into the grid at a given position.
 
-(defn carve-cave-room! [grid w h cx cy]
-  "Carve a cave room centered near cx,cy. Returns center point or nil."
-  (let [cave-w (+ 8 (rand-int 10))
-        cave-h (+ 6 (rand-int 6))
-        blob (generate-blob cave-w cave-h 55 5
-                            #{5 6 7 8} #{4 5 6 7 8}
-                            4 3)]
-    (when blob
+(defn carve-cave-room!
+  "Carve a cave room centered near cx,cy deterministically.
+   Returns [center-or-nil world']."
+  [world grid w h cx cy]
+  (let [w-ctx (det/with-context world [:terrain :cave-room cx cy])
+        p1 (det/int-in w-ctx 0 10)
+        cave-w (+ 8 (first p1))
+        w1 (second p1)
+        p2 (det/int-in w1 0 6)
+        cave-h (+ 6 (first p2))
+        w2 (second p2)
+        blob-pair (generate-blob w2 cave-w cave-h 55 5
+                                 #{5 6 7 8} #{4 5 6 7 8}
+                                 4 3)
+        blob (first blob-pair)
+        w3 (second blob-pair)]
+    (if-not blob
+      [nil w3]
       (let [ox (- cx (quot (:w blob) 2))
             oy (- cy (quot (:h blob) 2))
-            ;; collect all carved cells to find true center
             carved (atom [])]
         (dotimes [by (:bh blob)]
           (dotimes [bx (:bw blob)]
@@ -258,10 +282,10 @@
                 (when (in-bounds? w h tx ty)
                   (tset! grid w tx ty 1)
                   (swap! carved conj [tx ty]))))))
-        (when (seq @carved)
-          ;; return the middle cell of all carved positions
+        (if (seq @carved)
           (let [mid (quot (count @carved) 2)]
-            (nth @carved mid)))))))
+            [(nth @carved mid) w3])
+          [nil w3])))))
 
 ;; --- Connectivity Check ---
 ;; Array-based BFS flood fill — no atoms, no allocations in the hot loop.
@@ -322,31 +346,41 @@
 ;; Generate blob-shaped lakes and place them without breaking connectivity.
 
 (defn place-lake!
-  "Place a blob lake of the given type. deep-tile is the interior,
-   shallow-tile (or nil) is the wreath around it.
-   size-class: :small (6-12), :medium (12-22), :large (20-35).
-   Returns true if placed."
-  [grid w h deep-tile shallow-tile wreath-width size-class]
-  (let [[min-w extra-w min-h extra-h] (case (or size-class :medium)
+  "Place a blob lake of the given type deterministically.
+   Returns [placed? world']."
+  [world grid w h deep-tile shallow-tile wreath-width size-class]
+  (let [w-ctx (det/with-context world [:terrain :lake deep-tile size-class])
+        [min-w extra-w min-h extra-h] (case (or size-class :medium)
                                          :small  [6 6 4 4]
                                          :medium [12 10 6 6]
                                          :large  [20 15 10 8])
-        lake-w (+ min-w (rand-int extra-w))
-        lake-h (+ min-h (rand-int extra-h))
-        blob (generate-blob lake-w lake-h 55 5
-                            #{5 6 7 8} #{4 5 6 7 8}
-                            3 3)
+        pw (det/int-in w-ctx 0 extra-w)
+        lake-w (+ min-w (first pw))
+        w1 (second pw)
+        ph (det/int-in w1 0 extra-h)
+        lake-h (+ min-h (first ph))
+        w2 (second ph)
+        blob-pair (generate-blob w2 lake-w lake-h 55 5
+                                 #{5 6 7 8} #{4 5 6 7 8}
+                                 3 3)
+        blob (first blob-pair)
+        w3 (second blob-pair)
         sz (* w h)]
-    (when blob
-      (let [placed (atom false)
-            backup (byte-array sz)
+    (if-not blob
+      [false w3]
+      (let [backup (byte-array sz)
             bcells (:cells blob)
             bbw (:bw blob)
             bbh (:bh blob)]
-        (dotimes [_ 15]
-          (when-not @placed
-            (let [ox (+ 2 (rand-int (max 1 (- w lake-w 4))))
-                  oy (+ 2 (rand-int (max 1 (- h lake-h 4))))
+        (loop [attempt 0 w-cur w3]
+          (if (>= attempt 15)
+            [false w-cur]
+            (let [px-pair (det/int-in w-cur 0 (max 1 (- w lake-w 4)))
+                  ox (+ 2 (first px-pair))
+                  w-after-x (second px-pair)
+                  py-pair (det/int-in w-after-x 0 (max 1 (- h lake-h 4)))
+                  oy (+ 2 (first py-pair))
+                  w-after-y (second py-pair)
                   changed (atom false)]
               ;; save backup
               (dotimes [i sz] (aset backup i (aget grid i)))
@@ -374,62 +408,90 @@
                                   (when (or (= 1 t) (= 2 t))
                                     (aset grid (+ tx (* ty w)) shallow-tile)
                                     (reset! changed true))))))))))))
-              ;; only check connectivity if we actually overwrote walkable tiles
               (if (not @changed)
-                ;; nothing changed, skip (try another position)
-                nil
+                (recur (inc attempt) w-after-y)
                 (if (is-connected? grid w h)
-                  (reset! placed true)
-                  ;; revert
-                  (dotimes [i sz]
-                    (aset grid i (aget backup i))))))))
-        @placed))))
+                  [true w-after-y]
+                  (do (dotimes [i sz] (aset grid i (aget backup i)))
+                      (recur (inc attempt) w-after-y)))))))))))
 
 ;; --- Probability Flood Spread ---
 ;; Brogue-style spreading: start at a point, flood outward with decreasing probability.
 ;; Each wave tries to spread to 4-neighbors at (prob)%, then prob decreases by decrement.
 ;; Produces large organic patches that can fill entire rooms.
 
-(defn spread-feature! [grid w h sx sy tile start-prob decrement allowed-tiles]
-  (let [visited (int-array (* w h))
-        ;; wave 0: seed
-        _ (aset visited (+ sx (* sy w)) 1)
-        wave (atom [[sx sy]])
-        prob (atom start-prob)]
-    (while (and (seq @wave) (> @prob 0))
-      (let [next-wave (atom [])]
-        (doseq [[cx cy] @wave]
-          (doseq [[dx dy] [[1 0] [-1 0] [0 1] [0 -1]]]
-            (let [nx (+ cx dx) ny (+ cy dy)
-                  idx (+ nx (* ny w))]
-              (when (and (in-bounds? w h nx ny)
-                         (= (aget visited idx) 0)
-                         (contains? allowed-tiles (tget grid w nx ny))
-                         (< (rand-int 100) @prob))
-                (aset visited idx 1)
-                (tset! grid w nx ny tile)
-                (swap! next-wave conj [nx ny])))))
-        (reset! wave @next-wave)
-        (swap! prob - decrement)))))
+(defn spread-feature!
+  "Brogue-style probability flood: spread tile out from (sx,sy) into
+   allowed-tiles, with falling probability per wave. Returns world'."
+  [world grid w h sx sy tile start-prob decrement allowed-tiles]
+  (let [w-ctx (det/with-context world [:terrain :spread tile sx sy])
+        visited (int-array (* w h))]
+    (aset visited (+ sx (* sy w)) 1)
+    (loop [wave [[sx sy]]
+           prob start-prob
+           w-cur w-ctx]
+      (if (or (empty? wave) (<= prob 0))
+        w-cur
+        (let [step
+              (loop [pending wave
+                     next-wave []
+                     w-loop w-cur]
+                (if (empty? pending)
+                  [next-wave w-loop]
+                  (let [[cx cy] (first pending)
+                        rest-pending (rest pending)
+                        nbr-step
+                        (loop [dirs [[1 0] [-1 0] [0 1] [0 -1]]
+                               nw next-wave
+                               w-inner w-loop]
+                          (if (empty? dirs)
+                            [nw w-inner]
+                            (let [[dx dy] (first dirs)
+                                  nx (+ cx dx) ny (+ cy dy)
+                                  idx (+ nx (* ny w))]
+                              (if (and (in-bounds? w h nx ny)
+                                       (= (aget visited idx) 0)
+                                       (contains? allowed-tiles (tget grid w nx ny)))
+                                (let [p (det/int-in w-inner 0 100)
+                                      r (first p)
+                                      w-next (second p)]
+                                  (if (< r prob)
+                                    (do (aset visited idx 1)
+                                        (tset! grid w nx ny tile)
+                                        (recur (rest dirs) (conj nw [nx ny]) w-next))
+                                    (recur (rest dirs) nw w-next)))
+                                (recur (rest dirs) nw w-inner)))))]
+                    (recur rest-pending (first nbr-step) (second nbr-step)))))]
+          (recur (first step) (- prob decrement) (second step)))))))
 
 ;; --- Grass Patches ---
 ;; Brogue-style: pick a random floor tile, spread grass from it.
 ;; start-prob 75, decrement 5 = can fill entire rooms.
 
-(defn place-grass-patch! [grid w h]
-  (let [;; find a random floor tile to seed from
-        attempts 30
-        found (atom nil)]
-    (dotimes [_ attempts]
-      (when-not @found
-        (let [x (+ 1 (rand-int (- w 2)))
-              y (+ 1 (rand-int (- h 2)))]
-          (when (= 1 (tget grid w x y))
-            (reset! found [x y])))))
-    (when @found
-      (let [[sx sy] @found]
+(defn place-grass-patch!
+  "Place a grass patch deterministically. Returns world'."
+  [world grid w h]
+  (let [w-ctx (det/with-context world [:terrain :grass])
+        find-result
+        (loop [attempt 0 w-cur w-ctx]
+          (if (>= attempt 30)
+            [nil w-cur]
+            (let [px (det/int-in w-cur 0 (- w 2))
+                  x (+ 1 (first px))
+                  w1 (second px)
+                  py (det/int-in w1 0 (- h 2))
+                  y (+ 1 (first py))
+                  w2 (second py)]
+              (if (= 1 (tget grid w x y))
+                [[x y] w2]
+                (recur (inc attempt) w2)))))
+        found (first find-result)
+        w-after-find (second find-result)]
+    (if-not found
+      w-after-find
+      (let [[sx sy] found]
         (tset! grid w sx sy 2)
-        (spread-feature! grid w h sx sy 2 75 5 #{1})))))
+        (spread-feature! w-after-find grid w h sx sy 2 75 5 #{1})))))
 
 ;; --- Bridge Building ---
 ;; After lakes are placed, scan for bridge opportunities.
@@ -511,35 +573,39 @@
           [@gx @gy @span])))))
 
 (defn build-bridges!
-  "Scan the grid for bridge opportunities. Build bridges that shorten
-   pathing distance by at least 3x the bridge length. Repeat until
-   no more useful bridges found."
-  [grid w h]
-  (let [built-any (atom true)
-        total (atom 0)]
-    (while (and @built-any (< @total 6))
-      (reset! built-any false)
-      ;; shuffle scan order for variety
-      (let [coords (shuffle (for [y (range 1 (dec h)) x (range 1 (dec w))] [x y]))]
-        (doseq [[x y] coords]
-          (when (and (not @built-any) (< @total 6)
-                     (contains? bridge-shore-tiles (tget grid w x y)))
-            ;; try all 4 directions
-            (doseq [[dx dy] [[1 0] [0 1] [-1 0] [0 -1]]]
-              (when (and (not @built-any) (< @total 6))
-                (when-let [[ex ey span] (try-bridge grid w h x y dx dy)]
-                  ;; would this bridge shorten the walk significantly?
-                  (let [detour (walk-distance grid w h x y ex ey (* span 6))]
-                    (when (or (nil? detour)           ;; unreachable = definitely bridge
-                              (> detour (* span 3)))  ;; detour > 3x bridge length
-                      ;; build it
-                      (let [bx (atom (+ x dx)) by (atom (+ y dy))]
-                        (dotimes [_ span]
-                          (tset! grid w @bx @by 17)
-                          (swap! bx + dx)
-                          (swap! by + dy)))
-                      (swap! total inc)
-                      (reset! built-any true))))))))))))
+  "Scan the grid for bridge opportunities deterministically. Build bridges
+   that shorten pathing distance by at least 3x the bridge length. Repeat
+   until no more useful bridges found. Returns world'."
+  [world grid w h]
+  (let [w-ctx (det/with-context world [:terrain :bridges])
+        built-any (atom true)
+        total (atom 0)
+        all-coords (vec (for [y (range 1 (dec h)) x (range 1 (dec w))] [x y]))]
+    ;; outer loop: each pass shuffles scan order and threads world
+    (loop [w-cur w-ctx]
+      (if (or (not @built-any) (>= @total 6))
+        w-cur
+        (let [_ (reset! built-any false)
+              shuf (det/permute w-cur all-coords)
+              coords (first shuf)
+              w-next (second shuf)]
+          (doseq [[x y] coords]
+            (when (and (not @built-any) (< @total 6)
+                       (contains? bridge-shore-tiles (tget grid w x y)))
+              (doseq [[dx dy] [[1 0] [0 1] [-1 0] [0 -1]]]
+                (when (and (not @built-any) (< @total 6))
+                  (when-let [[ex ey span] (try-bridge grid w h x y dx dy)]
+                    (let [detour (walk-distance grid w h x y ex ey (* span 6))]
+                      (when (or (nil? detour)
+                                (> detour (* span 3)))
+                        (let [bx (atom (+ x dx)) by (atom (+ y dy))]
+                          (dotimes [_ span]
+                            (tset! grid w @bx @by 17)
+                            (swap! bx + dx)
+                            (swap! by + dy)))
+                        (swap! total inc)
+                        (reset! built-any true))))))))
+          (recur w-next))))))
 
 ;; --- Room Attachment ---
 ;; After initial rooms are placed, try to grow new rooms from existing walls.
@@ -547,11 +613,17 @@
 
 (def ^:private floor-adj-tiles #{1 2 18})
 
-(defn find-wall-attachment-point [grid w h]
-  "Find a wall tile adjacent to floor on one side and solid wall on the other.
-   Uses reservoir sampling — single scan, O(1) memory, uniform random pick."
-  (let [chosen (atom nil)
-        count (atom 0)]
+(defn find-wall-attachment-point
+  "Find a wall tile adjacent to floor on one side and solid wall on
+   the other, sampled uniformly via reservoir sampling.
+   Returns [chosen-or-nil world'] where chosen is [x y -dx -dy] or nil.
+
+   Two-pass: first collect candidate cells (no rolls), then reservoir-
+   sample over the collected vector with threaded world."
+  [world grid w h]
+  (let [w-ctx (det/with-context world [:terrain :wall-attach])
+        ;; pass 1: collect candidate cells (no rolls)
+        candidates (atom [])]
     (dotimes [y h]
       (dotimes [x w]
         (when (and (in-bounds? w h x y) (= 8 (aget grid (+ x (* y w)))))
@@ -565,177 +637,317 @@
                          (let [rx (+ bx (* (- dx) 2)) ry (+ by (* (- dy) 2))]
                            (and (in-bounds? w h rx ry)
                                 (= 8 (aget grid (+ rx (* ry w)))))))
-                (swap! count inc)
-                ;; reservoir sampling: replace with probability 1/count
-                (when (= 0 (rand-int @count))
-                  (reset! chosen [x y (- dx) (- dy)]))))))))
-    @chosen))
+                (swap! candidates conj [x y (- dx) (- dy)])))))))
+    ;; pass 2: reservoir sample with threaded world
+    (let [cs @candidates
+          n (count cs)]
+      (if (zero? n)
+        [nil w-ctx]
+        (loop [i 0 chosen nil w-cur w-ctx]
+          (if (>= i n)
+            [chosen w-cur]
+            (let [pr (det/int-in w-cur 0 (inc i))
+                  r (first pr)
+                  w-next (second pr)]
+              (recur (inc i)
+                     (if (= r 0) (nth cs i) chosen)
+                     w-next))))))))
 
-(defn attach-room! [grid w h rooms]
-  "Try to attach a new room to an existing wall. Returns new room center or nil."
-  (when-let [[wx wy dx dy] (find-wall-attachment-point grid w h)]
-    ;; carve a room in the direction away from existing floor
-    (let [rw (+ 4 (rand-int 6))
-          rh (+ 3 (rand-int 4))
-          ;; position room based on direction
-          x1 (if (> dx 0) (+ wx 1) (if (< dx 0) (- wx rw) (- wx (quot rw 2))))
-          y1 (if (> dy 0) (+ wy 1) (if (< dy 0) (- wy rh) (- wy (quot rh 2))))
-          x2 (+ x1 rw -1)
-          y2 (+ y1 rh -1)
-          ;; clamp
-          x1 (max 1 x1) y1 (max 1 y1)
-          x2 (min (- w 2) x2) y2 (min (- h 2) y2)]
-      ;; check that area is all wall (no overlap with existing rooms)
-      (let [all-wall (atom true)]
+(defn attach-room!
+  "Try to attach a new room to an existing wall deterministically.
+   Returns [new-center-or-nil world']."
+  [world grid w h rooms]
+  (let [find-result (find-wall-attachment-point world grid w h)
+        anchor (first find-result)
+        w1 (second find-result)]
+    (if-not anchor
+      [nil w1]
+      (let [[wx wy dx dy] anchor
+            ;; rw, rh rolls
+            prw (det/int-in w1 0 6)
+            rw (+ 4 (first prw))
+            w2 (second prw)
+            prh (det/int-in w2 0 4)
+            rh (+ 3 (first prh))
+            w3 (second prh)
+            x1 (if (> dx 0) (+ wx 1) (if (< dx 0) (- wx rw) (- wx (quot rw 2))))
+            y1 (if (> dy 0) (+ wy 1) (if (< dy 0) (- wy rh) (- wy (quot rh 2))))
+            x2 (+ x1 rw -1)
+            y2 (+ y1 rh -1)
+            x1 (max 1 x1) y1 (max 1 y1)
+            x2 (min (- w 2) x2) y2 (min (- h 2) y2)
+            all-wall (atom true)]
         (doseq [ry (range y1 (inc y2))]
           (doseq [rx (range x1 (inc x2))]
             (when (not= 8 (tget grid w rx ry))
               (reset! all-wall false))))
-        (when @all-wall
-          ;; carve it
-          (carve-room! grid w x1 y1 x2 y2)
-          ;; open the wall tile as a door or floor
-          (tset! grid w wx wy (if (< (rand) 0.3) 11 1))
-          (let [cx (quot (+ x1 x2) 2) cy (quot (+ y1 y2) 2)]
+        (if-not @all-wall
+          [nil w3]
+          (let [;; door chance: percent? gives [bool world']
+                pdoor (det/percent? w3 30)
+                is-door (first pdoor)
+                w4 (second pdoor)
+                cx (quot (+ x1 x2) 2)
+                cy (quot (+ y1 y2) 2)]
+            (carve-room! grid w x1 y1 x2 y2)
+            (tset! grid w wx wy (if is-door 11 1))
             (swap! rooms conj [cx cy])
-            [cx cy]))))))
+            [[cx cy] w4]))))))
 
 ;; --- Level Generation ---
 
-(defn ensure-connectivity! [grid w h rooms]
-  "If the map is disconnected, carve extra corridors between room centers
-   until everything is reachable."
-  (let [rs (vec rooms)]
-    (when (> (count rs) 1)
-      (dotimes [attempt 20]
-        (when-not (is-connected? grid w h)
-          ;; pick two random room centers and connect them
-          (let [[x1 y1] (nth rs (rand-int (count rs)))
-                [x2 y2] (nth rs (rand-int (count rs)))]
-            (if (< (rand) 0.5)
-              (do (carve-h-corridor! grid w x1 x2 y1)
-                  (carve-v-corridor! grid w y1 y2 x2))
-              (do (carve-v-corridor! grid w y1 y2 x1)
-                  (carve-h-corridor! grid w x1 x2 y2)))))))))
+(defn ensure-connectivity!
+  "If the map is disconnected, carve extra corridors deterministically
+   between room centers until everything is reachable. Returns world'."
+  [world grid w h rooms]
+  (let [rs (vec rooms)
+        n (count rs)]
+    (if (<= n 1)
+      world
+      (let [w-ctx (det/with-context world [:terrain :ensure-conn])]
+        (loop [attempt 0 w-cur w-ctx]
+          (if (or (>= attempt 20) (is-connected? grid w h))
+            w-cur
+            (let [p1 (det/int-in w-cur 0 n)
+                  i1 (first p1)
+                  w1 (second p1)
+                  p2 (det/int-in w1 0 n)
+                  i2 (first p2)
+                  w2 (second p2)
+                  pd (det/percent? w2 50)
+                  go-h-first (first pd)
+                  w3 (second pd)
+                  [x1 y1] (nth rs i1)
+                  [x2 y2] (nth rs i2)]
+              (if go-h-first
+                (do (carve-h-corridor! grid w x1 x2 y1)
+                    (carve-v-corridor! grid w y1 y2 x2))
+                (do (carve-v-corridor! grid w y1 y2 x1)
+                    (carve-h-corridor! grid w x1 x2 y2)))
+              (recur (inc attempt) w3))))))))
 
 (defn place-room-in-sector!
-  "Place a room (rect or cave) in a given sector of the map."
-  [grid w h rooms sx sy sw sh cave-chance]
-  (let [use-cave (< (rand) cave-chance)
-        ;; pick a point within the sector
-        rx (+ sx 2 (rand-int (max 1 (- sw 5))))
-        ry (+ sy 2 (rand-int (max 1 (- sh 5))))]
+  "Place a room (rect or cave) in a given sector deterministically.
+   Returns world'."
+  [world grid w h rooms sx sy sw sh cave-chance]
+  (let [w-ctx (det/with-context world [:terrain :place-room sx sy])
+        pc (det/percent? w-ctx (int (* 100 cave-chance)))
+        use-cave (first pc)
+        w1 (second pc)
+        prx (det/int-in w1 0 (max 1 (- sw 5)))
+        rx (+ sx 2 (first prx))
+        w2 (second prx)
+        pry (det/int-in w2 0 (max 1 (- sh 5)))
+        ry (+ sy 2 (first pry))
+        w3 (second pry)]
     (if use-cave
-      (when-let [center (carve-cave-room! grid w h rx ry)]
-        (swap! rooms conj center))
-      (let [rw (+ 4 (rand-int 7))
-            rh (+ 3 (rand-int 4))
+      (let [cave-pair (carve-cave-room! w3 grid w h rx ry)
+            center (first cave-pair)
+            w4 (second cave-pair)]
+        (when center (swap! rooms conj center))
+        w4)
+      (let [prw (det/int-in w3 0 7)
+            rw (+ 4 (first prw))
+            w5 (second prw)
+            prh (det/int-in w5 0 4)
+            rh (+ 3 (first prh))
+            w6 (second prh)
             x1 (max 1 (min (- w rw 1) rx))
             y1 (max 1 (min (- h rh 1) ry))
             x2 (min (- w 2) (+ x1 rw -1))
             y2 (min (- h 2) (+ y1 rh -1))]
         (carve-room! grid w x1 y1 x2 y2)
-        (swap! rooms conj [(quot (+ x1 x2) 2) (quot (+ y1 y2) 2)])))))
+        (swap! rooms conj [(quot (+ x1 x2) 2) (quot (+ y1 y2) 2)])
+        w6))))
 
 (defn generate-level
-  ([w h] (generate-level w h 1))
-  ([w h depth]
+  ([w h] (generate-level w h 1 {:seed 0}))
+  ([w h depth] (generate-level w h depth {:seed depth}))
+  ([w h depth world]
   (let [grid (make-terrain w h)
         rooms (atom [])
         cave-chance (min 0.6 (+ 0.25 (* depth 0.05)))
-        ;; divide map into a grid of sectors for even room distribution
         cols 3
         rows 2
         sw (quot w cols)
-        sh (quot h rows)]
+        sh (quot h rows)
+        w0 (det/with-context world [:terrain :level w h depth])
 
-    ;; === Phase 1a: Place 1-2 rooms per sector for even coverage ===
-    (doseq [sy (range rows)]
-      (doseq [sx (range cols)]
-        (let [x0 (* sx sw) y0 (* sy sh)]
-          (place-room-in-sector! grid w h rooms x0 y0 sw sh cave-chance)
-          ;; second room in some sectors
-          (when (< (rand) 0.6)
-            (place-room-in-sector! grid w h rooms x0 y0 sw sh cave-chance)))))
+        ;; === Phase 1a: rooms per sector ===
+        w-phase1a
+        (loop [ys (vec (range rows))
+               w-cur w0]
+          (if (empty? ys)
+            w-cur
+            (let [sy (first ys)
+                  w-row
+                  (loop [xs (vec (range cols))
+                         w-x w-cur]
+                    (if (empty? xs)
+                      w-x
+                      (let [sx (first xs)
+                            x0 (* sx sw) y0 (* sy sh)
+                            w-first (place-room-in-sector! w-x grid w h rooms x0 y0 sw sh cave-chance)
+                            ;; second room: 60% chance
+                            ps (det/percent? w-first 60)
+                            do-second (first ps)
+                            w-after-pct (second ps)
+                            w-after (if do-second
+                                      (place-room-in-sector! w-after-pct grid w h rooms x0 y0 sw sh cave-chance)
+                                      w-after-pct)]
+                        (recur (rest xs) w-after))))]
+              (recur (rest ys) w-row))))
 
-    ;; === Phase 1b: A few more random rooms for variety ===
-    (dotimes [_ (+ 2 (rand-int 3))]
-      (place-room-in-sector! grid w h rooms 0 0 w h cave-chance))
+        ;; === Phase 1b: extra random rooms ===
+        pextra (det/int-in w-phase1a 0 3)
+        n-extra (+ 2 (first pextra))
+        w-after-extra-count (second pextra)
+        w-phase1b
+        (loop [i 0 w-cur w-after-extra-count]
+          (if (>= i n-extra)
+            w-cur
+            (recur (inc i)
+                   (place-room-in-sector! w-cur grid w h rooms 0 0 w h cave-chance))))
 
-    ;; === Phase 2: Connect rooms with corridors ===
-    ;; Shuffle rooms so corridors don't always go sector-by-sector
-    (let [shuffled (shuffle @rooms)]
-      (reset! rooms shuffled)
-      (doseq [i (range 1 (count @rooms))]
-        (let [[x1 y1] (nth @rooms (dec i))
-              [x2 y2] (nth @rooms i)]
-          (if (< (rand) 0.5)
-            (do (carve-h-corridor! grid w x1 x2 y1)
-                (carve-v-corridor! grid w y1 y2 x2))
-            (do (carve-v-corridor! grid w y1 y2 x1)
-                (carve-h-corridor! grid w x1 x2 y2))))))
+        ;; === Phase 2: corridors ===
+        shuf (det/permute w-phase1b @rooms)
+        shuffled (first shuf)
+        w-after-shuf (second shuf)
+        _ (reset! rooms shuffled)
+        w-phase2
+        (loop [i 1 w-cur w-after-shuf]
+          (if (>= i (count @rooms))
+            w-cur
+            (let [[x1 y1] (nth @rooms (dec i))
+                  [x2 y2] (nth @rooms i)
+                  pdir (det/percent? w-cur 50)
+                  go-h-first (first pdir)
+                  w-next (second pdir)]
+              (if go-h-first
+                (do (carve-h-corridor! grid w x1 x2 y1)
+                    (carve-v-corridor! grid w y1 y2 x2))
+                (do (carve-v-corridor! grid w y1 y2 x1)
+                    (carve-h-corridor! grid w x1 x2 y2)))
+              (recur (inc i) w-next))))
 
-    ;; === Phase 2b: Attach extra rooms to walls to fill space ===
-    (dotimes [_ 30]
-      (attach-room! grid w h rooms))
+        ;; === Phase 2b: attach extra rooms ===
+        w-phase2b
+        (loop [i 0 w-cur w-phase2]
+          (if (>= i 30)
+            w-cur
+            (let [r (attach-room! w-cur grid w h rooms)]
+              (recur (inc i) (second r)))))
 
-    ;; === Phase 2c: Ensure connectivity ===
-    (ensure-connectivity! grid w h @rooms)
+        ;; === Phase 2c: ensure connectivity ===
+        w-phase2c (ensure-connectivity! w-phase2b grid w h @rooms)
 
-    ;; === Phase 3: Place doors at corridor junctions (fewer: ~30%) ===
-    (doseq [y (range 1 (dec h))]
-      (doseq [x (range 1 (dec w))]
-        (when (= 1 (tget grid w x y))
-          (let [n (tget grid w x (dec y))
-                s (tget grid w x (inc y))
-                e (tget grid w (inc x) y)
-                wt (tget grid w (dec x) y)
-                h-door (and (= 8 n) (= 8 s) (= 1 e) (= 1 wt))
-                v-door (and (= 8 e) (= 8 wt) (= 1 n) (= 1 s))]
-            (when (and (or h-door v-door) (< (rand) 0.3))
-              (tset! grid w x y 11))))))
+        ;; === Phase 3: doors at corridor junctions ===
+        w-phase3
+        (loop [y 1 w-cur w-phase2c]
+          (if (>= y (dec h))
+            w-cur
+            (let [w-row
+                  (loop [x 1 w-x w-cur]
+                    (if (>= x (dec w))
+                      w-x
+                      (if (= 1 (tget grid w x y))
+                        (let [n (tget grid w x (dec y))
+                              s (tget grid w x (inc y))
+                              e (tget grid w (inc x) y)
+                              wt (tget grid w (dec x) y)
+                              h-door (and (= 8 n) (= 8 s) (= 1 e) (= 1 wt))
+                              v-door (and (= 8 e) (= 8 wt) (= 1 n) (= 1 s))]
+                          (if (or h-door v-door)
+                            (let [pd (det/percent? w-x 30)
+                                  put-door (first pd)
+                                  w-next (second pd)]
+                              (when put-door (tset! grid w x y 11))
+                              (recur (inc x) w-next))
+                            (recur (inc x) w-x)))
+                        (recur (inc x) w-x))))]
+              (recur (inc y) w-row))))
 
-    ;; === Phase 4: Lakes ===
-    ;; Water lakes — 2 to 3 per level, mix of medium and large
-    (dotimes [_ (+ 2 (rand-int 2))]
-      (place-lake! grid w h 4 3 2
-                   (if (< (rand) 0.4) :large :medium)))
+        ;; === Phase 4: Lakes ===
+        pwlakes (det/int-in w-phase3 0 2)
+        n-water (+ 2 (first pwlakes))
+        w-after-nw (second pwlakes)
+        w-water
+        (loop [i 0 w-cur w-after-nw]
+          (if (>= i n-water)
+            w-cur
+            (let [psize (det/percent? w-cur 40)
+                  big (first psize)
+                  w-after-size (second psize)
+                  lake-pair (place-lake! w-after-size grid w h 4 3 2
+                                         (if big :large :medium))
+                  w-next (second lake-pair)]
+              (recur (inc i) w-next))))
+        ;; Chasm — 60% chance
+        pcham (det/percent? w-water 60)
+        do-cham (first pcham)
+        w-after-cham-roll (second pcham)
+        w-cham
+        (if do-cham
+          (let [psize (det/percent? w-after-cham-roll 50)
+                big (first psize)
+                w-after-size (second psize)
+                lake-pair (place-lake! w-after-size grid w h 6 10 1
+                                       (if big :large :medium))]
+            (second lake-pair))
+          w-after-cham-roll)
+        ;; Lava — depth-gated, 33% chance after depth 4
+        w-lava
+        (if (>= depth 4)
+          (let [pl (det/percent? w-cham 33)
+                do-lava (first pl)
+                w-after-pct (second pl)]
+            (if do-lava
+              (let [lake-pair (place-lake! w-after-pct grid w h 7 nil 0
+                                           (if (>= depth 7) :medium :small))]
+                (second lake-pair))
+              w-after-pct))
+          w-cham)
 
-    ;; Chasm — common, can be very large (Brogue-style, up to 1/3 of level)
-    (when (< (rand) 0.6)
-      (place-lake! grid w h 6 10 1
-                   (if (< (rand) 0.5) :large :medium)))
+        ;; === Phase 5: Grass patches ===
+        pgr (det/int-in w-lava 0 5)
+        n-grass (+ 4 (first pgr))
+        w-after-ng (second pgr)
+        w-grass
+        (loop [i 0 w-cur w-after-ng]
+          (if (>= i n-grass)
+            w-cur
+            (recur (inc i) (place-grass-patch! w-cur grid w h))))
 
-    ;; Lava — scales with depth. Absent on floor 1, rare on 2-3, common on 4+
-    ;; Lava — Brogue style: absent before depth 4, then 33% chance per level
-    (when (>= depth 4)
-      (when (< (rand) 0.33)
-        (place-lake! grid w h 7 nil 0
-                     (if (>= depth 7) :medium :small))))
+        ;; === Phase 6: Bridges — shuffles candidate cells deterministically ===
+        w-bridges (build-bridges! w-grass grid w h)
 
-    ;; === Phase 5: Grass patches — generous, 4-8 patches ===
-    (dotimes [_ (+ 4 (rand-int 5))]
-      (place-grass-patch! grid w h))
+        ;; === Phase 7: Torches on walls — 4% chance per wall ===
+        w-torches
+        (loop [y 1 w-cur w-bridges]
+          (if (>= y (dec h))
+            w-cur
+            (let [w-row
+                  (loop [x 1 w-x w-cur]
+                    (if (>= x (dec w))
+                      w-x
+                      (if (and (= 8 (tget grid w x y))
+                               (let [adj-floor (or (contains? walkable-tiles (tget grid w (inc x) y))
+                                                   (contains? walkable-tiles (tget grid w (dec x) y))
+                                                   (contains? walkable-tiles (tget grid w x (inc y)))
+                                                   (contains? walkable-tiles (tget grid w x (dec y))))]
+                                 adj-floor))
+                        (let [pt (det/percent? w-x 4)
+                              put-torch (first pt)
+                              w-next (second pt)]
+                          (when put-torch (tset! grid w x y 9))
+                          (recur (inc x) w-next))
+                        (recur (inc x) w-x))))]
+              (recur (inc y) w-row))))
 
-    ;; === Phase 6: Build bridges across chasms/water ===
-    (build-bridges! grid w h)
+        ;; === Phase 8: Stairs (no rolls) ===
+        [sx sy] (first @rooms)
+        [ex ey] (last @rooms)
+        _ (tset! grid w sx sy 14)
+        _ (tset! grid w ex ey 13)]
 
-    ;; === Phase 7: Torches on walls ===
-    (doseq [y (range 1 (dec h))]
-      (doseq [x (range 1 (dec w))]
-        (when (and (= 8 (tget grid w x y))
-                   (< (rand) 0.04))
-          (let [adj-floor (or (contains? walkable-tiles (tget grid w (inc x) y))
-                              (contains? walkable-tiles (tget grid w (dec x) y))
-                              (contains? walkable-tiles (tget grid w x (inc y)))
-                              (contains? walkable-tiles (tget grid w x (dec y))))]
-            (when adj-floor
-              (tset! grid w x y 9))))))
-
-    ;; === Phase 8: Stairs ===
-    (let [[sx sy] (first @rooms)
-          [ex ey] (last @rooms)]
-      (tset! grid w sx sy 14)
-      (tset! grid w ex ey 13))
-
-    {:grid grid :rooms @rooms})))
+    [{:grid grid :rooms @rooms} w-torches])))

--- a/xsofy/test/det_test.lg
+++ b/xsofy/test/det_test.lg
@@ -1,0 +1,306 @@
+(ns xsofy.test.det-test
+  "Tests for xsofy.det — deterministic randomness via hash-chain over world :seed.
+
+   The new API: every helper returns [value world'] where world' has :seed
+   advanced. Callers thread world. No salt-key parameter; the operation
+   signature + args ARE what gets folded into the chain."
+  (:require [test :refer [deftest is testing]]
+            [xsofy.check :as c]
+            [xsofy.det :as d]))
+
+;; Helper: extract value from a [value world'] tuple (let-go's chained
+;; vector destructure has been finicky; first/second is reliable).
+(defn- v [r] (first r))
+(defn- w [r] (second r))
+
+;; ============================================================================
+;; advance — the primitive
+;; ============================================================================
+
+(deftest advance-is-deterministic
+  (testing "Same (world, contextual) yields same advanced :seed"
+    (is (= (:seed (d/advance {:seed 42} [:foo]))
+           (:seed (d/advance {:seed 42} [:foo]))))))
+
+(deftest advance-mutates-seed
+  (testing "Advanced :seed differs from input :seed (under any non-trivial contextual)"
+    (is (not= 42 (:seed (d/advance {:seed 42} [:foo]))))))
+
+(deftest advance-context-sensitivity
+  (testing "Different contextuals give different advanced seeds"
+    (is (not= (:seed (d/advance {:seed 42} [:foo]))
+              (:seed (d/advance {:seed 42} [:bar]))))))
+
+(deftest advance-seed-sensitivity
+  (testing "Different starting seeds give different advanced seeds"
+    (is (not= (:seed (d/advance {:seed 1} [:foo]))
+              (:seed (d/advance {:seed 2} [:foo]))))))
+
+(deftest advance-defaults-missing-seed-to-zero
+  (testing "Missing :seed is treated as 0"
+    (is (= (:seed (d/advance {:seed 0} [:foo]))
+           (:seed (d/advance {} [:foo]))))))
+
+;; ============================================================================
+;; with-context — alias for advance, expresses intent
+;; ============================================================================
+
+(deftest with-context-equals-advance
+  (testing "with-context is functionally equivalent to advance"
+    (is (= (d/advance {:seed 7} [:phase :rooms])
+           (d/with-context {:seed 7} [:phase :rooms])))))
+
+;; ============================================================================
+;; int-in — determinism, range, threading
+;; ============================================================================
+
+(deftest int-in-is-deterministic
+  (testing "Repeated calls with same world yield same value AND same world'"
+    (let [w0 {:seed 42}
+          r1 (d/int-in w0 1 10)
+          r2 (d/int-in w0 1 10)]
+      (is (= (v r1) (v r2)))
+      (is (= (w r1) (w r2))))))
+
+(deftest int-in-advances-seed
+  (testing "Returned world' has different :seed than input"
+    (let [r (d/int-in {:seed 42} 0 100)]
+      (is (not= 42 (:seed (w r)))))))
+
+(deftest int-in-range-correctness
+  (testing "100 samples land in [lo, hi)"
+    (let [lo 3 hi 17]
+      (doseq [i (range 100)]
+        (let [r (d/int-in {:seed i} lo hi)
+              val (v r)]
+          (is (and (>= val lo) (< val hi))
+              (str "out of range: " val " for seed " i)))))))
+
+(deftest int-in-degenerate-range
+  (testing "hi <= lo returns [lo world-unchanged]"
+    (let [w0 {:seed 1}
+          r5 (d/int-in w0 5 5)
+          r10 (d/int-in w0 10 5)]
+      (is (= 5 (v r5)))
+      (is (= w0 (w r5)) "world unchanged when range collapses")
+      (is (= 10 (v r10)))
+      (is (= w0 (w r10))))))
+
+(deftest int-in-consecutive-calls-differ
+  (testing "Two consecutive rolls in the same chain produce different values"
+    (let [r1 (d/int-in {:seed 42} 0 1000000)
+          r2 (d/int-in (w r1) 0 1000000)]
+      (is (not= (v r1) (v r2))))))
+
+;; ============================================================================
+;; pick — pick from coll
+;; ============================================================================
+
+(deftest pick-is-deterministic
+  (testing "Repeated calls return same element AND same advanced world"
+    (let [w0 {:seed 7} coll [:a :b :c :d :e]
+          r1 (d/pick w0 coll)
+          r2 (d/pick w0 coll)]
+      (is (= (v r1) (v r2)))
+      (is (= (w r1) (w r2))))))
+
+(deftest pick-empty-returns-nil
+  (testing "Empty collection yields [nil world-unchanged]"
+    (let [w0 {:seed 1}
+          r (d/pick w0 [])]
+      (is (nil? (v r)))
+      (is (= w0 (w r))))))
+
+(deftest pick-result-is-member
+  (testing "Result is always an element of the input"
+    (let [coll [:a :b :c :d :e]]
+      (doseq [i (range 50)]
+        (is (contains? (set coll) (v (d/pick {:seed i} coll)))
+            (str "non-member result for seed " i))))))
+
+;; ============================================================================
+;; permute — preserves the multiset
+;; ============================================================================
+
+(deftest permute-preserves-multiset
+  (testing "Set of permuted elements equals set of input; count unchanged"
+    (let [coll [1 2 3 4 5 6 7 8 9 10]]
+      (doseq [i (range 20)]
+        (let [shuffled (v (d/permute {:seed i} coll))]
+          (is (= (set coll) (set shuffled)))
+          (is (= (count coll) (count shuffled))))))))
+
+(deftest permute-preserves-frequencies
+  (testing "Frequency map preserved (multiset, not just set)"
+    (let [coll [:a :a :b :b :b :c]]
+      (doseq [i (range 10)]
+        (let [shuffled (v (d/permute {:seed i} coll))]
+          (is (= (frequencies coll) (frequencies shuffled))))))))
+
+(deftest permute-empty-and-singleton
+  (testing "Edge cases: empty and single-element collections"
+    (let [w0 {:seed 1}
+          r0 (d/permute w0 [])
+          r1 (d/permute w0 [:x])]
+      (is (= [] (v r0)))
+      (is (= w0 (w r0)) "empty input doesn't advance seed")
+      (is (= [:x] (v r1)))
+      (is (= w0 (w r1)) "singleton doesn't advance seed"))))
+
+(deftest permute-produces-distinct-orderings
+  (testing "Across many seeds, permute yields multiple distinct orderings"
+    (let [coll [1 2 3 4 5]
+          perms (set (map (fn [i] (v (d/permute {:seed i} coll)))
+                          (range 20)))]
+      (is (>= (count perms) 10)))))
+
+;; ============================================================================
+;; percent?
+;; ============================================================================
+
+(deftest percent?-is-deterministic
+  (testing "Repeated calls return same boolean and same world"
+    (let [w0 {:seed 7}
+          r1 (d/percent? w0 30)
+          r2 (d/percent? w0 30)]
+      (is (= (v r1) (v r2)))
+      (is (= (w r1) (w r2))))))
+
+(deftest percent?-calibration
+  (testing "Over 1000 trials at chance=30, hit ratio is roughly 0.3"
+    (let [trials 1000
+          chance 30
+          hits (count (filter (fn [i] (v (d/percent? {:seed i} chance)))
+                              (range trials)))
+          ratio (/ hits (clojure.core/double trials))]
+      (is (and (> ratio 0.25) (< ratio 0.35))
+          (str "expected ~0.3, got " ratio " (" hits "/" trials ")")))))
+
+(deftest percent?-extremes
+  (testing "chance=0 always false; chance=100 always true"
+    (doseq [i (range 50)]
+      (is (false? (v (d/percent? {:seed i} 0))))
+      (is (true? (v (d/percent? {:seed i} 100)))))))
+
+;; ============================================================================
+;; unit — float in [0, 1)
+;; ============================================================================
+
+(deftest unit-is-deterministic
+  (testing "Repeated calls return same float and same world"
+    (let [w0 {:seed 7}
+          r1 (d/unit w0)
+          r2 (d/unit w0)]
+      (is (= (v r1) (v r2)))
+      (is (= (w r1) (w r2))))))
+
+(deftest unit-range-correctness
+  (testing "100 samples all land in [0.0, 1.0)"
+    (doseq [i (range 100)]
+      (let [val (v (d/unit {:seed i}))]
+        (is (and (>= val 0.0) (< val 1.0))
+            (str "out of range: " val " for seed " i))))))
+
+;; ============================================================================
+;; next-id — counter increment (independent of seed chain)
+;; ============================================================================
+
+(deftest next-id-increments
+  (testing "Consecutive calls produce different ids and grow :next-id"
+    (let [r1 (d/next-id {} :rat)
+          r2 (d/next-id (w r1) :rat)
+          r3 (d/next-id (w r2) :rat)]
+      (is (= :rat-1 (v r1)))
+      (is (= :rat-2 (v r2)))
+      (is (= :rat-3 (v r3)))
+      (is (= 1 (:next-id (w r1))))
+      (is (= 2 (:next-id (w r2))))
+      (is (= 3 (:next-id (w r3)))))))
+
+(deftest next-id-prefix-determines-name
+  (testing "The prefix keyword becomes the id name's prefix"
+    (is (= :goblin-1 (v (d/next-id {} :goblin))))))
+
+(deftest next-id-preserves-other-world-keys
+  (testing "next-id only touches :next-id, leaves everything else alone"
+    (let [w0 {:seed 42 :other :value :nested {:a 1}}
+          r (d/next-id w0 :rat)
+          w' (w r)]
+      (is (= 42 (:seed w')))
+      (is (= :value (:other w')))
+      (is (= {:a 1} (:nested w'))))))
+
+(deftest next-id-does-not-advance-seed
+  (testing "next-id is purely counter-based; :seed is untouched"
+    (let [w0 {:seed 42}
+          r (d/next-id w0 :rat)
+          w' (w r)]
+      (is (= 42 (:seed w'))))))
+
+;; ============================================================================
+;; Threading — chained calls produce a coherent sequence
+;; ============================================================================
+
+(deftest chained-calls-produce-distinct-values
+  (testing "Five rolls in sequence produce five different values"
+    (let [r1 (d/int-in {:seed 1} 0 1000000)
+          r2 (d/int-in (w r1) 0 1000000)
+          r3 (d/int-in (w r2) 0 1000000)
+          r4 (d/int-in (w r3) 0 1000000)
+          r5 (d/int-in (w r4) 0 1000000)
+          vals [(v r1) (v r2) (v r3) (v r4) (v r5)]]
+      (is (= 5 (count (set vals)))))))
+
+(deftest mixed-helpers-thread-cleanly
+  (testing "int-in then unit then pick then percent? all reading the same world chain"
+    (let [r1 (d/int-in {:seed 1} 0 100)
+          r2 (d/unit (w r1))
+          r3 (d/pick (w r2) [:a :b :c])
+          r4 (d/percent? (w r3) 50)]
+      ;; Just verify no error and final world is fully-advanced
+      (is (not= 1 (:seed (w r4))))
+      (is (number? (v r1)))
+      (is (number? (v r2)))
+      (is (keyword? (v r3)))
+      (is (boolean? (v r4))))))
+
+;; ============================================================================
+;; with-context — refactor stability anchor
+;; ============================================================================
+
+(deftest with-context-changes-downstream-rolls
+  (testing "Anchoring with a context changes the values of subsequent rolls"
+    (let [w0 {:seed 42}
+          ;; Without context
+          r-plain (d/int-in w0 0 1000000)
+          ;; With context first
+          r-anchored (d/int-in (d/with-context w0 [:my-phase]) 0 1000000)]
+      (is (not= (v r-plain) (v r-anchored))))))
+
+;; ============================================================================
+;; Property tests
+;; ============================================================================
+
+(def gen-seed (c/gen-int 0 1000000))
+(def gen-span (c/gen-int 1 1000))
+
+(c/defprop int-in-stays-in-range
+  [seed gen-seed
+   lo (c/gen-int -10000 10000)
+   span gen-span]
+  (let [hi (+ lo span)
+        val (v (d/int-in {:seed seed} lo hi))]
+    (and (>= val lo) (< val hi))))
+
+(c/defprop unit-stays-in-unit-interval
+  [seed gen-seed]
+  (let [val (v (d/unit {:seed seed}))]
+    (and (>= val 0.0) (< val 1.0))))
+
+(c/defprop permute-preserves-count
+  [seed gen-seed
+   n (c/gen-int 0 12)]
+  (let [coll (vec (range n))
+        shuffled (v (d/permute {:seed seed} coll))]
+    (and (= (count coll) (count shuffled))
+         (= (set coll) (set shuffled)))))

--- a/xsofy/test/run.lg
+++ b/xsofy/test/run.lg
@@ -7,6 +7,7 @@
             [xsofy.test.world-prop]
             [xsofy.test.combat-prop]
             [xsofy.test.hash-test]
-            [xsofy.test.det-test]))
+            [xsofy.test.det-test]
+            [xsofy.test.world-seed-test]))
 
 (run-tests)

--- a/xsofy/test/run.lg
+++ b/xsofy/test/run.lg
@@ -6,6 +6,7 @@
             [xsofy.test.spell-prop]
             [xsofy.test.world-prop]
             [xsofy.test.combat-prop]
-            [xsofy.test.hash-test]))
+            [xsofy.test.hash-test]
+            [xsofy.test.det-test]))
 
 (run-tests)

--- a/xsofy/test/spell_prop.lg
+++ b/xsofy/test/spell_prop.lg
@@ -147,13 +147,17 @@
 
 (c/defprop format-sexp-doesnt-leak-internal-shape
   [tokens gen-raw-program]
-  (let [tbl (runes/generate-rune-table)
+  (let [world (g/minimal-stone-room)
+        rune-pair (runes/generate-rune-table world)
+        tbl (first rune-pair)
         s (runes/format-sexp tbl tokens)]
     (not (looks-like-internal-map? s))))
 
 (c/defprop format-glyphs-doesnt-leak-internal-shape
   [tokens gen-raw-program]
-  (let [tbl (runes/generate-rune-table)
+  (let [world (g/minimal-stone-room)
+        rune-pair (runes/generate-rune-table world)
+        tbl (first rune-pair)
         s (runes/format-glyphs tbl tokens)]
     (not (looks-like-internal-map? s))))
 
@@ -185,7 +189,9 @@
   (testing "Inscribing :add (which needs two numeric args) with no args
             produces a parser error. The player-facing format-sexp output
             must not include the internal {:reason ... :error true} map."
-    (let [tbl (runes/generate-rune-table)
+    (let [world (g/minimal-stone-room)
+          rune-pair (runes/generate-rune-table world)
+          tbl (first rune-pair)
           ;; Same shape as the player's screenshot: a selector then a
           ;; math rune that consumes nothing.
           s (runes/format-sexp tbl [:nearest :add])]

--- a/xsofy/test/world_seed_test.lg
+++ b/xsofy/test/world_seed_test.lg
@@ -1,0 +1,66 @@
+(ns xsofy.test.world-seed-test
+  "Determinism test: same seed yields same world generation outcome.
+   This is the integration test that locks down PR3's threading
+   contract — if any caller drops a thread or order shifts, the
+   golden values change."
+  (:require [test :refer [deftest is testing]]
+            [xsofy.items :as items]
+            [xsofy.det :as d]))
+
+(deftest items-roll-floor-loot-is-deterministic
+  (testing "Same seed → same items"
+    (let [w0 {:seed 42}
+          r1 (items/roll-floor-loot w0 3)
+          r2 (items/roll-floor-loot w0 3)
+          items1 (first r1)
+          items2 (first r2)]
+      (is (= items1 items2)))))
+
+(deftest items-roll-floor-loot-advances-seed
+  (testing "Two consecutive floor rolls give different items (chain advances)"
+    (let [w0 {:seed 42}
+          r1 (items/roll-floor-loot w0 3)
+          items1 (first r1)
+          w1 (second r1)
+          r2 (items/roll-floor-loot w1 3)
+          items2 (first r2)]
+      (is (not= items1 items2)))))
+
+(deftest items-roll-floor-loot-depth-matters
+  (testing "Same seed, different depth → different items"
+    (let [w0 {:seed 42}
+          items-d1 (first (items/roll-floor-loot w0 1))
+          items-d5 (first (items/roll-floor-loot w0 5))]
+      (is (not= items-d1 items-d5)))))
+
+(deftest items-random-loot-is-deterministic
+  (testing "Same seed → same template"
+    (let [w0 {:seed 100}
+          t1 (first (items/random-loot w0 3))
+          t2 (first (items/random-loot w0 3))]
+      (is (= t1 t2)))))
+
+(deftest items-roll-enchant-is-deterministic
+  (testing "Same world + depth + slot → same enchant"
+    (let [w0 {:seed 7}
+          e1 (first (items/roll-enchant w0 3 0))
+          e2 (first (items/roll-enchant w0 3 0))]
+      (is (= e1 e2)))))
+
+(deftest items-roll-enchant-slot-sensitivity
+  (testing "Different slots produce at least a few distinct enchants"
+    (let [w0 {:seed 7}
+          enchants (set (map (fn [slot]
+                               (first (items/roll-enchant w0 3 slot)))
+                             (range 20)))]
+      ;; over 20 slots we should see at least 3 distinct enchant values
+      (is (>= (count enchants) 3)
+          (str "expected >=3 distinct enchants, got " (count enchants))))))
+
+(deftest items-roll-enchant-range
+  (testing "Enchant always in [-3, 5]"
+    (doseq [seed (range 50)]
+      (doseq [depth [1 3 5 10 20]]
+        (let [e (first (items/roll-enchant {:seed seed} depth 0))]
+          (is (and (>= e -3) (<= e 5))
+              (str "out of range: " e " for seed " seed " depth " depth)))))))

--- a/xsofy/test/world_seed_test.lg
+++ b/xsofy/test/world_seed_test.lg
@@ -1,10 +1,10 @@
 (ns xsofy.test.world-seed-test
   "Determinism test: same seed yields same world generation outcome.
-   This is the integration test that locks down PR3's threading
-   contract — if any caller drops a thread or order shifts, the
-   golden values change."
+   Locks down PR3 + PR3b's threading contracts — if any caller drops
+   a thread or order shifts, the golden values change."
   (:require [test :refer [deftest is testing]]
             [xsofy.items :as items]
+            [xsofy.terrain :as terrain]
             [xsofy.det :as d]))
 
 (deftest items-roll-floor-loot-is-deterministic
@@ -64,3 +64,45 @@
         (let [e (first (items/roll-enchant {:seed seed} depth 0))]
           (is (and (>= e -3) (<= e 5))
               (str "out of range: " e " for seed " seed " depth " depth)))))))
+
+;; ============================================================================
+;; End-to-end terrain determinism — locks PR3b's contract
+;; ============================================================================
+
+(deftest terrain-generation-is-deterministic
+  (testing "Same seed → same terrain grid"
+    (let [w 40 h 15 depth 1
+          r1 (terrain/generate-level w h depth {:seed 42})
+          r2 (terrain/generate-level w h depth {:seed 42})
+          g1 (:grid (first r1))
+          g2 (:grid (first r2))
+          n (* w h)
+          equal (loop [i 0]
+                  (if (>= i n) true
+                    (if (= (aget g1 i) (aget g2 i))
+                      (recur (inc i))
+                      false)))]
+      (is equal))))
+
+(deftest terrain-different-seeds-differ
+  (testing "Different seeds yield substantially different terrain"
+    (let [w 40 h 15 depth 1
+          r1 (terrain/generate-level w h depth {:seed 1})
+          r2 (terrain/generate-level w h depth {:seed 2})
+          g1 (:grid (first r1))
+          g2 (:grid (first r2))
+          n (* w h)
+          diffs (loop [i 0 c 0]
+                  (if (>= i n) c
+                    (recur (inc i)
+                           (if (= (aget g1 i) (aget g2 i)) c (inc c)))))]
+      (is (>= diffs (quot n 10))
+          (str "expected >=" (quot n 10) " differing cells, got " diffs)))))
+
+(deftest terrain-advances-seed
+  (testing "Two consecutive calls produce different output seeds"
+    (let [r1 (terrain/generate-level 40 15 1 {:seed 42})
+          r2 (terrain/generate-level 40 15 1 (second r1))
+          s1 (:seed (second r1))
+          s2 (:seed (second r2))]
+      (is (not= s1 s2)))))

--- a/xsofy/test/world_seed_test.lg
+++ b/xsofy/test/world_seed_test.lg
@@ -5,6 +5,7 @@
   (:require [test :refer [deftest is testing]]
             [xsofy.items :as items]
             [xsofy.terrain :as terrain]
+            [xsofy.world :as world]
             [xsofy.det :as d]))
 
 (deftest items-roll-floor-loot-is-deterministic
@@ -106,3 +107,63 @@
           s1 (:seed (second r1))
           s2 (:seed (second r2))]
       (is (not= s1 s2)))))
+
+;; ============================================================================
+;; Replay determinism — locks down the full-stack contract
+;;
+;; A replay is two runs of (make-world + a fixed action sequence) starting
+;; from identical state. If the engine is fully deterministic, both runs
+;; end in the same observable state.
+;;
+;; Today this passes for movement-only sequences (PR3+PR3b made worldgen
+;; deterministic) but fails as soon as combat/blood/projectile rolls fire,
+;; because those still use clojure.core/rand. The failure points at
+;; exactly which gameplay rolls need migrating to det/*.
+;; ============================================================================
+
+(defn- run-actions [world actions]
+  (reduce (fn [wrld act] (world/update-world wrld act))
+          world
+          actions))
+
+(defn- project
+  "Reduce world to comparable state for replay equality."
+  [w]
+  {:pos    (get-in w [:entities :player :pos])
+   :hp     (get-in w [:entities :player :body :hp])
+   :turn   (:turn w)
+   :seed   (:seed w)
+   :n-ents (count (:entities w))
+   :log-n  (count (:log w))})
+
+(deftest replay-movement-only-is-deterministic
+  (testing "Same starting world + same movement-only actions → same end state"
+    ;; Wandering with no combat trigger should be fully deterministic
+    ;; today, because all worldgen rolls thread :seed and player-move
+    ;; itself only consumes rolls when fighting an entity.
+    (let [actions [:up :down :left :right :wait :up-left :down-right :wait :wait :left]
+          w1 (run-actions (world/make-world 30 20) actions)
+          w2 (run-actions (world/make-world 30 20) actions)]
+      (is (= (project w1) (project w2))))))
+
+;; Long fuzzing run: with the same seed, longer sequences that bump into
+;; creatures and trigger combat rolls.
+;;
+;; Currently EXPECTED TO FAIL. The failure is the point — it confirms
+;; gameplay rolls (combat hit, blood splatter, projectile accuracy, drop
+;; chance, drift) are still on clojure.core/rand. Once those migrate to
+;; det/*, this test should pass and lock the contract.
+;;
+;; PR4 migrated all gameplay-time rolls to det/* and reset the global
+;; id-counter at make-world. This test is now the permanent end-to-end
+;; determinism lockdown: same seed + same action sequence → identical state.
+(deftest replay-long-sequence-is-deterministic
+  (testing "Long replay including combat — full-stack determinism contract"
+    (let [base [:up :right :down :right :up-left :wait :down-right :left]
+          actions (apply concat (repeat 5 base))
+          w1 (run-actions (world/make-world 30 20) actions)
+          w2 (run-actions (world/make-world 30 20) actions)]
+      (is (= (project w1) (project w2))
+          (str "REPLAY DIVERGED — non-determinism leak in gameplay rolls:\n"
+               "  w1=" (project w1) "\n"
+               "  w2=" (project w2))))))

--- a/xsofy/world.lg
+++ b/xsofy/world.lg
@@ -145,28 +145,31 @@
 
 (defn generate-floor [w h depth player]
   (dbg/log "generate-floor" w h "depth:" depth)
-  (let [{:keys [grid rooms]} (terrain/generate-level w h depth)
+  (let [;; seed up front; terrain consumes & advances it deterministically
+        initial-world {:seed depth}
+        terrain-result (terrain/generate-level w h depth initial-world)
+        {:keys [grid rooms]} (first terrain-result)
+        world-after-terrain (second terrain-result)
         [px py] (first rooms)]
     (dbg/log "  rooms:" (count rooms) "player-pos:" [px py])
     (let [lights (light/collect-terrain-lights grid w h)
-          ;; world carries an explicit per-floor seed so worldgen rolls
-          ;; are reproducible. depth alone disambiguates floors; if a
-          ;; caller wants a different seed it can pass in a player with
-          ;; :base-seed (not currently used).
-          world {:terrain grid
-                 :width w
-                 :height h
-                 :seed depth
-                 :entities {:player (assoc player :pos [px py])}
-                 :fov #{}
-                 :memory {}
-                 :lights lights
-                 :stains {}
-                 :gases {}
-                 :log []
-                 :turn 0
-                 :depth depth
-                 :running true}
+          ;; merge gameplay fields onto the terrain-advanced world.
+          ;; :seed from world-after-terrain is preserved (assoc doesn't drop existing keys
+          ;; we don't override).
+          world (assoc world-after-terrain
+                       :terrain grid
+                       :width w
+                       :height h
+                       :entities {:player (assoc player :pos [px py])}
+                       :fov #{}
+                       :memory {}
+                       :lights lights
+                       :stains {}
+                       :gases {}
+                       :log []
+                       :turn 0
+                       :depth depth
+                       :running true)
           world (det/with-context world [:worldgen :floor depth])]
       (dbg/log "  populating rooms")
       (let [;; spawn creatures per room (each call returns world')

--- a/xsofy/world.lg
+++ b/xsofy/world.lg
@@ -398,33 +398,38 @@
 (defn bfs-path [world goal-fn]
   (let [{:keys [terrain width height]} world
         [px py] (get-in world [:entities :player :pos])
-        start [px py]
-        visited (atom #{start})
-        queue (atom [[start nil]])
-        found (atom nil)
-        steps (atom 0)]
-    (loop []
-      (when (and (seq @queue) (nil? @found) (< @steps 3000))
-        (swap! steps inc)
-        (let [[pos first-dir] (first @queue)]
-          (swap! queue #(subvec % 1))
-          (let [[cx cy] pos]
-            (doseq [[dx dy] [[0 -1] [0 1] [-1 0] [1 0]]]
-              (when (nil? @found)
-                (let [nx (+ cx dx) ny (+ cy dy)
-                      npos [nx ny]
-                      tile (terrain/tget terrain width nx ny)]
-                  (when (and (>= nx 0) (< nx width) (>= ny 0) (< ny height)
-                             (not (contains? @visited npos))
-                             (or (terrain/walkable? terrain width height nx ny)
-                                 (= tile 11)))
-                    (swap! visited conj npos)
-                    (let [step-dir (or first-dir [dx dy])]
-                      (if (goal-fn npos tile)
-                        (reset! found step-dir)
-                        (swap! queue conj [npos step-dir]))))))))
-          (recur))))
-    @found))
+        start [px py]]
+    (loop [visited #{start}
+           queue [[start nil]]
+           found nil
+           steps 0]
+      (if (or (empty? queue) found (>= steps 3000))
+        found
+        (let [[pos first-dir] (first queue)
+              queue (subvec queue 1)
+              [cx cy] pos
+              state (reduce (fn [[visited queue found] [dx dy]]
+                              (if found
+                                [visited queue found]
+                                (let [nx (+ cx dx) ny (+ cy dy)
+                                      npos [nx ny]
+                                      tile (terrain/tget terrain width nx ny)]
+                                  (if (and (>= nx 0) (< nx width) (>= ny 0) (< ny height)
+                                           (not (contains? visited npos))
+                                           (or (terrain/walkable? terrain width height nx ny)
+                                               (= tile 11)))
+                                    (let [visited (conj visited npos)
+                                          step-dir (or first-dir [dx dy])]
+                                      (if (goal-fn npos tile)
+                                        [visited queue step-dir]
+                                        [visited (conj queue [npos step-dir]) found]))
+                                    [visited queue found]))))
+                            [visited queue found]
+                            [[0 -1] [0 1] [-1 0] [1 0]])]
+          (recur (first state)
+                 (second state)
+                 (nth state 2)
+                 (inc steps)))))))
 
 (defn route-to-tile [world tile-type]
   (let [memory (or (:memory world) {})
@@ -718,24 +723,26 @@
         dx (math/abs (- x2 x1))
         dy (- (math/abs (- y2 y1)))
         sx (if (< x1 x2) 1 -1)
-        sy (if (< y1 y2) 1 -1)
-        err (atom (+ dx dy))
-        cx (atom x1)
-        cy (atom y1)
-        clear (atom true)]
-    (while (and @clear (not (and (= @cx x2) (= @cy y2))))
-      (let [e2 (* 2 @err)]
-        (when (>= e2 dy)
-          (swap! err + dy)
-          (swap! cx + sx))
-        (when (<= e2 dx)
-          (swap! err + dx)
-          (swap! cy + sy)))
-      ;; check intermediate tiles (not start or end)
-      (when (and @clear (not (and (= @cx x2) (= @cy y2))))
-        (when-not (terrain/transparent? terrain width height @cx @cy)
-          (reset! clear false))))
-    @clear))
+        sy (if (< y1 y2) 1 -1)]
+    (loop [err (+ dx dy)
+           cx x1
+           cy y1
+           clear true]
+      (if (or (not clear) (and (= cx x2) (= cy y2)))
+        clear
+        (let [e2 (* 2 err)
+              [err cx] (if (>= e2 dy)
+                         [(+ err dy) (+ cx sx)]
+                         [err cx])
+              [err cy] (if (<= e2 dx)
+                         [(+ err dx) (+ cy sy)]
+                         [err cy])
+              ;; check intermediate tiles (not start or end)
+              clear (if (and (not (and (= cx x2) (= cy y2)))
+                             (not (terrain/transparent? terrain width height cx cy)))
+                      false
+                      clear)]
+          (recur err cx cy clear))))))
 
 ;; --- Ranged Attack ---
 

--- a/xsofy/world.lg
+++ b/xsofy/world.lg
@@ -445,10 +445,10 @@
       (log-msg world "You haven't seen any stairs yet."))))
 
 (defn autoexplore-step [world]
+  (doseq [[k v] (or (:entities world) {})]
+    (when-not (map? v)
+      (dbg/log "BAD ENTITY:" k "=" v)))
   (let [memory (or (:memory world) {})
-        _ (doseq [[k v] (or (:entities world) {})]
-            (when-not (map? v)
-              (dbg/log "BAD ENTITY:" k "=" v)))
         ents (vec (filter (fn [e] (and (some? e) (map? e))) (vals (or (:entities world) {}))))
         floor-items (set (reduce (fn [acc e]
                                    (if (and (:pos e) (= :item (:entity-type e)))

--- a/xsofy/world.lg
+++ b/xsofy/world.lg
@@ -12,6 +12,7 @@
             [xsofy.runes :as runes]
             [xsofy.status :as status]
             [xsofy.items :as items]
+            [xsofy.det :as det]
             [xsofy.debug :as dbg]
             [xsofy.bestiary]
             [xsofy.title :as title]
@@ -48,62 +49,81 @@
    ;; deep dungeon
    {:species :dragon         :peak 9  :spread 1.5  :weight 2}])
 
-(defn pick-creature [depth]
-  "Pick a creature using depth-weighted random selection."
-  (let [weighted (mapv (fn [e]
+(defn pick-creature
+  "Pick a creature deterministically using depth-weighted random selection.
+   Returns [species world']."
+  [world depth]
+  (let [world (det/with-context world [:worldgen :pick-creature depth])
+        weighted (mapv (fn [e]
                          (assoc e :eff-weight
                                 (* (:weight e)
                                    (depth-freq depth (:peak e) (:spread e)))))
                        creature-table)
         total (reduce (fn [s e] (+ s (:eff-weight e))) 0.0 weighted)
-        roll (* (rand) total)]
+        [u world'] (det/unit world)
+        roll (* u total)]
     (loop [remaining weighted acc 0.0]
       (if (empty? remaining)
-        :goblin  ;; fallback
+        [:goblin world']  ;; fallback
         (let [e (first remaining)
               acc (+ acc (:eff-weight e))]
           (if (>= acc roll)
-            (:species e)
+            [(:species e) world']
             (recur (rest remaining) acc)))))))
 
-(defn populate-room-creatures [world room-center grid tw th depth]
-  "Spawn creatures in a room using depth-curved selection."
-  (let [num-creatures (rand-int 3)
-        [rx ry] room-center]
-    (loop [world world n num-creatures]
-      (if (<= n 0) world
-        (let [species (pick-creature depth)
-              ox (+ rx (- (rand-int 5) 2))
-              oy (+ ry (- (rand-int 5) 2))]
+(defn populate-room-creatures
+  "Spawn creatures in a room using depth-curved deterministic selection. Returns world'."
+  [world room-center grid tw th depth]
+  (let [[rx ry] room-center
+        w (det/with-context world [:worldgen :populate-creatures depth rx ry])
+        [num-creatures w] (det/int-in w 0 3)]
+    (loop [w w n num-creatures]
+      (if (<= n 0) w
+        (let [[species w] (pick-creature w depth)
+              [ox-roll w] (det/int-in w 0 5)
+              [oy-roll w] (det/int-in w 0 5)
+              ox (+ rx (- ox-roll 2))
+              oy (+ ry (- oy-roll 2))]
           (if (and (>= ox 0) (< ox tw) (>= oy 0) (< oy th)
                    (terrain/walkable? grid tw th ox oy)
-                   (nil? (ent/creature-at world [ox oy])))
-            (recur (ent/spawn world species [ox oy]) (dec n))
-            (recur world (dec n))))))))
+                   (nil? (ent/creature-at w [ox oy])))
+            (recur (ent/spawn w species [ox oy]) (dec n))
+            (recur w (dec n))))))))
 
-(defn find-spawn-pos [grid tw th rx ry]
-  "Find a walkable position near (rx,ry) for item placement."
-  (loop [attempts 5]
-    (when (> attempts 0)
-      (let [ox (+ rx (- (rand-int 5) 2))
-            oy (+ ry (- (rand-int 5) 2))]
-        (if (and (>= ox 0) (< ox tw) (>= oy 0) (< oy th)
-                 (terrain/walkable? grid tw th ox oy))
-          [ox oy]
-          (recur (dec attempts)))))))
+(defn find-spawn-pos
+  "Find a walkable position near (rx,ry) deterministically.
+   Returns [[ox oy] world'] on success, [nil world'] on failure."
+  [world grid tw th rx ry]
+  (let [w (det/with-context world [:worldgen :find-spawn rx ry])]
+    (loop [attempts 5 w w]
+      (if (<= attempts 0)
+        [nil w]
+        (let [[ox-roll w] (det/int-in w 0 5)
+              [oy-roll w] (det/int-in w 0 5)
+              ox (+ rx (- ox-roll 2))
+              oy (+ ry (- oy-roll 2))]
+          (if (and (>= ox 0) (< ox tw) (>= oy 0) (< oy th)
+                   (terrain/walkable? grid tw th ox oy))
+            [[ox oy] w]
+            (recur (dec attempts) w)))))))
 
-(defn distribute-loot [world loot-bag rooms grid tw th]
-  "Distribute a bag of loot descriptors across rooms (skip first room = player start)."
+(defn distribute-loot
+  "Distribute a bag of loot descriptors across rooms deterministically
+   (skip first room = player start). Returns world'."
+  [world loot-bag rooms grid tw th]
   (let [target-rooms (vec (rest rooms))
         num-rooms (count target-rooms)]
     (if (or (empty? loot-bag) (= 0 num-rooms))
       world
-      (reduce (fn [w descriptor]
-                (let [[rx ry] (nth target-rooms (rand-int num-rooms))]
-                  (if-let [pos (find-spawn-pos grid tw th rx ry)]
-                    (ent/spawn-loot-item w descriptor pos)
-                    w)))
-              world loot-bag))))
+      (let [world (det/with-context world [:worldgen :distribute-loot])]
+        (reduce (fn [w descriptor]
+                  (let [[idx w] (det/int-in w 0 num-rooms)
+                        [rx ry] (nth target-rooms idx)
+                        [pos w] (find-spawn-pos w grid tw th rx ry)]
+                    (if pos
+                      (ent/spawn-loot-item w descriptor pos)
+                      w)))
+                world loot-bag)))))
 
 ;; --- FOV ---
 
@@ -129,9 +149,14 @@
         [px py] (first rooms)]
     (dbg/log "  rooms:" (count rooms) "player-pos:" [px py])
     (let [lights (light/collect-terrain-lights grid w h)
+          ;; world carries an explicit per-floor seed so worldgen rolls
+          ;; are reproducible. depth alone disambiguates floors; if a
+          ;; caller wants a different seed it can pass in a player with
+          ;; :base-seed (not currently used).
           world {:terrain grid
                  :width w
                  :height h
+                 :seed depth
                  :entities {:player (assoc player :pos [px py])}
                  :fov #{}
                  :memory {}
@@ -141,18 +166,19 @@
                  :log []
                  :turn 0
                  :depth depth
-                 :running true}]
+                 :running true}
+          world (det/with-context world [:worldgen :floor depth])]
       (dbg/log "  populating rooms")
-      (let [;; spawn creatures per room
+      (let [;; spawn creatures per room (each call returns world')
             with-creatures (reduce (fn [wrld room]
                                      (dbg/log "    populate room:" room)
                                      (populate-room-creatures wrld room grid w h depth))
                                    world
                                    (rest rooms))
             ;; generate floor loot and distribute across rooms
-            loot-bag (items/roll-floor-loot depth)
+            [loot-bag with-loot-world] (items/roll-floor-loot with-creatures depth)
             _ (dbg/log "  loot bag:" (count loot-bag) "items")
-            with-loot (distribute-loot with-creatures loot-bag rooms grid w h)
+            with-loot (distribute-loot with-loot-world loot-bag rooms grid w h)
             with-rooms (assoc with-loot :rooms-cache rooms)]
         (dbg/log "  rooms populated, running update-fov")
         (let [result (update-fov with-rooms)]
@@ -820,38 +846,45 @@
 
 ;; --- Runestones ---
 
-(defn spawn-runestones [world]
-  "Spawn 1-2 runestones on the floor for unidentified runes."
+(defn spawn-runestones
+  "Spawn 1-2 runestones on the floor for unidentified runes deterministically.
+   Returns world'."
+  [world]
   (let [rune-table (or (:rune-table world) {})
         unidentified (runes/undiscovered-runes rune-table)
         {:keys [terrain width height]} world
-        rooms (:rooms-cache world)
-        num-stones (if (seq unidentified) (+ 1 (rand-int 2)) 0)]
+        rooms (:rooms-cache world)]
     (if (or (empty? unidentified) (nil? rooms))
       world
-      (loop [w world n num-stones remaining (shuffle unidentified)]
-        (if (or (<= n 0) (empty? remaining))
-          w
-          (let [rune-info (first remaining)
-                rune-key (:rune rune-info)
-                ;; pick a random room (not the first = player start)
-                target-rooms (vec (rest rooms))
-                room (when (seq target-rooms)
-                       (nth target-rooms (rand-int (count target-rooms))))
-                [rx ry] (or room [5 5])
-                pos (find-spawn-pos terrain width height rx ry)]
-            (if pos
-              (let [id (ent/next-id :runestone)
-                    template (get @ent/templates :runestone)
-                    glyph (:glyph rune-info)
-                    instance (-> template
-                                 (assoc :id id
-                                        :template :runestone
-                                        :pos pos
-                                        :rune-key rune-key
-                                        :item-name (str "runestone " (or glyph "?"))))]
-                (recur (assoc-in w [:entities id] instance) (dec n) (rest remaining)))
-              (recur w (dec n) (rest remaining)))))))))
+      (let [w (det/with-context world [:worldgen :spawn-runestones])
+            [num-roll w] (det/int-in w 0 2)
+            num-stones (+ 1 num-roll)
+            [shuffled w] (det/permute w unidentified)
+            target-rooms (vec (rest rooms))
+            num-target-rooms (count target-rooms)]
+        (loop [w w n num-stones remaining shuffled]
+          (if (or (<= n 0) (empty? remaining))
+            w
+            (let [rune-info (first remaining)
+                  rune-key (:rune rune-info)
+                  [room w] (if (zero? num-target-rooms)
+                             [[5 5] w]
+                             (let [[idx w] (det/int-in w 0 num-target-rooms)]
+                               [(nth target-rooms idx) w]))
+                  [rx ry] room
+                  [pos w] (find-spawn-pos w terrain width height rx ry)]
+              (if pos
+                (let [id (ent/next-id :runestone)
+                      template (get @ent/templates :runestone)
+                      glyph (:glyph rune-info)
+                      instance (-> template
+                                   (assoc :id id
+                                          :template :runestone
+                                          :pos pos
+                                          :rune-key rune-key
+                                          :item-name (str "runestone " (or glyph "?"))))]
+                  (recur (assoc-in w [:entities id] instance) (dec n) (rest remaining)))
+                (recur w (dec n) (rest remaining))))))))))
 
 (defn consume-runestone [world item]
   "Consume a runestone, identifying its rune. Returns updated world."

--- a/xsofy/world.lg
+++ b/xsofy/world.lg
@@ -200,7 +200,9 @@
 
 (defn give-item [world item-type owner-id]
   "Spawn an item and put it in owner's inventory. Returns [world item-id]."
-  (let [id (ent/next-id item-type)
+  (let [id-pair (ent/next-id world item-type)
+        id (first id-pair)
+        world (second id-pair)
         template (get @ent/templates item-type)
         item (assoc template :id id :template item-type :pos [0 0])
         w (assoc-in world [:entities id] item)
@@ -217,11 +219,6 @@
     w))
 
 (defn make-world [w h]
-  ;; Reset the entity ID counter so replays generate identical IDs.
-  ;; ent/id-counter is a global atom; if we don't reset, IDs drift across
-  ;; runs and break replay equality. Long-term fix: thread world's :next-id
-  ;; via det/next-id and remove the global counter. For now, reset suffices.
-  (reset! ent/id-counter 0)
   (let [world (generate-floor w h 1 (make-player))
         rune-pair (runes/generate-rune-table world)
         rune-table (first rune-pair)
@@ -900,7 +897,7 @@
                   [rx ry] room
                   [pos w] (find-spawn-pos w terrain width height rx ry)]
               (if pos
-                (let [id (ent/next-id :runestone)
+                (let [[id w] (ent/next-id w :runestone)
                       template (get @ent/templates :runestone)
                       glyph (:glyph rune-info)
                       instance (-> template

--- a/xsofy/world.lg
+++ b/xsofy/world.lg
@@ -217,10 +217,18 @@
     w))
 
 (defn make-world [w h]
-  (let [world (generate-floor w h 1 (make-player))]
+  ;; Reset the entity ID counter so replays generate identical IDs.
+  ;; ent/id-counter is a global atom; if we don't reset, IDs drift across
+  ;; runs and break replay equality. Long-term fix: thread world's :next-id
+  ;; via det/next-id and remove the global counter. For now, reset suffices.
+  (reset! ent/id-counter 0)
+  (let [world (generate-floor w h 1 (make-player))
+        rune-pair (runes/generate-rune-table world)
+        rune-table (first rune-pair)
+        world (second rune-pair)]
     (-> world
         give-starting-items
-        (assoc :floors {} :gold 0 :rune-table (runes/generate-rune-table))
+        (assoc :floors {} :gold 0 :rune-table rune-table)
         spawn-runestones)))
 
 ;; --- Floor Transition ---
@@ -337,24 +345,32 @@
     world))
 
 (defn splatter-blood [world x y dmg hp-before killed]
-  "Blood scales with overkill. Light hits = maybe a drop. Overkill = splat."
-  (if killed
-    (let [overkill (- dmg hp-before)]  ;; how much damage beyond lethal
-      (cond
-        ;; massive overkill (double+ the hp) — big splat
-        (> overkill hp-before)
-        (fx/blood-puddle world x y)
-        ;; moderate overkill — small puddle
-        (> overkill 0)
-        (let [w (fx/add-stain world x y :blood 3)]
-          (if (< (rand-int 3) 2) (fx/blood-drop w x y) w))
-        ;; just barely killed — center blood only
-        :else
-        (fx/add-stain world x y :blood 2)))
-    ;; not killed — small chance of a drop on big hits
-    (if (and (> dmg 5) (< (rand-int 6) 1))
-      (fx/blood-drop world x y)
-      world)))
+  "Blood scales with overkill deterministically. Light hits = maybe a drop.
+   Overkill = splat. Threads world through fx-det calls + det rolls."
+  (let [w-ctx (det/with-context world [:fx :splatter x y])]
+    (if killed
+      (let [overkill (- dmg hp-before)]
+        (cond
+          ;; massive overkill (double+ the hp) — big splat
+          (> overkill hp-before)
+          (fx/blood-puddle-det w-ctx x y)
+          ;; moderate overkill — small puddle + maybe drop
+          (> overkill 0)
+          (let [w (fx/add-stain w-ctx x y :blood 3)
+                pair (det/int-in w 0 3)
+                drip? (< (first pair) 2)
+                w' (second pair)]
+            (if drip? (fx/blood-drop-det w' x y) w'))
+          ;; just barely killed — center blood only
+          :else
+          (fx/add-stain w-ctx x y :blood 2)))
+      ;; not killed — small chance of a drop on big hits
+      (if (> dmg 5)
+        (let [pair (det/int-in w-ctx 0 6)
+              drip? (< (first pair) 1)
+              w' (second pair)]
+          (if drip? (fx/blood-drop-det w' x y) w'))
+        world))))
 
 ;; --- Message Log ---
 
@@ -619,7 +635,9 @@
         target (get-in world [:entities target-id])]
     (if (or (nil? attacker) (nil? target))
       world
-      (let [result (combat/resolve-attack world attacker-id target-id)
+      (let [ra-pair (combat/resolve-attack-det world attacker-id target-id)
+            result (first ra-pair)
+            world (second ra-pair)
             atk-name (entity-name attacker)
             def-name (entity-name target)]
         (if (nil? result)
@@ -777,8 +795,13 @@
         accuracy (or (:accuracy opts) 80)]
     (let [hit-result (first-entity-on-path world flight-path launcher-id)
           hit-entity (when hit-result (first hit-result))
-          ;; accuracy roll — can miss even if projectile reaches target
-          did-hit (and hit-entity (< (rand-int 100) accuracy))
+          ;; accuracy roll — only fires when there's an entity in path
+          hit-pair (if hit-entity
+                     (det/percent? (det/with-context world [:projectile launcher-id])
+                                   accuracy)
+                     [false world])
+          did-hit (first hit-pair)
+          world (second hit-pair)
           actual-path (if hit-result (second hit-result) flight-path)
           landed-pos (last actual-path)
           hit-pos (if hit-entity (:pos hit-entity) landed-pos)]
@@ -972,7 +995,10 @@
           (assoc :screen :quick-menu :menu-action :enchant :enchant-scroll-id item-id))
 
       :identify
-      (let [[new-table rune-key] (runes/identify-random-rune (or (:rune-table world) {}))]
+      (let [tr (runes/identify-random-rune world (or (:rune-table world) {}))
+            new-table (first tr)
+            rune-key (second tr)
+            world (nth tr 2)]
         (if rune-key
           (-> world
               (assoc :rune-table new-table)
@@ -1103,7 +1129,9 @@
                       (let [e (get-in w [:entities creature-id])
                             ename (let [k (or (:template e) (:id e))]
                                     (if k (name k) "???"))
-                            s (when e (snd/creature-idle (:pos e) ename (:sounds e)))]
+                            [s w] (if e
+                                    (snd/creature-idle-det w creature-id (:pos e) ename (:sounds e))
+                                    [nil w])]
                         (if s (snd/deliver-sound w s) w))
                       w)
                   w (ai/ai-act w creature-id melee-attack ranged-attack)
@@ -1204,7 +1232,9 @@
                 (if-not (has-clear-line? world px py tx ty)
                   (log-msg world "No clear line of fire.")
                   ;; resolve damage using combat system
-                  (let [result (combat/resolve-attack world :player (:id target))
+                  (let [ra-pair (combat/resolve-attack-det world :player (:id target))
+                        result (first ra-pair)
+                        world (second ra-pair)
                         dmg (if (and result (:hit result)) (:damage result) 0)
                         speed (or (get-in wep [:item :speed]) 100)]
                     (if (and result (not (:hit result)))
@@ -1245,20 +1275,28 @@
                                             " for " dmg "."))))))))))))))))
 
 (defn swim-drop-item [world]
-  "While swimming, 15% chance to lose an item from inventory each move."
-  (if (< (rand-int 100) 15)
-    (let [inv (or (get-in world [:entities :player :inventory]) [])
-          equipment (or (get-in world [:entities :player :equipment]) {})
-          equipped-ids (set (filter some? (vals equipment)))
-          droppable (vec (filter #(not (contains? equipped-ids %)) inv))]
-      (if (seq droppable)
-        (let [item-id (nth droppable (rand-int (count droppable)))
-              iname (or (get-in world [:entities item-id :item-name])
-                        (name (or (get-in world [:entities item-id :template]) :item)))]
-          (-> (ent/drop-item world item-id :player)
-              (log-msg (str "The " iname " slips from your grasp!"))))
-        world))
-    world))
+  "While swimming, 15% chance to lose an item from inventory each move.
+   Threads world for replay determinism."
+  (let [w-ctx (det/with-context world [:swim-drop])
+        chance-pair (det/percent? w-ctx 15)
+        drop-now (first chance-pair)
+        w-after-chance (second chance-pair)]
+    (if-not drop-now
+      w-after-chance
+      (let [inv (or (get-in w-after-chance [:entities :player :inventory]) [])
+            equipment (or (get-in w-after-chance [:entities :player :equipment]) {})
+            equipped-ids (set (filter some? (vals equipment)))
+            droppable (vec (filter #(not (contains? equipped-ids %)) inv))]
+        (if-not (seq droppable)
+          w-after-chance
+          (let [pick-pair (det/int-in w-after-chance 0 (count droppable))
+                idx (first pick-pair)
+                w-after-pick (second pick-pair)
+                item-id (nth droppable idx)
+                iname (or (get-in w-after-pick [:entities item-id :item-name])
+                          (name (or (get-in w-after-pick [:entities item-id :template]) :item)))]
+            (-> (ent/drop-item w-after-pick item-id :player)
+                (log-msg (str "The " iname " slips from your grasp!")))))))))
 
 (defn check-leave-water [world]
   "Remove swimming status when player is no longer on deep water."
@@ -1273,12 +1311,13 @@
     world))
 
 (defn drift-water-items [world]
-  "Items on deep water drift in a random direction each turn."
+  "Items on deep water drift in a random direction each turn (deterministic)."
   (let [{:keys [terrain width height]} world
         items (->> (vals (:entities world))
                    (filter (fn [e] (and (some? e) (map? e)
                                          (= :item (:entity-type e)) (:pos e))))
-                   (vec))]
+                   (vec))
+        w0 (det/with-context world [:drift-water])]
     (reduce (fn [w item]
               (let [cur (get-in w [:entities (:id item)])]
                 (if (or (nil? cur) (nil? (:pos cur)))
@@ -1286,7 +1325,10 @@
                   (let [[x y] (:pos cur)
                         tile (terrain/tget terrain width x y)]
                     (if (= tile 4)
-                      (let [[dx dy] (nth [[1 0] [-1 0] [0 1] [0 -1]] (rand-int 4))
+                      (let [dir-pair (det/int-in w 0 4)
+                            idx (first dir-pair)
+                            w (second dir-pair)
+                            [dx dy] (nth [[1 0] [-1 0] [0 1] [0 -1]] idx)
                             nx (+ x dx) ny (+ y dy)
                             ntile (terrain/tget terrain width nx ny)]
                         (if (and (>= nx 0) (< nx width) (>= ny 0) (< ny height)
@@ -1295,7 +1337,7 @@
                           (assoc-in w [:entities (:id item) :pos] [nx ny])
                           w))
                       w)))))
-            world items)))
+            w0 items)))
 
 (defn player-move [world dx dy]
   (if-not (get-in world [:entities :player :pos])
@@ -1364,8 +1406,15 @@
                       [(first targets)]
                       targets)]
         (if (seq targets)
-          ;; attack all targets
-          (let [first-result (combat/resolve-attack world :player (:id (first targets)))
+          ;; attack all targets. We peek at the first target's resolution to
+          ;; compute swing-speed before applying. Note: this peek does advance
+          ;; the world's :seed (det/percent? + det/int-in fire), but that's
+          ;; intentional — the peek IS a roll commitment under the deterministic
+          ;; chain. The actual melee-attack below uses a fresh roll (different
+          ;; with-context), so swing speed and actual hit are independent rolls.
+          (let [peek-pair (combat/resolve-attack-det world :player (:id (first targets)))
+                first-result (first peek-pair)
+                world (second peek-pair)
                 speed (if first-result (or (:speed first-result) move-cost) move-cost)
                 ;; attack each target in sequence
                 w (reduce (fn [w tgt]


### PR DESCRIPTION
Implements the agreed-upon "small piece" from #18 (deterministic seeding) — the foundation that makes `same seed → same world → same playthrough` hold. Builds on the pure-Lisp xxh3-64 hash already merged in #27.

## What's in this PR

Per the #18 roadmap (PR1/hash already landed via #27):

- **det helpers** — `xsofy/det.lg` rewritten as pure salted helpers (`det/int-in`, `det/percent?`, `det/permute`, `det/with-context`, …). No monad, no threading ceremony; every call site picks a unique salt like `[:combat :hit attacker-id target-id]`.
- **Deterministic world-gen** — `world/new-deterministic`; `:seed-input` / `:seed-history-hash` / `:seed` set at creation; world-gen + item-gen rolls migrated. Typing a seed now gives the same map.
- **Deterministic terrain** — `terrain.lg` threading migration.
- **Gameplay rolls migrated** — combat, blood, AI, fire, runes, projectile, drops all read `:seed` via `det/`.
- **Seed-derived entity IDs** — removes the global ID counter.

Only sanctioned non-determinism remains, all per your note in #18: title flicker, renderer color jitter, the rune error-sentinel glyph noise, and the property-test harness's own RNG.

## Also included

- **`refactor(spell)`** — extract a `reduce-cursor-targets` helper and route the effect primitives (`r-damage`/`r-heal`/`r-fire`/`r-ice`/`r-push`) through it; remove dead non-deterministic twins in `combat.lg`/`effects.lg` (superseded by the `-det` variants).
- **`docs(spell-dsl v3)`** — records the magic-system / enchantment design direction (cost cascade, discovery leaks, five-role model, container-aware runes, creature-abilities-as-rune-programs). Design notes only; no behavior change.

## Not in this PR (coming next)

The **action dispatcher** (#18 PR5) — `xsofy/dispatch.lg` + game-state wrapper + per-turn `seed' = xxh3-64(seed ⊕ action-bytes)`. Today the `det/` helpers hash-chain the seed per roll; the per-*action* boundary (and with it replay-by-action-log, full-game property tests, and the balance harness) lands with the dispatcher. Drafting it now.

## Testing

`./bin/lg xsofy/test/run.lg` → **214 tests, 1035 assertions, 0 fail, 0 error** (includes the existing render/world_prop suites alongside the new det/hash/world-seed tests).
