### PR TITLE
Remove stale README line count

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The power curve is inverted - early game is desperate survival, late game is app
 
 Meanwhile the dungeon is trying to kill you through more conventional means. Spiders shoot web cones that trap you while goblins close in. Slimes split when you hit them. Trolls regenerate. Set something on fire and it panics, runs through grass, ignites the grass, ignites more creatures - it's fine, everything is fine. Push an ogre into lava. Push a goblin into another goblin. Push yourself into a chasm by accident. Chasms are educational.
 
-Written in ~6900 lines of [let-go](https://github.com/nooga/let-go) - a Clojure dialect on a Go bytecode VM. Persistent data structures all the way down. No dependencies. 6ms startup. Runs natively or [in the browser](https://nooga.github.io/xsofy/) via WASM.
+Written in [let-go](https://github.com/nooga/let-go) - a Clojure dialect on a Go bytecode VM. Persistent data structures all the way down. No dependencies. 6ms startup. Runs natively or [in the browser](https://nooga.github.io/xsofy/) via WASM.
 
 If you like how this game looks check out [Brogue](https://sites.google.com/site/broguegame/) - my main inspiration.
 


### PR DESCRIPTION
## Summary
- remove the stale approximate let-go line count from the README

## Testing
- not run; README-only change