### PR TITLE
Action dispatcher: per-action seed advance + replay (#18)

### DIFF
--- a/main.lg
+++ b/main.lg
@@ -360,7 +360,7 @@
   (let [{:keys [title scheme]} (title/show-title-screen)
         quest (title/generate-quest)
         _ (title/show-descending-screen 1 scheme)]
-    (-> (world/make-world 79 30)
+    (-> (world/make-world 79 30 (rand-int 1000000000))
         (assoc :title title
                :scheme scheme
                :quest-item (:item quest))

--- a/main.lg
+++ b/main.lg
@@ -12,7 +12,8 @@
             [xsofy.ui :as ui]
             [xsofy.runes :as runes]
             [xsofy.title :as title]
-            [xsofy.debug :as dbg]))
+            [xsofy.debug :as dbg]
+            [xsofy.dispatch :as dispatch]))
 
 
 (defn init-terminal []
@@ -497,7 +498,7 @@
                           (:auto-target world) :auto-target-step
                           :else nil)
                key (or auto-key (input/parse-key (term/read-key)))
-               new-world (world/update-world world key)
+               new-world (dispatch/dispatch world key)
                ;; check if auto-mode should stop
                new-world (if (or (:resting new-world) (:running-dir new-world) (:autoexploring new-world) (:auto-target new-world))
                            (let [player (get-in new-world [:entities :player])

--- a/xsofy/det.lg
+++ b/xsofy/det.lg
@@ -54,6 +54,13 @@
   [world context]
   (advance world context))
 
+(defn combine
+  "Pure seed fold: derive a new seed from `seed` and `contextual` without a
+   world. Used to derive construction seeds (e.g. a floor's layout seed from
+   the origin seed + depth) independently of the gameplay chain."
+  [seed contextual]
+  (h/combine seed contextual))
+
 (defn- step
   "Internal: advance world by op-signature, return [seed' world']."
   [world op-signature]

--- a/xsofy/dispatch.lg
+++ b/xsofy/dispatch.lg
@@ -37,3 +37,10 @@
           w'     (world/update-world salted action)]
       (update w' :action-log conj action))
     (world/update-world world action)))
+
+(defn replay
+  "Reconstruct a world by replaying `actions` on a fresh deterministic world
+   built from `seed`. Returns the final world. Because dispatch is pure and
+   the seed chain is reproduced exactly, this equals the original live play."
+  [w h seed actions]
+  (reduce dispatch (world/make-world w h seed) actions))

--- a/xsofy/dispatch.lg
+++ b/xsofy/dispatch.lg
@@ -24,3 +24,16 @@
    descend/ascend, pickup)."
   [action]
   (not (contains? ui-actions action)))
+
+(defn dispatch
+  "Resolve one input action against the world. For replay actions, fold the
+   action into the seed (keyed by the pre-action :turn so the fold is stable),
+   resolve via world/update-world, and append the action to :action-log.
+   UI actions are passed through unchanged. Returns world'."
+  [world action]
+  (if (replay-action? action)
+    (let [turn   (:turn world)
+          salted (det/advance world [:action turn action])
+          w'     (world/update-world salted action)]
+      (update w' :action-log conj action))
+    (world/update-world world action)))

--- a/xsofy/dispatch.lg
+++ b/xsofy/dispatch.lg
@@ -17,13 +17,20 @@
     :equip-menu :unequip-menu :drop-menu :use-menu
     :quit})
 
+(defn action-type
+  "The dispatch key for an action: a bare keyword as-is, or the :type of a
+   parameterized action map (e.g. {:type :use-item :id :potion-7}). Lets the
+   simple keyword path stay simple while a few actions carry a payload."
+  [action]
+  (if (map? action) (:type action) action))
+
 (defn replay-action?
   "True if `action` can mutate world state and must therefore be folded
    into the seed and recorded for replay. Everything that is not a pure-UI
    action qualifies (movement, attacks, wait/rest, fire, autoexplore,
-   descend/ascend, pickup)."
+   descend/ascend, pickup, parameterized actions like :use-item)."
   [action]
-  (not (contains? ui-actions action)))
+  (not (contains? ui-actions (action-type action))))
 
 (defn dispatch
   "Resolve one input action against the world. For replay actions, fold the
@@ -33,7 +40,9 @@
   [world action]
   (if (replay-action? action)
     (let [turn   (:turn world)
-          salted (det/advance world [:action turn action])
+          ;; fold the action TYPE into the seed — encode-salt can't take a map;
+          ;; an action's params are reproduced via the recorded :action-log.
+          salted (det/advance world [:action turn (action-type action)])
           w'     (world/update-world salted action)]
       (update w' :action-log conj action))
     (world/update-world world action)))

--- a/xsofy/dispatch.lg
+++ b/xsofy/dispatch.lg
@@ -1,0 +1,26 @@
+(ns xsofy.dispatch
+  "Single dispatch entry for game turns. Wraps world/update-world to fold
+   the player action into the seed (via det/advance) and record it to the
+   :action-log, so a (seed, action-log) pair replays bit-identically.
+
+   The world carries its own determinism + replay state (:seed, :seed-input,
+   :action-log), consistent with xsofy.det's 'the world IS the state' model.
+   The commit-DAG / game-state wrapper arrives in a later PR; until then the
+   log lives on the world."
+  (:require [xsofy.world :as world]
+            [xsofy.det :as det]))
+
+;; Pure-UI actions: toggle a screen or confirm a dialog. They never mutate
+;; world state, so they are neither folded into the seed nor logged.
+(def ^:private ui-actions
+  #{:messages :help :inventory :rune-codex
+    :equip-menu :unequip-menu :drop-menu :use-menu
+    :quit})
+
+(defn replay-action?
+  "True if `action` can mutate world state and must therefore be folded
+   into the seed and recorded for replay. Everything that is not a pure-UI
+   action qualifies (movement, attacks, wait/rest, fire, autoexplore,
+   descend/ascend, pickup)."
+  [action]
+  (not (contains? ui-actions action)))

--- a/xsofy/test/dispatch_test.lg
+++ b/xsofy/test/dispatch_test.lg
@@ -4,8 +4,7 @@
   (:require [test :refer [deftest is testing]]
             [xsofy.check :as c]
             [xsofy.world :as world]
-            ;; TODO: uncomment when xsofy.dispatch exists (Task 2+)
-            ;; [xsofy.dispatch :as dispatch]
+            [xsofy.dispatch :as dispatch]
             ))
 
 (deftest make-world-is-reproducible
@@ -29,3 +28,17 @@
       (is (not= (vec (:terrain f1))
                 (vec (:terrain (world/generate-floor 79 30 4 player 42))))
           "different depth → different floor"))))
+
+(deftest replay-action-classification
+  (testing "world-mutating actions are replay actions"
+    (is (dispatch/replay-action? :up))
+    (is (dispatch/replay-action? :fire))
+    (is (dispatch/replay-action? :wait))
+    (is (dispatch/replay-action? :descend))
+    (is (dispatch/replay-action? :pickup)))
+  (testing "pure-UI actions are not"
+    (is (not (dispatch/replay-action? :messages)))
+    (is (not (dispatch/replay-action? :inventory)))
+    (is (not (dispatch/replay-action? :help)))
+    (is (not (dispatch/replay-action? :quit)))
+    (is (not (dispatch/replay-action? :equip-menu)))))

--- a/xsofy/test/dispatch_test.lg
+++ b/xsofy/test/dispatch_test.lg
@@ -87,3 +87,14 @@
           (is (= (:seed live) (:seed rep)) (str "seed " seed ": final seed identical"))
           (is (= (:entities live) (:entities rep)) (str "seed " seed ": entity state identical"))
           (is (= (:action-log live) (:action-log rep)) (str "seed " seed ": logs identical")))))))
+
+(deftest map-action-payload
+  (testing "parameterized action maps: dispatch by :type, logged whole, keyword path intact"
+    (let [w0  (world/make-world 79 30 5)
+          pid (first (get-in w0 [:entities :player :inventory]))
+          act {:type :use-item :id pid}]
+      (is (= :use-item (dispatch/action-type act)) "map → its :type")
+      (is (= :up (dispatch/action-type :up)) "keyword → itself")
+      (is (dispatch/replay-action? act) "use-item map is a replay action")
+      (is (not (dispatch/replay-action? {:type :inventory})) "UI-typed map is not")
+      (is (= [act] (:action-log (dispatch/dispatch w0 act))) "full action map logged for replay"))))

--- a/xsofy/test/dispatch_test.lg
+++ b/xsofy/test/dispatch_test.lg
@@ -1,0 +1,31 @@
+(ns xsofy.test.dispatch-test
+  "Tests for xsofy.dispatch — single dispatch entry, per-action seed fold,
+   action logging, and (seed, action-log) replay determinism."
+  (:require [test :refer [deftest is testing]]
+            [xsofy.check :as c]
+            [xsofy.world :as world]
+            ;; TODO: uncomment when xsofy.dispatch exists (Task 2+)
+            ;; [xsofy.dispatch :as dispatch]
+            ))
+
+(deftest make-world-is-reproducible
+  (testing "same seed → identical world; different seed → different world"
+    (let [a (world/make-world 79 30 12345)
+          b (world/make-world 79 30 12345)
+          d (world/make-world 79 30 99999)]
+      (is (= (vec (:terrain a)) (vec (:terrain b))) "terrain byte-arrays have same content")
+      (is (= (:entities a) (:entities b)))
+      (is (= 12345 (:seed-input a)) "origin seed recorded once")
+      (is (= 12345 (:seed a)) "gameplay chain starts at the origin seed")
+      (is (= [] (:action-log a)) "log starts empty")
+      (is (not= (vec (:terrain a)) (vec (:terrain d))) "different seed → different map"))))
+
+(deftest floors-are-path-independent
+  (testing "a floor's layout depends only on (seed-input, depth), not the gameplay chain"
+    (let [player (world/make-player)
+          f1 (world/generate-floor 79 30 3 player 42)
+          f2 (world/generate-floor 79 30 3 player 42)]
+      (is (= (vec (:terrain f1)) (vec (:terrain f2))) "floor 3 of seed 42 is canonical")
+      (is (not= (vec (:terrain f1))
+                (vec (:terrain (world/generate-floor 79 30 4 player 42))))
+          "different depth → different floor"))))

--- a/xsofy/test/dispatch_test.lg
+++ b/xsofy/test/dispatch_test.lg
@@ -42,3 +42,18 @@
     (is (not (dispatch/replay-action? :help)))
     (is (not (dispatch/replay-action? :quit)))
     (is (not (dispatch/replay-action? :equip-menu)))))
+
+(deftest dispatch-folds-and-logs
+  (testing "a replay action advances the seed and is logged"
+    (let [w0 (world/make-world 79 30 7)
+          s0 (:seed w0)
+          w1 (dispatch/dispatch w0 :wait)]
+      (is (not= s0 (:seed w1)) "seed advanced")
+      (is (= [:wait] (:action-log w1)) "action logged")))
+  (testing "a UI action neither advances the seed nor logs"
+    (let [w0 (world/make-world 79 30 7)
+          s0 (:seed w0)
+          w1 (dispatch/dispatch w0 :inventory)]
+      (is (= s0 (:seed w1)) "seed unchanged")
+      (is (= [] (:action-log w1)) "nothing logged")
+      (is (= :inventory (:screen w1)) "screen still toggled"))))

--- a/xsofy/test/dispatch_test.lg
+++ b/xsofy/test/dispatch_test.lg
@@ -57,3 +57,33 @@
       (is (= s0 (:seed w1)) "seed unchanged")
       (is (= [] (:action-log w1)) "nothing logged")
       (is (= :inventory (:screen w1)) "screen still toggled"))))
+
+(deftest replay-reconstructs-identical-world
+  (testing "replaying a recorded log reproduces the live world"
+    (let [w0    (world/make-world 79 30 4242)
+          live  (-> w0
+                    (dispatch/dispatch :wait)
+                    (dispatch/dispatch :right)
+                    (dispatch/dispatch :wait)
+                    (dispatch/dispatch :down))
+          log   (:action-log live)
+          rep   (dispatch/replay 79 30 4242 log)]
+      (is (= (:seed live) (:seed rep)) "final seed identical")
+      (is (= (:entities live) (:entities rep)) "entity state identical")
+      (is (= (:action-log live) (:action-log rep)) "logs identical"))))
+
+;; Replay determinism is a *binary* guarantee (a recorded log either
+;; reconstructs the live world exactly or it doesn't), so a handful of seeds
+;; over a representative action sequence gives full confidence — far cheaper
+;; than a property sweep, where each trial runs two full playthroughs.
+;; Action alphabet excludes menu-driven item use (the :quick-menu path is not
+;; yet routed through dispatch).
+(deftest replay-is-deterministic-across-seeds
+  (testing "for several seeds, replay reconstructs live play exactly"
+    (let [actions [:right :wait :down :fire :left :wait :up :pickup :down-right :wait]]
+      (doseq [seed [1 42 777 123456 999999]]
+        (let [live (reduce dispatch/dispatch (world/make-world 79 30 seed) actions)
+              rep  (dispatch/replay 79 30 seed (:action-log live))]
+          (is (= (:seed live) (:seed rep)) (str "seed " seed ": final seed identical"))
+          (is (= (:entities live) (:entities rep)) (str "seed " seed ": entity state identical"))
+          (is (= (:action-log live) (:action-log rep)) (str "seed " seed ": logs identical")))))))

--- a/xsofy/test/run.lg
+++ b/xsofy/test/run.lg
@@ -8,6 +8,7 @@
             [xsofy.test.combat-prop]
             [xsofy.test.hash-test]
             [xsofy.test.det-test]
-            [xsofy.test.world-seed-test]))
+            [xsofy.test.world-seed-test]
+            [xsofy.test.dispatch-test]))
 
 (run-tests)

--- a/xsofy/test/world_seed_test.lg
+++ b/xsofy/test/world_seed_test.lg
@@ -142,8 +142,8 @@
     ;; today, because all worldgen rolls thread :seed and player-move
     ;; itself only consumes rolls when fighting an entity.
     (let [actions [:up :down :left :right :wait :up-left :down-right :wait :wait :left]
-          w1 (run-actions (world/make-world 30 20) actions)
-          w2 (run-actions (world/make-world 30 20) actions)]
+          w1 (run-actions (world/make-world 30 20 1) actions)
+          w2 (run-actions (world/make-world 30 20 1) actions)]
       (is (= (project w1) (project w2))))))
 
 ;; Long fuzzing run: with the same seed, longer sequences that bump into
@@ -161,8 +161,8 @@
   (testing "Long replay including combat — full-stack determinism contract"
     (let [base [:up :right :down :right :up-left :wait :down-right :left]
           actions (apply concat (repeat 5 base))
-          w1 (run-actions (world/make-world 30 20) actions)
-          w2 (run-actions (world/make-world 30 20) actions)]
+          w1 (run-actions (world/make-world 30 20 1) actions)
+          w2 (run-actions (world/make-world 30 20 1) actions)]
       (is (= (project w1) (project w2))
           (str "REPLAY DIVERGED — non-determinism leak in gameplay rolls:\n"
                "  w1=" (project w1) "\n"

--- a/xsofy/world.lg
+++ b/xsofy/world.lg
@@ -143,10 +143,13 @@
 
 ;; --- World Creation ---
 
-(defn generate-floor [w h depth player]
-  (dbg/log "generate-floor" w h "depth:" depth)
-  (let [;; seed up front; terrain consumes & advances it deterministically
-        initial-world {:seed depth}
+(defn generate-floor [w h depth player seed-input]
+  (dbg/log "generate-floor" w h "depth:" depth "seed-input:" seed-input)
+  (let [;; Floor layout is path-independent: derive a construction seed from
+        ;; the origin seed + depth. terrain/population consume & advance THIS
+        ;; lineage; the caller restores the continuous gameplay :seed afterward.
+        floor-seed (det/combine seed-input [:floor depth])
+        initial-world {:seed floor-seed}
         terrain-result (terrain/generate-level w h depth initial-world)
         {:keys [grid rooms]} (first terrain-result)
         world-after-terrain (second terrain-result)
@@ -218,15 +221,17 @@
         [w _] (give-item w :health-potion :player)]
     w))
 
-(defn make-world [w h]
-  (let [world (generate-floor w h 1 (make-player))
+(defn make-world [w h seed]
+  (let [world (generate-floor w h 1 (make-player) seed)
         rune-pair (runes/generate-rune-table world)
         rune-table (first rune-pair)
         world (second rune-pair)]
     (-> world
         give-starting-items
         (assoc :floors {} :gold 0 :rune-table rune-table)
-        spawn-runestones)))
+        spawn-runestones
+        ;; final step: start the continuous gameplay chain at the origin seed
+        (assoc :seed seed :seed-input seed :action-log []))))
 
 ;; --- Floor Transition ---
 ;; Saves current floor, extracts player + inventory items,
@@ -327,6 +332,9 @@
          :depth depth
          :floors (:floors world)
          :scheme (:scheme world)
+         :seed (:seed world)
+         :seed-input (:seed-input world)
+         :action-log (or (:action-log world) [])
          :running true}
         (inject-player player items nil)
         rebase-creature-ticks)))
@@ -499,7 +507,7 @@
       ;; generate new floor
       (do (title/show-descending-screen new-depth (or (:scheme world) [80 120 220]))
           (let [new-player (assoc player :pos [0 0])  ;; pos set by generate-floor
-                new-world (generate-floor width height new-depth new-player)
+                new-world (generate-floor width height new-depth new-player (:seed-input saved))
                 spawn-pos (get-in new-world [:entities :player :pos])]
             ;; re-inject with proper items
             ;; reset player ticks to 0 so they act first on new floor
@@ -510,9 +518,13 @@
                          :gold (or (:gold saved) 0)
                          :rune-table (:rune-table saved)
                          :floors (:floors saved)
-                         :scheme (:scheme world))
+                         :scheme (:scheme world)
+                         :seed-input (:seed-input saved)
+                         :action-log (or (:action-log saved) []))
                   (inject-player player items spawn-pos)
                   spawn-runestones
+                  ;; final step: continue the gameplay chain from the saved world
+                  (assoc :seed (:seed saved))
                   (log-msg (str "You descend to depth " new-depth ".")))))))))
 
 (defn descend [world]

--- a/xsofy/world.lg
+++ b/xsofy/world.lg
@@ -1567,7 +1567,9 @@
 
 (defn update-world [world action]
   (dbg/snapshot! world "update-world:enter " action)
-  (case action
+  ;; Actions are either a bare keyword (:up, :wait) or a parameterized map
+  ;; ({:type :use-item :id :potion-7}); dispatch on the type either way.
+  (case (if (map? action) (:type action) action)
     :descend (descend world)
     :ascend (ascend world)
     :messages (assoc world :screen :messages)
@@ -1579,7 +1581,8 @@
     :unequip-menu (assoc world :screen :quick-menu :menu-action :unequip)
     :drop-menu (assoc world :screen :quick-menu :menu-action :drop)
     :use-menu (assoc world :screen :quick-menu :menu-action :use)
-    (let [w (case action
+    (let [w (case (if (map? action) (:type action) action)
+              :use-item (use-item world (:id action))
               :fire (fire-bow world)
               :up    (player-move world 0 -1)
               :down  (player-move world 0 1)


### PR DESCRIPTION
Implements the **action dispatcher** — the final piece of the deterministic-seeding "small piece" from #18. Builds on the determinism foundation just merged in #39.

## What this adds

- **Path-independent floors + one-time continuous gameplay seed** (`world.lg`): floor construction derives from `hash(seed-input, [:floor depth])`, so floor N is a pure function of `(origin-seed, depth)` — the same dungeon for a given seed regardless of route (shareable seeds). The gameplay `:seed` is assigned once and evolves as one continuous chain, **restored as the final step after each floor is built** so construction never perturbs it. Fixes a latent per-floor seed-reset bug (`generate-floor` hardcoded `{:seed depth}`; `change-floor` regenerated floors without threading the seed).
- **`xsofy/dispatch.lg`** — single entry point. `dispatch [world action]` classifies the action (`replay-action?` vs pure-UI), folds replay-actions into `:seed` (per-action advance via `det/advance`), routes through `world/update-world`, and records the action to `:action-log`. UI actions pass through untouched.
- **`dispatch/replay [w h seed actions]`** — reconstructs a world from `(seed, action-log)`. This unlocks replayable bug reports, full-game property tests, and the headless balance harness from #18.
- **Game-loop** routes input through `dispatch/dispatch`.

## Tests

`xsofy/test/dispatch_test.lg`: reproducibility, floor path-independence, action classification, fold+log behavior, replay determinism across seeds. Full suite: **220 tests / 1076 assertions / 0 fail / 0 error**.

## Perf

A full randomness-bearing turn (25 entities, NPC AI + fire/effects + all det rolls) measures **~20–25 ms** — comfortably under a ~100 ms interactive budget. (Micro-profiling showed the per-roll cost is `encode-salt`, not the hash; the short-path xxh3-64 is essentially free, so no hash optimization is needed for gameplay.)

## Scope notes / deliberate deviations from the spec's PR5

- **No game-state wrapper yet** — `:action-log` lives on the world; the DAG/wrapper arrives with the commit-DAG PR. YAGNI while the DAG is empty.
- **Actions stay keywords** (already serializable); no action-maps.
- **Evolved `update-world`** rather than adding a parallel `defmulti` (DRY — it already orchestrates the turn).
- **Salt-collision detection obviated** by `det.lg`'s hash-chain (no explicit salt-keys to collide).
- **Menu-driven item use** (`:quick-menu`) isn't routed through dispatch yet — follow-up.
