### PR TITLE
Balance harness + perception layer (recovered, dispatch-adapted)

### DIFF
--- a/docs/balance-harness.md
+++ b/docs/balance-harness.md
@@ -217,6 +217,44 @@ Run `./bin/lg xsofy/test/run.lg` to verify the harness compiles and tests pass.
 ; - Was the loadout unsuitable? (compare other loadouts)
 ```
 
+## Sample Sweep & Findings (2026-05-30)
+
+A 40-run sweep across all 4 loadouts × all 5 policies (`max-turns 250`, `target-depth 5`, `seed 7`), ~20s wall time:
+
+```
+Per-loadout outcomes:                          mean-turns survived
+  starter:                   8 died, 2 stuck       72.0
+  starter-with-damage-rune:  7 died, 3 stuck       80.9
+  heavy-melee:               7 died, 3 stuck       63.5
+  ranged:                    8 died, 2 stuck       75.8
+  (reach-rate 0.0 for all — see note below)
+
+Death by depth:
+  starter:                   depth 1: 6, depth 2: 1, depth 3: 1
+  starter-with-damage-rune:  depth 1: 6, depth 2: 1
+  heavy-melee:               depth 1: 6, depth 2: 1
+  ranged:                    depth 1: 6, depth 2: 2
+
+Death by creature (top killers):
+  starter:                   slime 3, archer 2, rat 2, status/env 1
+  ranged:                    spider 3, slime 2, kobold 1, archer 1, rat 1
+  heavy-melee:               archer 2, slime 2, kobold 1, spider 1, status/env 1
+  starter-with-damage-rune:  kobold 2, rat 2, slime 1, spider 1, status/env 1
+```
+
+Signals worth a look (balance observations, not bugs):
+
+- **The `:damage` rune measurably helps survival** — `starter-with-damage-rune` averaged 80.9 turns vs 72.0 for plain `:starter`.
+- **`:heavy-melee` is the *worst* performer (63.5 mean-turns)** — it dies *faster* than the starter, which is counterintuitive. Likely the long-sword's speed penalty lets creatures land extra hits before the bot swings. Worth checking weapon-speed vs. survivability.
+- **Top early killers:** slimes (all loadouts), spiders (punish `:ranged`), archers (ranged attackers hit everyone). `status/env` = burning/poison or lava/chasm deaths.
+- **`reach-rate = 0.0`** — none of the heuristic bots reach `target-depth 5`. Absolute depth reflects *bot quality + early-game lethality*, so trust the **comparative** numbers (rune vs. no-rune, loadout vs. loadout), not the absolute reach rate.
+
+Harness/agent limitation surfaced by the sweep:
+
+- **`:ensouled` and `:passive-rest` frequently report `:stuck`** (e.g. `:ensouled → stuck (turn 41)` recurs). `:ensouled` emits many non-advancing actions (blocked moves), so the world advances only ~41 turns before the iteration cap. This is a **policy-quality issue in `:ensouled`** (stall / weak pathing), not a harness bug — a candidate for follow-up.
+
+> Reproduce: `(b/explore {:n-runs 40 :loadouts [:starter :starter-with-damage-rune :heavy-melee :ranged] :policies [:greedy-melee :greedy-descend :random :passive-rest :ensouled] :max-turns 250 :target-depth 5 :seed 7})`
+
 ## See Also
 
 - `xsofy/balance.lg` — full harness code

--- a/docs/balance-harness.md
+++ b/docs/balance-harness.md
@@ -1,0 +1,225 @@
+# Balance Harness — Survivability Testing
+
+## Purpose
+
+The balance harness (`xsofy/balance.lg`) is a **statistical evidence generator** for dungeon-game balance tuning. It runs synthetic players through procedurally generated dungeons with various loadouts and AI policies, collecting outcomes (survived, died, where, to what creature, how long) to answer questions like:
+
+- At what depth does a starter loadout (dagger + leather) die?
+- Does a rune inscribed on the dagger meaningfully shift survival curves?
+- Which creatures kill the most players, and at what depth?
+- Does an aggressive melee policy outperform a "rush downstairs" strategy?
+- How does a perception-driven AI compare to heuristic-only policies?
+
+**This is NOT a correctness or property test.** It produces observational data from realistic gameplay, not formal guarantees.
+
+## Loadouts
+
+A loadout specifies the player's starting equipment, armor, and inventory. Supported loadouts (defined in `xsofy/balance.lg`):
+
+- **`:starter`** — Dagger + leather armor + 2 health potions (baseline)
+- **`:starter-with-damage-rune`** — Same, but dagger inscribed with `:damage` rune (7 HP boost per hit)
+- **`:heavy-melee`** — Long sword + chain mail + 3 health potions (slower but more durable)
+- **`:ranged`** — Short bow + arrows + leather + 2 health potions (damage-at-distance test)
+
+Custom loadouts can be added by extending the `all-loadouts` map.
+
+## Policies (AI Behaviors)
+
+Each run is controlled by an AI policy that decides the next action each turn. The harness includes:
+
+- **`:greedy-melee`** — Rush to the nearest visible enemy and attack; if no enemy visible, route to known stairs or autoexplore.
+- **`:greedy-descend`** — Prioritize reaching stairs over combat; only fight if in the way (or on encounter).
+- **`:random`** — Step in a random direction each turn (baseline chaos).
+- **`:passive-rest`** — Stay in place and rest (for measuring passive damage over time, e.g., starvation or status effects).
+- **`:ensouled`** — Perception-driven AI using the `xsofy.percept` layer:
+  - Flees when HP < 30% or burning/frozen
+  - Attacks the highest-threat enemy if in range
+  - Routes to stairs if low on health
+  - Otherwise explores
+
+The `:ensouled` policy demonstrates how a more sophisticated perception and utility-scoring AI can be integrated into the harness. It is a template for future AI experiments.
+
+## How to Run
+
+### From the REPL
+
+```clojure
+(require '[xsofy.balance :as b])
+
+; Quick smoke test (4 runs, should finish in ~10 seconds)
+(def report (b/explore {:n-runs 4 
+                        :loadouts [:starter] 
+                        :policies [:greedy-melee]
+                        :max-turns 200 
+                        :target-depth 3 
+                        :seed 42}))
+(b/print-report report)
+
+; Medium sweep (40 runs across 2 loadouts × 2 policies)
+(def report (b/explore {:n-runs 40
+                        :loadouts [:starter :starter-with-damage-rune]
+                        :policies [:greedy-melee :ensouled]
+                        :max-turns 2000
+                        :target-depth 9
+                        :seed 999}))
+(b/print-report report)
+```
+
+### As a Script
+
+```bash
+lg xsofy/test/balance_explore.lg
+```
+
+The script runs with **small parameters by default** (n-runs=6, max-turns=200, target-depth=3) for quick feedback. See the script (`xsofy/test/balance_explore.lg`) to adjust for longer sweeps.
+
+## Runtime Cost & Warnings
+
+⚠️ **A turn takes ~20–25 ms.** Wall time = n-runs × max-turns × ~0.02 seconds.
+
+Default parameters (n-runs=40, max-turns=2000) = 40 × 2000 × 0.02 = **~27 minutes of continuous computation** with **no progress output**. This is the bug we fixed.
+
+### How to Avoid the Silent 30-Minute Hang
+
+1. **Start small.** Always use small parameters on first run:
+   ```clojure
+   {:n-runs 3 :max-turns 60 :target-depth 3}  ; ~3 seconds
+   ```
+   Watch the progress lines appear in real time (one per completed run).
+
+2. **Estimate before scaling.** If 3 runs × 60 turns = 3.6 seconds, then 40 runs × 2000 turns = ~27 minutes (40/3 × 2000/60 ≈ 450 wall time).
+
+3. **Use `:seed` for reproducibility.** Include a `:seed` in your params so you get the same run sequence every time. Without it, timings vary due to procedural generation differences.
+
+## Reproducibility via Seed + Replay
+
+Each outcome record includes `:seed` (the initial RNG seed for that run) and `:action-log` (the list of actions the policy took). You can **reconstruct any run exactly**:
+
+```clojure
+(require '[xsofy.dispatch :as dispatch])
+
+; Outcome from a previous run
+(def outcome {...
+              :seed 12345
+              :action-log [:autoexplore :autoexplore :up ...]})
+
+; Replay: same seed + same actions = identical world
+(def replayed (dispatch/replay 50 30 (:seed outcome) (:action-log outcome)))
+; replayed has the same :depth, :turn, :entities, :terrain, etc. as the live run
+```
+
+**Use case:** Found an interesting death? Save the outcome, replay it locally for debugging, or feed it to a visualizer.
+
+## Output Format
+
+### Outcome Record
+
+Each run produces an outcome map:
+
+```clojure
+{:loadout :starter
+ :policy :greedy-melee
+ :outcome :died              ; :died | :reached-target | :stuck
+ :turn 127                   ; turns played
+ :depth 3                    ; dungeon depth reached
+ :killed-by :goblin          ; creature that killed player (nil if survived)
+ :hp-final 0                 ; final HP
+ :final-pos [12 8]           ; final position
+ :seed 12345                 ; RNG seed used (for replay)
+ :action-log [...]           ; ordered sequence of actions taken
+}
+```
+
+### Report Structure
+
+`(b/explore opts)` returns:
+
+```clojure
+{:n-runs 40                  ; total runs
+ :by-loadout 
+   {:starter {:died 20, :reached-target 5, :stuck 15}
+    :heavy-melee {:died 8, :reached-target 18, :stuck 14}}
+ :death-by-depth
+   {:starter {1 12, 2 6, 3 2}}
+ :death-by-creature
+   {:starter {:goblin 12, :slime 5, :fire-imp 2}}
+ :mean-turns {:starter 89.4}
+ :reach-rate {:starter 0.125}
+ :outcomes [outcome1 outcome2 ...]}  ; raw outcome records for post-processing
+```
+
+Use `(b/print-report report)` to pretty-print it to stdout, or access fields directly for custom analysis.
+
+## Integration with Percept
+
+The `:ensouled` policy uses `xsofy.percept`, the perception layer. The percept is a structured view of the world from the player's perspective:
+
+```clojure
+(require '[xsofy.percept :as percept])
+
+(def p (percept/perceive world :player))
+; => {:self :player
+;     :turn 5
+;     :depth 1
+;     :threats [{:id :goblin-3, :pos [...], :score 12.0, ...} ...]
+;     :resources {:hp 20, :max-hp 30, :hp-frac 0.67, 
+;                 :inventory {...}, :equipment {...}, ...}
+;     :goals {:stairs-down [[...]], :nearest-stairs-down [...], ...}
+;     :adjacency {[0 -1] {:tile 0, :walkable? true, ...}, ...}
+;     :fov #{[10 12] [10 13] ...}}
+```
+
+Policies can use the full percept or convenience functions like `(percept/in-danger? world :player)` to make context-aware decisions. The harness keeps percept isolated so it doesn't affect reproducibility (it's called at action-decision time, not state mutation time).
+
+## Testing the Harness
+
+The main test suite confirms that:
+- Worlds are deterministic: same seed → identical layout, items, runes
+- Action logs replay exactly: seed + actions → identical final state
+- Outcomes record correctly: loadout/policy/seed/actions are all captured
+
+Run `./bin/lg xsofy/test/run.lg` to verify the harness compiles and tests pass.
+
+## Limitations & Future Work
+
+- **No parallelization yet.** Runs are sequential. For large sweeps (100+ runs), consider batching or async.
+- **Procedural generation variance.** Different seeds produce different floor layouts, creaturecounts, etc. Use large n-runs for statistical confidence.
+- **Policy is stateless.** Policies see the current world and return an action; they have no memory. Future: add agent state (e.g., "remember patrol routes").
+- **No player-AI training loop.** This harness is for testing existing policies, not learning new ones. Future: integrate an optimization loop.
+
+## Example Workflow
+
+```clojure
+; 1. Tune balance: does the damage rune help survival?
+(def report1 (b/explore {:n-runs 40
+                         :loadouts [:starter :starter-with-damage-rune]
+                         :policies [:greedy-melee]
+                         :max-turns 2000
+                         :target-depth 9}))
+(b/print-report report1)
+; => starter: 12 died, 28 reached
+;    starter-with-damage-rune: 8 died, 32 reached
+; Conclusion: damage rune helps (~+14% reach rate).
+
+; 2. Find interesting death: take one outcome
+(def interesting-death (first (filter #(and (= :starter (:loadout %))
+                                            (= :died (:outcome %)))
+                                     (:outcomes report1))))
+
+; 3. Replay it for debugging
+(def replayed-world (dispatch/replay 50 30 (:seed interesting-death) 
+                                    (:action-log interesting-death)))
+(println "Replayed death at depth" (:depth replayed-world))
+
+; 4. Ask follow-up questions
+; - Did the policy make poor choices? (inspect :action-log)
+; - Was the creature too strong? (check :killed-by)
+; - Was the loadout unsuitable? (compare other loadouts)
+```
+
+## See Also
+
+- `xsofy/balance.lg` — full harness code
+- `xsofy/percept.lg` — perception layer (used by `:ensouled` policy)
+- `xsofy/dispatch.lg` — single-turn dispatcher and replay system
+- `xsofy/test/balance_explore.lg` — example script

--- a/xsofy/balance.lg
+++ b/xsofy/balance.lg
@@ -1,0 +1,593 @@
+(ns xsofy.balance
+  "Dungeon-survivability exploration harness.
+
+   Drives synthetic players through real dungeon floors via dispatch/dispatch
+   and reports outcomes. Useful for answering:
+     - At what depth does a starter loadout (dagger + leather) die?
+     - Does adding (runes :damage) to the dagger meaningfully shift
+       death-by-depth?
+     - Which creatures kill the most players, and at what depth?
+     - Does greedy-descend (rush to stairs) outperform greedy-melee
+       (clear every level)?
+
+   This is NOT a property test. It produces statistical evidence, not
+   correctness claims. Run it deliberately when balance-tuning, not on
+   every CI run.
+
+   Usage from REPL:
+     (require '[xsofy.balance :as b])
+     (def report (b/explore {:n-runs 50 :seed 42}))
+     (b/print-report report)
+
+   Usage as script:
+     lg xsofy/test/balance_explore.lg"
+  (:require [xsofy.world :as w]
+            [xsofy.entities :as ent]
+            [xsofy.dispatch :as dispatch]
+            [xsofy.percept :as percept]
+            [xsofy.check :as c]
+            [xsofy.bestiary]
+            [xsofy.items]
+            [xsofy.terrain :as terrain]
+            [xsofy.runes]
+            [string :as str]
+            [math]))
+
+;; --- Loadout generation ---
+;;
+;; A loadout is the player's starting equipment + inventory. It overrides
+;; the defaults that give-starting-items installs.
+;;
+;;   {:weapon       :dagger     ; item template to equip
+;;    :weapon-runes [:damage]   ; rune program to inscribe (or nil)
+;;    :weapon-enchant 0         ; enchant level
+;;    :armor        :leather-armor
+;;    :armor-enchant 0
+;;    :potions      [:health-potion :health-potion]}
+
+(def starter-loadout
+  "The current default: dagger + leather + two health potions."
+  {:weapon :dagger
+   :weapon-runes nil
+   :weapon-enchant 0
+   :armor :leather-armor
+   :armor-enchant 0
+   :potions [:health-potion :health-potion]})
+
+(def dagger-with-damage-rune-loadout
+  "Mirrors the local WIP change: dagger inscribed with (runes :damage)."
+  (assoc starter-loadout :weapon-runes [:damage]))
+
+(def heavy-melee-loadout
+  "Long sword + chain mail. Stronger but heavier — tests whether
+   raw stats overcome the speed cost."
+  {:weapon :long-sword
+   :weapon-runes nil
+   :weapon-enchant 1
+   :armor :chain-mail
+   :armor-enchant 1
+   :potions [:health-potion :health-potion :health-potion]})
+
+(def ranged-loadout
+  "Short bow + arrows + leather. Tests ranged play."
+  {:weapon :short-bow
+   :weapon-runes nil
+   :weapon-enchant 0
+   :armor :leather-armor
+   :armor-enchant 0
+   :potions [:health-potion :health-potion]
+   :ammo [:arrow]})
+
+(def all-loadouts
+  {:starter starter-loadout
+   :starter-with-damage-rune dagger-with-damage-rune-loadout
+   :heavy-melee heavy-melee-loadout
+   :ranged ranged-loadout})
+
+;; --- Loadout application ---
+
+(defn- give-with-enchant
+  "Spawn an item with optional enchant level + rune program, then equip
+   the player with it. Returns [world item-id]."
+  [world item-type {:keys [enchant runes]}]
+  (let [[w id] (w/give-item world item-type :player)]
+    (if id
+      (let [w (if (and enchant (not= 0 enchant))
+                (assoc-in w [:entities id :item :enchant] enchant)
+                w)
+            w (if (seq runes)
+                (assoc-in w [:entities id :runes] (vec runes))
+                w)
+            w (or (ent/equip-item w id :player) w)]
+        [w id])
+      [world nil])))
+
+(defn apply-loadout
+  "Build a world for the given loadout. Replaces give-starting-items'
+   defaults with the loadout's choices."
+  [world loadout]
+  (let [[w _wid] (give-with-enchant world (:weapon loadout)
+                                    {:enchant (:weapon-enchant loadout)
+                                     :runes (:weapon-runes loadout)})
+        [w _aid] (give-with-enchant w (:armor loadout)
+                                    {:enchant (:armor-enchant loadout)})
+        ;; potions stack via pickup-item's :consumable path
+        w (reduce (fn [w pot]
+                    (first (w/give-item w pot :player)))
+                  w
+                  (or (:potions loadout) []))
+        ;; ammo (arrows)
+        w (reduce (fn [w ammo]
+                    (first (w/give-item w ammo :player)))
+                  w
+                  (or (:ammo loadout) []))]
+    w))
+
+(defn make-loadout-world
+  "Construct a fresh world for a synthetic player with `loadout`.
+   Optional :seed for reproducibility."
+  ([width height loadout]
+   (make-loadout-world width height loadout nil))
+  ([width height loadout seed]
+   (let [seed (or seed (mod (try (System/currentTimeMillis) (catch e 1)) 2147483647))]
+     ;; Canonical deterministic world, then override equipment per loadout.
+     (apply-loadout (w/make-world width height seed) loadout))))
+
+;; --- Action policies ---
+;;
+;; A policy is (fn [world] action). Given the current world state, return
+;; the next action to feed to update-world.
+
+(defn- player-hp [world]
+  (or (get-in world [:entities :player :body :hp]) 0))
+
+(defn- player-pos [world]
+  (get-in world [:entities :player :pos]))
+
+(defn- visible-enemy-positions [world]
+  (let [fov (or (:fov world) #{})]
+    (->> (vals (:entities world))
+         (filter (fn [e]
+                   (and (:ai e) (:pos e)
+                        (not= :player (:id e))
+                        (contains? fov (:pos e)))))
+         (map :pos))))
+
+(defn- nearest-visible-enemy-dir
+  "Return [dx dy] step toward the nearest visible enemy, or nil. Guards
+   against transient nil :pos (mid-floor-transition, dead player) and
+   enemies with missing :pos."
+  [world]
+  (let [ppos (player-pos world)
+        enemies (filterv (fn [p]
+                           (and (vector? p)
+                                (number? (first p))
+                                (number? (second p))))
+                         (visible-enemy-positions world))]
+    (when (and (vector? ppos)
+               (number? (first ppos))
+               (number? (second ppos))
+               (seq enemies))
+      (let [[px py] ppos
+            nearest (first (sort-by (fn [[ex ey]]
+                                      (let [dx (- ex px) dy (- ey py)]
+                                        (+ (* dx dx) (* dy dy))))
+                                    enemies))
+            [ex ey] nearest
+            dx (- ex px) dy (- ey py)]
+        [(cond (pos? dx) 1 (neg? dx) -1 :else 0)
+         (cond (pos? dy) 1 (neg? dy) -1 :else 0)]))))
+
+(def directions
+  [:up :down :left :right :up-left :up-right :down-left :down-right])
+
+(defn- dir-action [[dx dy]]
+  (case [dx dy]
+    [0 -1] :up
+    [0 1] :down
+    [-1 0] :left
+    [1 0] :right
+    [-1 -1] :up-left
+    [1 -1] :up-right
+    [-1 1] :down-left
+    [1 1] :down-right
+    :wait))
+
+;; Policy: random walk.
+(defn random-policy [world]
+  (nth directions (rand-int 8)))
+
+(defn- on-stairs-down? [world]
+  (let [{:keys [terrain width]} world
+        ppos (player-pos world)]
+    (when (and terrain ppos)
+      (let [[px py] ppos]
+        (= 13 (xsofy.terrain/tget terrain width px py))))))
+
+(defn- has-seen-stairs? [world]
+  (some (fn [[_pos tile]] (= 13 tile)) (or (:memory world) {})))
+
+;; Policy: greedy melee — step toward the nearest visible enemy. If no
+;; enemy visible: if standing on stairs-down, descend. Otherwise, if any
+;; stairs are remembered route there; else autoexplore.
+(defn greedy-melee-policy [world]
+  (or (when-let [dir (nearest-visible-enemy-dir world)]
+        (dir-action dir))
+      (when (on-stairs-down? world) :descend)
+      (when (has-seen-stairs? world) :descend)
+      :autoexplore))
+
+;; Policy: greedy descend — rush to stairs. Autoexplore until stairs are
+;; remembered, then route to them and descend.
+(defn greedy-descend-policy [world]
+  (cond
+    (on-stairs-down? world) :descend
+    (has-seen-stairs? world) :descend
+    :else :autoexplore))
+
+;; Policy: passive rest — rest in place. For measuring baseline status
+;; effects and starvation.
+(defn passive-rest-policy [world]
+  :rest)
+
+;; Policy: ensouled — perception-driven AI that uses the percept layer.
+;; Prioritizes: flee when in danger, attack nearest threat, use stairs if low health.
+(defn ensouled-policy [world]
+  (let [p (percept/perceive world :player)]
+    (cond
+      ;; In critical danger (burned, frozen, or < 30% HP): flee toward nearest stairs
+      (percept/in-danger? world :player)
+      (if-let [stairs (:nearest-stairs-down p)]
+        (let [[px py] (get-in p [:resources :pos])
+              [sx sy] stairs
+              dx (- sx px) dy (- sy py)]
+          (dir-action [(cond (pos? dx) 1 (neg? dx) -1 :else 0)
+                       (cond (pos? dy) 1 (neg? dy) -1 :else 0)]))
+        :autoexplore)
+
+      ;; Has a nearby threat: attack the top-scored one
+      (when-let [top-threat (first (:threats p))]
+        (when (:in-attack-range? top-threat)
+          (let [[px py] (get-in p [:resources :pos])
+                [tx ty] (:pos top-threat)
+                dx (- tx px) dy (- ty py)]
+            (dir-action [(cond (pos? dx) 1 (neg? dx) -1 :else 0)
+                         (cond (pos? dy) 1 (neg? dy) -1 :else 0)]))))
+
+      ;; On stairs: descend
+      (:on-stairs-down? p) :descend
+
+      ;; Know where stairs are: route to them
+      (:nearest-stairs-down p) :descend
+
+      ;; Otherwise: explore
+      :else :autoexplore)))
+
+(def policies
+  {:random random-policy
+   :greedy-melee greedy-melee-policy
+   :greedy-descend greedy-descend-policy
+   :passive-rest passive-rest-policy
+   :ensouled ensouled-policy})
+
+;; --- Outcome recording ---
+;;
+;; A run-outcome describes what happened:
+;;   {:loadout   :starter
+;;    :policy    :greedy-melee
+;;    :outcome   :died | :reached-target | :stuck
+;;    :turn      127
+;;    :depth     3
+;;    :killed-by :goblin       ; nil if survived
+;;    :hp-final  0
+;;    :final-pos [12 8]
+;;    :seed      42}
+
+(def ^:private death-msg-prefixes
+  ;; Maps a log-message prefix to a heuristic killer source.
+  ;; Order matters: more specific first.
+  [["You die from burning"     :burning]
+   ["You die from poison"      :poison]
+   ["The "                      :creature]    ; "The goblin kills you!" / "The X shoots and kills you!"
+   ["The fire"                 :fire]])
+
+(defn- index-of-space [s]
+  ;; Linear scan since let-go's String may not expose indexOf.
+  (loop [i 0]
+    (cond
+      (>= i (count s)) -1
+      (= (str (nth s i)) " ") i
+      :else (recur (inc i)))))
+
+(defn- creature-from-log-line [line]
+  ;; "The goblin kills you!" -> :goblin
+  ;; "The goblin's arrow kills you!" -> :goblin  (best effort)
+  (let [line (or line "")
+        ;; strip "The " prefix
+        rest (if (and (> (count line) 4) (= "The " (subs line 0 4)))
+               (subs line 4)
+               line)
+        ;; take everything before the next space
+        space (index-of-space rest)
+        name-or-rest (if (>= space 0) (subs rest 0 space) rest)
+        ;; if name-or-rest ends with "'s", strip it
+        name (if (and (>= (count name-or-rest) 2)
+                      (= "'s" (subs name-or-rest (- (count name-or-rest) 2))))
+               (subs name-or-rest 0 (- (count name-or-rest) 2))
+               name-or-rest)]
+    (when (and name (> (count name) 0))
+      (keyword name))))
+
+(defn- infer-killer
+  "Look at the message log for the death-cause. Prefers specific killer
+   identifications ('The goblin kills you!') over generic ones
+   ('You die...'). The generic 'You die' line is appended last by
+   update-world, so we scan all recent entries for a specific match
+   before falling back."
+  [world]
+  (let [log (or (:log world) [])
+        last-line (fn [entry]
+                    (cond
+                      (string? entry) entry
+                      (map? entry) (:msg entry)
+                      :else nil))
+        recent (vec (take-last 12 log))
+        ;; first try: a specific killer line
+        specific (some (fn [entry]
+                         (let [line (last-line entry)]
+                           (cond
+                             (nil? line) nil
+                             (str/includes? line "shoots and kills you")
+                             (creature-from-log-line line)
+                             (str/includes? line "kills you")
+                             (creature-from-log-line line)
+                             :else nil)))
+                       recent)]
+    (or specific
+        ;; fallback: any "You die" / "You die from X"
+        (some (fn [entry]
+                (let [line (last-line entry)]
+                  (when (and line (str/includes? line "You die"))
+                    :status-or-environment)))
+              recent))))
+
+(defn- record-outcome [world loadout-key policy-key starting-seed target-depth]
+  (let [player (get-in world [:entities :player])
+        alive (and player (> (player-hp world) 0))
+        cause-of-death (get world :cause-of-death)]
+    {:loadout loadout-key
+     :policy policy-key
+     :outcome (cond
+                (not alive) :died
+                (>= (or (:depth world) 1) target-depth) :reached-target
+                :else :stuck)
+     :turn (or (:turn world) 0)
+     :depth (or (:depth world) 1)
+     :killed-by (when (not alive)
+                  (or
+                    ;; precise: the production cause-of-death field
+                    (when (keyword? cause-of-death)
+                      (get-in world [:entities cause-of-death :template] cause-of-death))
+                    ;; fallback: scan log
+                    (infer-killer world)))
+     :hp-final (or (player-hp world) 0)
+     :final-pos (player-pos world)
+     :seed (:seed-input world)
+     :action-log (or (:action-log world) [])}))
+
+;; --- Run loop ---
+
+(def default-max-turns 2000)
+(def default-target-depth 9)
+(def default-world-width 50)
+(def default-world-height 30)
+
+(defn simulate-run
+  "Run one simulation: build a world with `loadout`, drive it with
+   `policy-fn` until the player dies, reaches target depth, or hits
+   the turn cap. Returns an outcome record."
+  ([loadout policy-key]
+   (simulate-run loadout policy-key {}))
+  ([loadout policy-key {:keys [max-turns target-depth width height seed]
+                        :or {max-turns default-max-turns
+                             target-depth default-target-depth
+                             width default-world-width
+                             height default-world-height}}]
+   (let [policy-fn (get policies policy-key random-policy)
+         seed (or seed (mod (try (System/currentTimeMillis) (catch e 1)) 2147483647))
+         loadout-key (cond
+                       (= loadout starter-loadout) :starter
+                       (= loadout dagger-with-damage-rune-loadout) :starter-with-damage-rune
+                       (= loadout heavy-melee-loadout) :heavy-melee
+                       (= loadout ranged-loadout) :ranged
+                       :else :custom)
+         world (make-loadout-world width height loadout seed)]
+     (loop [w world
+            turn 0
+            stall-count 0]
+       (let [player-alive (and (get-in w [:entities :player])
+                               (> (player-hp w) 0))
+             depth (or (:depth w) 1)]
+         (cond
+           ;; died
+           (not player-alive)
+           (record-outcome w loadout-key policy-key seed target-depth)
+
+           ;; reached target depth
+           (>= depth target-depth)
+           (record-outcome w loadout-key policy-key seed target-depth)
+
+           ;; hit turn cap
+           (>= turn max-turns)
+           (record-outcome (assoc w :stuck true) loadout-key policy-key seed target-depth)
+
+           :else
+           (let [;; Anti-stall: if the policy has produced 5 consecutive
+                 ;; actions that didn't advance the world turn, override
+                 ;; with :rest to break out. Saves runs that would
+                 ;; otherwise burn the entire turn budget repeating a
+                 ;; blocked move.
+                 action (if (>= stall-count 5)
+                          :rest
+                          (policy-fn w))
+                 w' (try (dispatch/dispatch w action)
+                         (catch e w))   ;; defensive: if action crashes, end run
+                 advanced (> (or (:turn w') 0) (or (:turn w) 0))]
+             (recur w'
+                    (inc turn)
+                    (if advanced 0 (inc stall-count))))))))))
+
+;; --- Aggregation ---
+
+(defn- count-by [f coll]
+  (reduce (fn [m x]
+            (let [k (f x)]
+              (assoc m k (inc (or (get m k) 0)))))
+          {}
+          coll))
+
+(defn aggregate
+  "Fold a vector of outcomes into a summary report.
+
+   Report shape:
+     {:n-runs N
+      :by-loadout {:starter {:died 45 :reached-target 5}}
+      :death-by-depth {:starter {1 12, 2 18, 3 15}}
+      :death-by-creature {:starter {:rat 5, :goblin 20}}
+      :mean-turns {:starter 89.4}
+      :reach-rate {:starter 0.10}}"
+  [outcomes]
+  (let [by-loadout (group-by :loadout outcomes)]
+    {:n-runs (count outcomes)
+     :by-loadout (into {}
+                   (map (fn [[lk lo]]
+                          [lk (count-by :outcome lo)])
+                        by-loadout))
+     :death-by-depth (into {}
+                       (map (fn [[lk lo]]
+                              [lk (count-by :depth
+                                            (filterv #(= :died (:outcome %)) lo))])
+                            by-loadout))
+     :death-by-creature (into {}
+                          (map (fn [[lk lo]]
+                                 [lk (count-by :killed-by
+                                               (filterv #(= :died (:outcome %)) lo))])
+                               by-loadout))
+     :mean-turns (into {}
+                   (map (fn [[lk lo]]
+                          [lk (if (seq lo)
+                                (float (/ (reduce + (mapv :turn lo))
+                                          (count lo)))
+                                0.0)])
+                        by-loadout))
+     :reach-rate (into {}
+                   (map (fn [[lk lo]]
+                          [lk (if (seq lo)
+                                ;; let-go quirk: (count (filter ...)) over an
+                                ;; empty match returns 1, not 0. Force vec.
+                                (float (/ (count (filterv #(= :reached-target (:outcome %)) lo))
+                                          (count lo)))
+                                0.0)])
+                        by-loadout))}))
+
+;; --- Top-level ---
+
+(defn explore
+  "Run a balance exploration sweep.
+
+   Options:
+     :n-runs       — total simulations across all combinations (default 40)
+     :loadouts     — vector of loadout keys to test (default: all)
+     :policies     — vector of policy keys to test (default: :greedy-melee)
+     :max-turns    — turns-per-run cap
+     :target-depth — depth at which a run is considered a 'win'
+     :seed         — optional reproducible seed; each run gets seed+i
+
+   Returns an aggregate report. The raw outcomes are also in :outcomes."
+  ([] (explore {}))
+  ([{:keys [n-runs loadouts policies max-turns target-depth width height seed]
+     :or {n-runs 40
+          loadouts [:starter :starter-with-damage-rune :heavy-melee :ranged]
+          policies [:greedy-melee]
+          max-turns default-max-turns
+          target-depth default-target-depth
+          width default-world-width
+          height default-world-height}}]
+   (let [combos (for [lk loadouts pk policies] [lk pk])
+         runs-per-combo (max 1 (quot n-runs (count combos)))
+         run-specs (vec (for [[lk pk] combos _ (range runs-per-combo)] [lk pk]))
+         total-runs (count run-specs)
+         outcomes (vec
+                    (map-indexed
+                      (fn [i [lk pk]]
+                        (let [loadout (get all-loadouts lk)
+                              run-seed (when seed (+ seed i))
+                              outcome (simulate-run loadout pk {:max-turns max-turns
+                                                               :target-depth target-depth
+                                                               :width width
+                                                               :height height
+                                                               :seed run-seed})]
+                          ;; Progress output: show completion as each run finishes
+                          (println (str "[" (inc i) "/" total-runs "] "
+                                       (name lk) "/" (name pk) " -> "
+                                       (:outcome outcome) " (turn " (:turn outcome)
+                                       ", depth " (:depth outcome)
+                                       (when (:killed-by outcome)
+                                         (str ", killed-by " (name (:killed-by outcome))))
+                                       ")"))
+                          outcome))
+                      run-specs))]
+     (assoc (aggregate outcomes) :outcomes outcomes))))
+
+;; --- Reporting ---
+
+(defn- index-of-dot [s]
+  (loop [i 0]
+    (cond
+      (>= i (count s)) -1
+      (= (str (nth s i)) ".") i
+      :else (recur (inc i)))))
+
+(defn- format-float [f precision]
+  (let [s (str f)
+        dot (index-of-dot s)]
+    (if (>= dot 0)
+      (let [end (min (count s) (+ dot precision 1))]
+        (subs s 0 end))
+      s)))
+
+(defn- format-loadout-row [report loadout-key]
+  (let [outcomes (get-in report [:by-loadout loadout-key] {})
+        died (or (get outcomes :died) 0)
+        reached (or (get outcomes :reached-target) 0)
+        stuck (or (get outcomes :stuck) 0)
+        total (+ died reached stuck)
+        reach-rate (get-in report [:reach-rate loadout-key] 0.0)
+        mean-turns (get-in report [:mean-turns loadout-key] 0.0)]
+    (str "  " (name loadout-key) ": "
+         total " runs, "
+         died " died, " reached " reached, " stuck " stuck. "
+         "reach-rate=" (format-float reach-rate 2) " "
+         "mean-turns=" (format-float mean-turns 1))))
+
+(defn print-report
+  "Pretty-print a balance report to stdout."
+  [report]
+  (println "=== Balance exploration report ===")
+  (println (str "Total runs: " (:n-runs report)))
+  (println)
+  (println "Per-loadout outcomes:")
+  (doseq [lk (sort (keys (:by-loadout report)))]
+    (println (format-loadout-row report lk)))
+  (println)
+  (println "Death by depth (loadout -> depth -> count):")
+  (doseq [lk (sort (keys (:death-by-depth report)))]
+    (println (str "  " (name lk) ":"))
+    (doseq [[depth n] (sort-by first (get (:death-by-depth report) lk))]
+      (println (str "    depth " depth ": " n))))
+  (println)
+  (println "Death by creature (loadout -> creature -> count):")
+  (doseq [lk (sort (keys (:death-by-creature report)))]
+    (println (str "  " (name lk) ":"))
+    (doseq [[creature n] (sort-by (fn [[_ c]] (- c)) (get (:death-by-creature report) lk))]
+      (println (str "    " (if creature (name creature) "<unknown>") ": " n)))))

--- a/xsofy/percept.lg
+++ b/xsofy/percept.lg
@@ -1,0 +1,408 @@
+(ns xsofy.percept
+  "Perception layer — derives a structured view of the world from any
+   entity's point of view. Parameterized by entity-id so it works for
+   the player, an NPC agent, or a player-AI for the balance harness.
+
+   The percept is a pure function of (world, entity-id, opts):
+
+     (perceive world :player)
+     (perceive world :goblin-3 {:fov-radius 6})
+
+   What the caller does with the percept is policy. The percept itself
+   takes no side effects, makes no decisions, and is safe to compute
+   for an arbitrary number of entities per turn.
+
+   Shared between:
+     - Balance harness ensouled-agent policies (decides what to do)
+     - NPC AI dispatch (decides which behavior fragment to run)
+     - Future debug overlays (visualize what the agent sees)
+     - Property tests that need a stable view of world state
+
+   Conceptually inspired by the Sims utility-AI percept model: a flat
+   map of named features that a policy can score over."
+  (:require [xsofy.entities :as ent]
+            [xsofy.terrain :as terrain]
+            [xsofy.fov :as fov]
+            [xsofy.fire :as fire]
+            [xsofy.status :as status]
+            [math]))
+
+;; ============================================================================
+;; Configuration
+;; ============================================================================
+
+(def default-fov-radius 12)
+(def default-threat-radius 16)
+(def default-goal-radius 30)
+
+;; ============================================================================
+;; Position helpers
+;; ============================================================================
+
+(defn- distance [[ax ay] [bx by]]
+  (let [dx (- ax bx) dy (- ay by)]
+    (math/sqrt (+ (* dx dx) (* dy dy)))))
+
+(defn- manhattan [[ax ay] [bx by]]
+  (+ (math/abs (- ax bx)) (math/abs (- ay by))))
+
+(defn- chebyshev [[ax ay] [bx by]]
+  ;; "King-step" distance: max of x-delta and y-delta. This is what
+  ;; the game uses for melee adjacency (see xsofy.util/adjacent?).
+  (max (math/abs (- ax bx)) (math/abs (- ay by))))
+
+;; ============================================================================
+;; FOV — per-entity, not just the player's
+;; ============================================================================
+;;
+;; The player has a precomputed :fov on the world (updated each turn).
+;; NPCs don't get this for free — we compute on demand. Cached per-call
+;; via opts to avoid recomputing during a single perceive pass.
+
+(defn entity-fov
+  "Return the set of cells visible from entity-id's position. For the
+   player, prefers the precomputed :fov on the world. For NPCs, computes
+   fresh."
+  [world entity-id opts]
+  (let [entity (get-in world [:entities entity-id])
+        pos (:pos entity)]
+    (cond
+      (nil? pos) #{}
+      (and (= entity-id :player) (some? (:fov world))) (:fov world)
+      :else
+      (let [[x y] pos
+            radius (or (:fov-radius opts) default-fov-radius)
+            {:keys [terrain width height]} world]
+        (when (and terrain width height)
+          (fov/compute-fov terrain width height x y radius))))))
+
+;; ============================================================================
+;; Threat assessment
+;; ============================================================================
+
+(defn- creature? [entity self-id]
+  (and (:ai entity)
+       (:pos entity)
+       (not= self-id (:id entity))
+       (get-in entity [:body :hp])))
+
+(defn- estimated-damage
+  "Heuristic: expected damage this creature deals per attack."
+  [entity]
+  (let [melee-dmg (or (get-in entity [:spells :melee :damage]) 0)
+        ranged-dmg (or (get-in entity [:spells :ranged :damage]) 0)]
+    (max melee-dmg ranged-dmg)))
+
+(defn- can-attack-from
+  "Heuristic: can this creature damage `target-pos` from `enemy-pos`?
+   Returns max effective range in tiles (adjacent for melee, range
+   for ranged)."
+  [entity]
+  (let [ranged-range (get-in entity [:spells :ranged :range])
+        melee-range 1]
+    (or ranged-range melee-range)))
+
+(defn- threat-score
+  "Compose a single danger number from per-threat features. Higher =
+   more dangerous to me right now. Used by utility-AI policies to
+   rank threats."
+  [dist expected-dmg attack-range los]
+  (let [in-range (<= dist attack-range)
+        proximity-factor (cond
+                           in-range 4.0
+                           (<= dist (* attack-range 1.5)) 2.0
+                           :else (/ 1.0 (max 1.0 dist)))
+        los-factor (if los 1.0 0.3)]
+    (* expected-dmg proximity-factor los-factor)))
+
+(defn- has-clear-line?
+  "Bresenham LOS — duplicate of world.lg's. Living here so percept has
+   no dependency on world.lg. Could be unified later via xsofy.util."
+  [world x1 y1 x2 y2]
+  (let [{:keys [terrain width height]} world
+        dx (math/abs (- x2 x1))
+        dy (- (math/abs (- y2 y1)))
+        sx (if (< x1 x2) 1 -1)
+        sy (if (< y1 y2) 1 -1)
+        err (atom (+ dx dy))
+        cx (atom x1) cy (atom y1)
+        clear (atom true)]
+    (while (and @clear (not (and (= @cx x2) (= @cy y2))))
+      (let [e2 (* 2 @err)]
+        (when (>= e2 dy) (swap! err + dy) (swap! cx + sx))
+        (when (<= e2 dx) (swap! err + dx) (swap! cy + sy)))
+      (when (and @clear (not (and (= @cx x2) (= @cy y2))))
+        (when-not (terrain/transparent? terrain (:width world) (:height world) @cx @cy)
+          (reset! clear false))))
+    @clear))
+
+(defn threats
+  "Vec of threats visible to entity-id. Each entry:
+     {:id        :goblin-3
+      :template  :goblin
+      :pos       [12 8]
+      :dist      4.2
+      :expected-dmg 3
+      :attack-range 1
+      :los       true
+      :in-attack-range? true     ; can it hit me from where it is?
+      :i-can-attack?    true     ; can I hit it from here?
+      :score     12.0}            ; threat-score
+   Ordered by descending :score (most dangerous first)."
+  [world entity-id opts]
+  (let [self (get-in world [:entities entity-id])
+        self-pos (:pos self)
+        self-attack-range (let [m (get-in self [:spells :melee :damage])
+                                r (get-in self [:spells :ranged :range])]
+                            (cond (and r m) r
+                                  r r
+                                  :else 1))
+        fov-set (entity-fov world entity-id opts)
+        radius (or (:threat-radius opts) default-threat-radius)]
+    (if-not self-pos
+      []
+      (let [[sx sy] self-pos]
+        (->> (vals (:entities world))
+             (filterv (fn [e] (creature? e entity-id)))
+             (filterv (fn [e]
+                        (and (contains? fov-set (:pos e))
+                             (<= (distance self-pos (:pos e)) radius))))
+             (mapv (fn [e]
+                     (let [[ex ey] (:pos e)
+                           d (distance self-pos (:pos e))
+                           cheb (chebyshev self-pos (:pos e))
+                           dmg (estimated-damage e)
+                           rng (can-attack-from e)
+                           ;; Melee = king-step adjacent (chebyshev <= 1).
+                           ;; Ranged checks Euclidean distance vs :range.
+                           in-melee (and (<= rng 1) (= cheb 1))
+                           in-ranged (and (> rng 1) (<= d rng))
+                           los (has-clear-line? world sx sy ex ey)]
+                       {:id (:id e)
+                        :template (:template e)
+                        :pos (:pos e)
+                        :dist d
+                        :chebyshev cheb
+                        :expected-dmg dmg
+                        :attack-range rng
+                        :los los
+                        :in-attack-range? (and los (or in-melee in-ranged))
+                        :i-can-attack? (and los (or (and (<= self-attack-range 1)
+                                                         (= cheb 1))
+                                                    (and (> self-attack-range 1)
+                                                         (<= d self-attack-range))))
+                        :score (threat-score d dmg rng los)})))
+             (sort-by (fn [t] (- (:score t))))
+             vec)))))
+
+;; ============================================================================
+;; Resource state
+;; ============================================================================
+
+(defn- inventory-by-template
+  "Bucket the entity's inventory by item template. Returns
+   {:health-potion 2 :arrow 5 ...}."
+  [world entity-id]
+  (let [inv-ids (or (get-in world [:entities entity-id :inventory]) [])]
+    (reduce (fn [m id]
+              (let [item (get-in world [:entities id])
+                    tpl (:template item)
+                    cnt (or (get-in item [:item :count]) 1)]
+                (if tpl
+                  (assoc m tpl (+ (or (get m tpl) 0) cnt))
+                  m)))
+            {}
+            inv-ids)))
+
+(defn- equipment-summary
+  [world entity-id]
+  (let [equip (get-in world [:entities entity-id :equipment] {})]
+    (reduce (fn [m [slot item-id]]
+              (assoc m slot (get-in world [:entities item-id :template])))
+            {}
+            equip)))
+
+(defn- active-statuses
+  "Returns the set of active status keywords on the entity."
+  [world entity-id]
+  (set (keys (or (get-in world [:entities entity-id :statuses]) {}))))
+
+(defn resources
+  "Snapshot of the entity's own state — HP fraction, MP fraction once
+   it exists, inventory, equipment, active statuses. The numbers an
+   agent needs to make survival decisions."
+  [world entity-id _opts]
+  (let [entity (get-in world [:entities entity-id])
+        hp (get-in entity [:body :hp] 0)
+        max-hp (get-in entity [:body :max-hp] hp)
+        mp (get-in entity [:body :mp] 0)
+        max-mp (get-in entity [:body :max-mp] 0)]
+    {:hp hp
+     :max-hp max-hp
+     :hp-frac (if (> max-hp 0) (/ (float hp) (float max-hp)) 1.0)
+     :mp mp
+     :max-mp max-mp
+     :mp-frac (if (> max-mp 0) (/ (float mp) (float max-mp)) 1.0)
+     :strength (get-in entity [:body :strength] 0)
+     :inventory (inventory-by-template world entity-id)
+     :equipment (equipment-summary world entity-id)
+     :statuses (active-statuses world entity-id)
+     :pos (:pos entity)
+     :flying (get-in entity [:properties :flying] false)
+     :burning? (status/has-status? world entity-id :burning)
+     :webbed? (status/has-status? world entity-id :webbed)
+     :frozen? (status/has-status? world entity-id :frozen)
+     :on-fire-tile? (let [pos (:pos entity)
+                          {:keys [terrain width]} world]
+                      (when (and pos terrain)
+                        (let [[x y] pos]
+                          (= 15 (terrain/tget terrain width x y)))))}))
+
+;; ============================================================================
+;; Goal information
+;; ============================================================================
+;;
+;; What does the entity know about reaching some objective?
+;;   - Player wants to descend. :goal looks at stairs-down memory.
+;;   - NPCs typically want to reach the player; :goal points there.
+;;
+;; For simplicity, percept exposes both objectives. The policy picks
+;; which to prioritize.
+
+(defn- memory-positions-of-tile
+  "All remembered positions for a given tile id, derived from
+   (:memory world). Player-only — NPCs don't have a memory map today."
+  [world tile-id]
+  (->> (or (:memory world) {})
+       (filter (fn [[_pos tile]] (= tile tile-id)))
+       (mapv first)))
+
+(defn- nearest-position [from positions]
+  (when (seq positions)
+    (first (sort-by #(distance from %) positions))))
+
+(defn goal-info
+  "Stairs/unexplored/items knowledge for entity-id. Most useful for
+   the player or a player-AI; NPCs would typically use :target-pos
+   in their AI state rather than this."
+  [world entity-id _opts]
+  (let [self (get-in world [:entities entity-id])
+        self-pos (:pos self)
+        stairs-down (memory-positions-of-tile world 13)
+        stairs-up (memory-positions-of-tile world 14)
+        memory (or (:memory world) {})
+        ;; Items the entity has seen sitting on the floor.
+        floor-items (->> (vals (:entities world))
+                         (filterv (fn [e]
+                                    (and (= :item (:entity-type e))
+                                         (:pos e)
+                                         (contains? memory (:pos e)))))
+                         (mapv (fn [e] {:id (:id e)
+                                        :template (:template e)
+                                        :pos (:pos e)})))]
+    {:stairs-down stairs-down
+     :stairs-up stairs-up
+     :nearest-stairs-down (when self-pos (nearest-position self-pos stairs-down))
+     :nearest-stairs-up   (when self-pos (nearest-position self-pos stairs-up))
+     :on-stairs-down?     (when self-pos
+                            (let [{:keys [terrain width]} world
+                                  [x y] self-pos]
+                              (= 13 (terrain/tget terrain width x y))))
+     :on-stairs-up?       (when self-pos
+                            (let [{:keys [terrain width]} world
+                                  [x y] self-pos]
+                              (= 14 (terrain/tget terrain width x y))))
+     :floor-items floor-items
+     :nearest-item-pos    (when (and self-pos (seq floor-items))
+                            (nearest-position self-pos (mapv :pos floor-items)))
+     :memory-size (count memory)}))
+
+;; ============================================================================
+;; Adjacent terrain — for hazard avoidance
+;; ============================================================================
+
+(def ^:private hazard-tiles #{4 6 7 15})  ; deep-water chasm lava fire
+(def ^:private cardinal-dirs [[0 -1] [0 1] [-1 0] [1 0]])
+(def ^:private diagonal-dirs [[-1 -1] [1 -1] [-1 1] [1 1]])
+(def ^:private all-dirs (vec (concat cardinal-dirs diagonal-dirs)))
+
+(defn adjacency
+  "Tile information for the 8 cells around entity-id. Each entry maps a
+   direction-vector to {:tile :hazard? :walkable? :pos}."
+  [world entity-id _opts]
+  (let [self (get-in world [:entities entity-id])
+        self-pos (:pos self)
+        {:keys [terrain width height]} world]
+    (when (and self-pos terrain width height)
+      (let [[sx sy] self-pos]
+        (into {}
+              (mapv (fn [[dx dy]]
+                      (let [nx (+ sx dx) ny (+ sy dy)
+                            in-bounds (and (>= nx 0) (< nx width)
+                                           (>= ny 0) (< ny height))
+                            tile (when in-bounds
+                                   (terrain/tget terrain width nx ny))]
+                        [[dx dy]
+                         {:pos [nx ny]
+                          :tile tile
+                          :in-bounds in-bounds
+                          :hazard? (when tile (contains? hazard-tiles tile))
+                          :walkable? (when in-bounds
+                                       (terrain/walkable? terrain width height nx ny))
+                          :occupied? (when in-bounds
+                                       (some? (ent/creature-at world [nx ny])))}]))
+                    all-dirs))))))
+
+;; ============================================================================
+;; Main entry point
+;; ============================================================================
+
+(defn perceive
+  "Build a percept for entity-id. Returns:
+     {:self        ; entity-id (echo)
+      :turn        ; world turn
+      :depth       ; world depth
+      :threats     ; vec of threats (sorted by descending :score)
+      :resources   ; HP/MP/inventory/equipment/statuses
+      :goals       ; stairs/items knowledge
+      :adjacency   ; 8-direction tile info
+      :fov         ; the visible cell set (for debug overlays)}"
+  ([world entity-id]
+   (perceive world entity-id {}))
+  ([world entity-id opts]
+   (let [fov-set (entity-fov world entity-id opts)
+         opts-with-fov (assoc opts :fov-cache fov-set)]
+     {:self entity-id
+      :turn (or (:turn world) 0)
+      :depth (or (:depth world) 1)
+      :threats (threats world entity-id opts-with-fov)
+      :resources (resources world entity-id opts-with-fov)
+      :goals (goal-info world entity-id opts-with-fov)
+      :adjacency (adjacency world entity-id opts-with-fov)
+      :fov fov-set})))
+
+;; ============================================================================
+;; Convenience accessors — for policies that don't need the full percept
+;; ============================================================================
+
+(defn top-threat
+  "Just the most dangerous threat to entity-id, or nil if none visible."
+  [world entity-id]
+  (first (threats world entity-id {})))
+
+(defn in-danger?
+  "True if the entity's HP fraction is below danger-threshold or it is
+   burning/frozen. Tuned for the player-AI flee decision."
+  ([world entity-id] (in-danger? world entity-id 0.30))
+  ([world entity-id danger-threshold]
+   (let [r (resources world entity-id {})]
+     (or (< (:hp-frac r) danger-threshold)
+         (:burning? r)
+         (:frozen? r)
+         (:on-fire-tile? r)))))
+
+(defn has-melee-target?
+  "True if there is an adjacent enemy the entity can hit on bump."
+  [world entity-id]
+  (let [adj (adjacency world entity-id {})]
+    (some (fn [[_dir info]] (:occupied? info)) adj)))

--- a/xsofy/test/balance_explore.lg
+++ b/xsofy/test/balance_explore.lg
@@ -15,9 +15,9 @@
 (println "Running balance sweep (small params: 6 runs per policy, should finish in ~30s)...")
 (let [report (b/explore {:n-runs 6
                          :loadouts [:starter :starter-with-damage-rune]
-                         :policies [:greedy-melee :ensouled]
-                         :max-turns 200
-                         :target-depth 3
+                         :policies [:greedy-descend :ensouled]
+                         :max-turns 400
+                         :target-depth 4
                          :width 40
                          :height 25
                          :seed 42})]

--- a/xsofy/test/balance_explore.lg
+++ b/xsofy/test/balance_explore.lg
@@ -1,0 +1,25 @@
+(ns xsofy.test.balance-explore
+  "Standalone script: runs a balance-exploration sweep and prints the
+   report. Not part of the regular test runner — invoke directly:
+
+     lg xsofy/test/balance_explore.lg
+
+   Adjust the call to b/explore below to vary loadouts, policies, run
+   count, etc. See xsofy/balance.lg for available knobs.
+
+   This script uses SMALL parameters (n-runs=6, max-turns=200) for quick
+   smoke testing. For a full balance sweep, increase n-runs to 40+ and
+   max-turns to 2000, but expect ~30 minutes of runtime."
+  (:require [xsofy.balance :as b]))
+
+(println "Running balance sweep (small params: 6 runs per policy, should finish in ~30s)...")
+(let [report (b/explore {:n-runs 6
+                         :loadouts [:starter :starter-with-damage-rune]
+                         :policies [:greedy-melee :ensouled]
+                         :max-turns 200
+                         :target-depth 3
+                         :width 40
+                         :height 25
+                         :seed 42})]
+  (println)
+  (b/print-report report))

--- a/xsofy/title.lg
+++ b/xsofy/title.lg
@@ -200,12 +200,13 @@
 (defn show-descending-screen
   "Display a brief animated descending screen. Runes rise and fade."
   [depth scheme]
-  (let [[tw th] (term/size)
-        cx (quot tw 2)
-        cy (quot th 2)
-        msg (nth descending-messages (rand-int (count descending-messages)))
-        depth-str (str "Depth " depth)
-        runes (scatter-runes tw th 25 scheme)]
+  (when (term/size)            ;; no-op headless (balance harness / tests)
+   (let [[tw th] (term/size)
+         cx (quot tw 2)
+         cy (quot th 2)
+         msg (nth descending-messages (rand-int (count descending-messages)))
+         depth-str (str "Depth " depth)
+         runes (scatter-runes tw th 25 scheme)]
     ;; clear
     (clear-screen tw th)
     ;; animate — runes drift upward, erase old position each frame
@@ -245,4 +246,4 @@
         (term/set-bg 10 10 10)
         (term/write msg))
       (term/flush)
-      (pause! 60))))
+      (pause! 60)))))


### PR DESCRIPTION
Recovers and ships the **dungeon-survivability balance harness** (`xsofy.balance`) plus the **perception layer** (`xsofy.percept`) it builds on, adapted to the action-dispatcher API. **Stacks on #42** (action dispatcher) — review/merge that first.

## What it is
`xsofy.balance` drives synthetic players (policies) through real dungeons and reports statistical outcomes — death-by-depth, death-by-creature, reach-rate per loadout — to answer balance questions ("does a damage rune shift death-by-depth?", "which creatures kill the most?"). It produces **evidence, not correctness claims**; run it deliberately when balance-tuning, not in CI.

## Why it was missing
`balance.lg` and `percept.lg` were written in the pre-determinism WIP and left behind when that work was split into the clean PRs (#39, #42). This recovers them and brings them to the current API.

## Changes
- **`xsofy/percept.lg`** (recovered) — pure perception layer: `(perceive world entity-id)` derives a structured view (resources, threats, goals) for any entity. Used by the harness `ensouled` policy; designed to back NPC AI too.
- **`xsofy/balance.lg`** (recovered + adapted):
  - Routes synthetic players through **`dispatch/dispatch`** (was `update-world`) — every run records `:action-log` and is **replayable** via `dispatch/replay`.
  - Builds worlds via **`make-world [w h seed]`**; fixes a seed-reproducibility bug (the recorded seed now actually reproduces the world).
  - Policies: `greedy-melee`, `greedy-descend`, `random`, `passive-rest`, `ensouled` (percept-driven).
  - **Per-run progress output** — no more silent multi-minute runs.
- **`xsofy/title.lg`** — `show-descending-screen` is now a no-op when headless (`term/size` nil). It previously crashed on descend; the harness's try/catch swallowed it, so **every headless run was silently stuck at depth 1, burning turns to the cap** (a big part of the slow-silent-run problem). Now safe for any headless caller.
- **`xsofy/test/balance_explore.lg`** — runnable demo, small fast params + progress.
- **`docs/balance-harness.md`** — usage, policies, loadouts, runtime-cost warning, reproducibility, replay.

## Tested
- `./bin/lg xsofy/test/balance_explore.lg` runs end-to-end, prints live progress + a death-by-depth/creature report.
- Descend verified headless: a survivable (HP-boosted) player reaches depth 6.
- Replay round-trips: `(dispatch/replay w h seed action-log)` reproduces a run's final state.
- Full suite: **220 tests / 1076 assertions / 0 fail / 0 error**.

## Perf — no quadratic
Per-turn cost is flat ~15–25 ms across a 600-turn / 6-floor session, and dispatch cost is flat as the action-log grows to 16k entries. Harness runtime is **linear** in `runs × turns`, not quadratic — a turn is dominated by NPC AI + effects. A full 40×2000 sweep is ~30 min; use small `n-runs` and watch the progress. (Offline batch throughput is the only place native hashing would help later — not interactive play.)
