### PR TITLE
Faction-aware AI (friend/enemy partition) — #37

### DIFF
--- a/xsofy/ai.lg
+++ b/xsofy/ai.lg
@@ -150,23 +150,18 @@
 (def investigate-turns 6) ;; turns to search last known position
 
 (defn in-fov?
-  "Is this position in the player's current FOV? Friendlies share the
-   player's awareness — see docs/ai-design.md for the design call.
-   Used as the visibility proxy in find-target and the state machine."
+  "Pos in the player's current FOV. Friendlies share the player's
+   awareness — see docs/ai-design.md."
   [world pos]
   (contains? (or (:fov world) #{}) pos))
 
 (defn find-target
-  "Return the entity this actor should target, or nil. Friendlies seek
-   the nearest visible hostile; hostiles seek the player, or the
-   nearest visible friendly if one is closer. Actor itself must be in
-   FOV — mutual-visibility gate, same as the old can-see-player?
-   semantics. Returns nil when the actor has no eligible quarry, which
-   the state machine treats as 'idle' (fall through to sleep/wander).
+  "Entity this actor should target, or nil. Friendlies seek nearest
+   visible hostile; hostiles seek the player, or the nearest visible
+   friendly if closer. Actor must be in FOV.
 
    Ties on chebyshev distance break on (str :id) so equidistant
-   candidates are picked deterministically from (seed, action-log).
-   Same discipline as the rest of the engine."
+   candidates are picked deterministically from (seed, action-log)."
   [world entity]
   (let [pos (:pos entity)]
     (when (and pos (in-fov? world pos))
@@ -204,9 +199,8 @@
 ;; :investigate — moving to last known target position, then searching
 ;; :flee      — running away from target (low HP / burning)
 ;;
-;; "Target" is the player for hostiles, the nearest hostile for
-;; friendlies. find-target above does the lookup; everything else here
-;; treats target uniformly. Pre-faction code hardcoded :player.
+;; "Target" = find-target's return value. Player for hostiles, nearest
+;; hostile for friendlies.
 
 (defn update-ai-state [world entity-id]
   (let [entity (get-in world [:entities entity-id])
@@ -384,9 +378,9 @@
             target (find-target world entity)
             target-id (:id target)
             target-pos (:pos target)
-            ;; :investigate uses the LAST KNOWN position from :ai :target,
-            ;; not the live find-target lookup (the whole point is searching
-            ;; somewhere we no longer see them).
+            ;; :investigate uses LAST KNOWN from :ai :target, not the
+            ;; live find-target lookup (whole point is searching where
+            ;; we no longer see).
             last-known (get ai :target)]
         (if (nil? pos)
           world
@@ -398,9 +392,8 @@
 
             :hunt
             (if (nil? target)
-              ;; lost target this turn (e.g. friendly killed last hostile) —
-              ;; idle this tick, update-ai-state will rotate to investigate
-              ;; or sleep on the next pass.
+              ;; lost target (e.g. friendly killed last hostile); idle,
+              ;; update-ai-state rotates state next pass.
               world
               (case behavior
                 :ranged (hunt-ranged world entity-id pos target-id target-pos

--- a/xsofy/ai.lg
+++ b/xsofy/ai.lg
@@ -149,39 +149,82 @@
 (def wander-chance 30)    ;; % chance to wander each turn when sleeping
 (def investigate-turns 6) ;; turns to search last known position
 
-(defn can-see-player? [world entity]
-  (let [fov (:fov world)
-        pos (:pos entity)]
-    ;; simplified: if entity is in player's FOV, assume mutual visibility
-    (contains? fov pos)))
+(defn in-fov?
+  "Is this position in the player's current FOV? Friendlies share the
+   player's awareness — see docs/ai-design.md for the design call.
+   Used as the visibility proxy in find-target and the state machine."
+  [world pos]
+  (contains? (or (:fov world) #{}) pos))
+
+(defn find-target
+  "Return the entity this actor should target, or nil. Friendlies seek
+   the nearest visible hostile; hostiles seek the player, or the
+   nearest visible friendly if one is closer. Actor itself must be in
+   FOV — mutual-visibility gate, same as the old can-see-player?
+   semantics. Returns nil when the actor has no eligible quarry, which
+   the state machine treats as 'idle' (fall through to sleep/wander).
+
+   Ties on chebyshev distance break on (str :id) so equidistant
+   candidates are picked deterministically from (seed, action-log).
+   Same discipline as the rest of the engine."
+  [world entity]
+  (let [pos (:pos entity)]
+    (when (and pos (in-fov? world pos))
+      (let [es (vals (:entities world))
+            dist-to (fn [e] (distance pos (:pos e)))]
+        (if (ent/friendly? entity)
+          (->> es
+               (filter (fn [e]
+                         (and (ent/hostile-to-player? e)
+                              (:pos e)
+                              (in-fov? world (:pos e)))))
+               (sort-by (juxt dist-to (comp str :id)))
+               first)
+          (let [player (get-in world [:entities :player])
+                friendly (->> es
+                              (filter (fn [e]
+                                        (and (ent/friendly? e)
+                                             (:pos e)
+                                             (in-fov? world (:pos e)))))
+                              (sort-by (juxt dist-to (comp str :id)))
+                              first)]
+            (cond
+              (and player friendly (:pos player)
+                   (< (dist-to friendly) (dist-to player)))
+              friendly
+              (and player (:pos player)) player
+              :else friendly)))))))
 
 ;; --- AI State Machine ---
 ;; States: :sleep, :wander, :hunt, :investigate, :flee
 ;;
-;; :sleep     — standing still, might wander or wake on seeing player
-;; :wander    — roaming randomly, alert to player presence
-;; :hunt      — chasing the player, attacks when adjacent
-;; :investigate — moving to last known player position, then searching
-;; :flee      — running away from player (low HP)
+;; :sleep     — standing still, might wander or wake on spotting target
+;; :wander    — roaming randomly, alert to target presence
+;; :hunt      — chasing target, attacks when adjacent
+;; :investigate — moving to last known target position, then searching
+;; :flee      — running away from target (low HP / burning)
+;;
+;; "Target" is the player for hostiles, the nearest hostile for
+;; friendlies. find-target above does the lookup; everything else here
+;; treats target uniformly. Pre-faction code hardcoded :player.
 
 (defn update-ai-state [world entity-id]
   (let [entity (get-in world [:entities entity-id])
-        player (get-in world [:entities :player])]
-    (if (or (nil? entity) (nil? player) (nil? (:pos entity)) (nil? (:pos player)))
+        target (when entity (find-target world entity))]
+    (if (or (nil? entity) (nil? (:pos entity)))
       world
       (let [ai (:ai entity)
             state (get ai :state :sleep)
             pos (:pos entity)
-            player-pos (:pos player)
-            dist (distance pos player-pos)
-            sees-player (can-see-player? world entity)
+            target-pos (:pos target)
+            sees-target (some? target)
+            dist (when target-pos (distance pos target-pos))
             hp (get-in entity [:body :hp] 1)
             max-hp (get-in entity [:body :max-hp] 1)
             behavior (or (:behavior ai) :hunter)
             low-hp (< (/ (float hp) max-hp) flee-hp-pct)
-            ;; ranged creatures also flee when player gets too close
             ranged-too-close (and (= behavior :ranged)
-                                  sees-player
+                                  sees-target
                                   (< dist 3)
                                   (= state :hunt))]
         (cond
@@ -190,8 +233,8 @@
                (not (get-in entity [:properties :fire-immune])))
           (assoc-in world [:entities entity-id :ai :state] :flee)
 
-          ;; --- From any state: flee if low HP and can see player ---
-          (or (and low-hp sees-player (< dist chase-radius) (not= state :flee))
+          ;; --- From any state: flee if low HP and can see target ---
+          (or (and low-hp sees-target (< dist chase-radius) (not= state :flee))
               ranged-too-close)
           (-> world
               (assoc-in [:entities entity-id :ai :state] :flee))
@@ -199,12 +242,10 @@
           ;; --- SLEEP ---
           (= state :sleep)
           (cond
-            ;; see player nearby → hunt
-            (and sees-player (< dist wake-radius))
+            (and sees-target (< dist wake-radius))
             (-> world
                 (assoc-in [:entities entity-id :ai :state] :hunt)
-                (assoc-in [:entities entity-id :ai :target] player-pos))
-            ;; random chance to start wandering — deterministic roll
+                (assoc-in [:entities entity-id :ai :target] target-pos))
             :else
             (let [w-ctx (det/with-context world [:ai :sleep-wake entity-id])
                   pair (det/percent? w-ctx wander-chance)
@@ -217,12 +258,10 @@
           ;; --- WANDER ---
           (= state :wander)
           (cond
-            ;; see player → hunt
-            (and sees-player (< dist wake-radius))
+            (and sees-target (< dist wake-radius))
             (-> world
                 (assoc-in [:entities entity-id :ai :state] :hunt)
-                (assoc-in [:entities entity-id :ai :target] player-pos))
-            ;; random chance to go back to sleep — deterministic roll
+                (assoc-in [:entities entity-id :ai :target] target-pos))
             :else
             (let [w-ctx (det/with-context world [:ai :wander-sleep entity-id])
                   pair (det/percent? w-ctx 10)
@@ -235,25 +274,21 @@
           ;; --- HUNT ---
           (= state :hunt)
           (cond
-            ;; lost sight and out of range → investigate last known pos
-            (and (not sees-player) (> dist chase-radius))
+            (and (not sees-target) (or (nil? dist) (> dist chase-radius)))
             (-> world
                 (assoc-in [:entities entity-id :ai :state] :investigate)
                 (assoc-in [:entities entity-id :ai :search-turns] investigate-turns))
-            ;; update target if we can see player
-            sees-player
-            (assoc-in world [:entities entity-id :ai :target] player-pos)
+            sees-target
+            (assoc-in world [:entities entity-id :ai :target] target-pos)
             :else world)
 
           ;; --- INVESTIGATE ---
           (= state :investigate)
           (cond
-            ;; spotted player again → hunt
-            (and sees-player (< dist chase-radius))
+            (and sees-target (< dist chase-radius))
             (-> world
                 (assoc-in [:entities entity-id :ai :state] :hunt)
-                (assoc-in [:entities entity-id :ai :target] player-pos))
-            ;; ran out of search turns → sleep
+                (assoc-in [:entities entity-id :ai :target] target-pos))
             (<= (get ai :search-turns 0) 0)
             (-> world
                 (assoc-in [:entities entity-id :ai :state] :sleep)
@@ -264,19 +299,16 @@
           ;; --- FLEE ---
           (= state :flee)
           (cond
-            ;; player far away or not visible → sleep
-            (or (> dist chase-radius) (not sees-player))
+            (or (nil? dist) (> dist chase-radius) (not sees-target))
             (assoc-in world [:entities entity-id :ai :state] :sleep)
-            ;; HP recovered → hunt instead
             (not low-hp)
             (-> world
                 (assoc-in [:entities entity-id :ai :state] :hunt)
-                (assoc-in [:entities entity-id :ai :target] player-pos))
-            ;; ranged: got to safe distance → back to hunt (kiting)
+                (assoc-in [:entities entity-id :ai :target] target-pos))
             (and (= behavior :ranged) (>= dist (or (:preferred-range ai) 5)))
             (-> world
                 (assoc-in [:entities entity-id :ai :state] :hunt)
-                (assoc-in [:entities entity-id :ai :target] player-pos))
+                (assoc-in [:entities entity-id :ai :target] target-pos))
             :else world)
 
           :else world)))))
@@ -284,16 +316,17 @@
 ;; --- AI Actions ---
 
 (defn hunt-melee
-  "Standard melee hunt: approach and attack when adjacent."
-  [world entity-id pos player-pos attack-fn]
-  (if (adjacent? pos player-pos)
-    (attack-fn world entity-id :player)
-    (let [[dx dy] (step-toward pos player-pos)]
+  "Standard melee hunt: approach and attack when adjacent to target."
+  [world entity-id pos target-id target-pos attack-fn]
+  (if (adjacent? pos target-pos)
+    (attack-fn world entity-id target-id)
+    (let [[dx dy] (step-toward pos target-pos)]
       (try-move world entity-id dx dy))))
 
 (defn hunt-ranged
-  "Ranged hunt: maintain preferred distance. Shoot when in range + LOS.
-   Flee if too close, approach if too far, sidestep if no LOS.
+  "Ranged hunt: maintain preferred distance from target. Shoot when in
+   range + LOS. Flee if too close, approach if too far, sidestep if
+   no LOS.
 
    The fire-chance roll fires deterministically whenever we evaluate the
    shoot branch's gating condition (in-range + LOS). Even if the chance
@@ -301,23 +334,18 @@
    has been consumed — this matches the original semantics: cond
    short-circuits, so the rand-int only fired when the in-range+LOS
    prerequisites were met."
-  [world entity-id pos player-pos attack-fn ranged-attack-fn]
+  [world entity-id pos target-id target-pos attack-fn ranged-attack-fn]
   (let [entity (get-in world [:entities entity-id])
         ai (:ai entity)
         pref-range (or (:preferred-range ai) 5)
         spell-data (get-in entity [:spells :ranged])
         max-range (or (:range spell-data) 6)
-        dist (distance pos player-pos)
-        [px py] player-pos
+        dist (distance pos target-pos)
+        [tx ty] target-pos
         [ex ey] pos
-        los (has-clear-line? world ex ey px py)
+        los (has-clear-line? world ex ey tx ty)
         too-close (< dist (- pref-range 1))
         in-range-with-los (and (<= dist max-range) los)
-        ;; Pre-roll fire-chance only when the cond would have evaluated it.
-        ;; In the original, the rand-int was inside branch 2's predicate,
-        ;; which is only reached if branch 1 (too close) is false AND
-        ;; the and-clause short-circuits past the (<= dist max-range) and
-        ;; los checks. So we fire iff (not too-close) AND in-range-with-los.
         fire-pair (if (and (not too-close) in-range-with-los)
                     (det/percent? (det/with-context world [:ai :ranged-fire entity-id])
                                   (or (:fire-chance spell-data) 100))
@@ -325,43 +353,42 @@
         fires-now (first fire-pair)
         world (second fire-pair)]
     (cond
-      ;; too close — back away
       (< dist (- pref-range 1))
-      (let [w (let [[dx dy] (step-away pos player-pos)]
+      (let [w (let [[dx dy] (step-away pos target-pos)]
                 (try-move world entity-id dx dy))]
-        ;; if couldn't move (cornered), melee
         (if (= (get-in w [:entities entity-id :pos]) pos)
-          (if (adjacent? pos player-pos)
-            (attack-fn world entity-id :player)
+          (if (adjacent? pos target-pos)
+            (attack-fn world entity-id target-id)
             w)
           w))
 
-      ;; in range and has LOS and rolled to fire — shoot
       (and in-range-with-los fires-now)
-      (ranged-attack-fn world entity-id :player)
+      (ranged-attack-fn world entity-id target-id)
 
-      ;; in range but no LOS — approach to get angle
       (<= dist max-range)
-      (let [[dx dy] (step-toward pos player-pos)]
+      (let [[dx dy] (step-toward pos target-pos)]
         (try-move world entity-id dx dy))
 
-      ;; too far — approach
       :else
-      (let [[dx dy] (step-toward pos player-pos)]
+      (let [[dx dy] (step-toward pos target-pos)]
         (try-move world entity-id dx dy)))))
 
 (defn ai-act [world entity-id attack-fn ranged-attack-fn]
-  (let [entity (get-in world [:entities entity-id])
-        player (get-in world [:entities :player])]
-    (if (or (nil? entity) (nil? player))
+  (let [entity (get-in world [:entities entity-id])]
+    (if (nil? entity)
       world
       (let [ai (:ai entity)
             state (get ai :state :sleep)
             behavior (or (:behavior ai) :hunter)
             pos (:pos entity)
-            player-pos (:pos player)
-            target (get ai :target)]
-        (if (or (nil? pos) (nil? player-pos))
+            target (find-target world entity)
+            target-id (:id target)
+            target-pos (:pos target)
+            ;; :investigate uses the LAST KNOWN position from :ai :target,
+            ;; not the live find-target lookup (the whole point is searching
+            ;; somewhere we no longer see them).
+            last-known (get ai :target)]
+        (if (nil? pos)
           world
           (case state
             :sleep world
@@ -370,41 +397,46 @@
             (random-step world entity-id)
 
             :hunt
-            (case behavior
-              :ranged (hunt-ranged world entity-id pos player-pos attack-fn ranged-attack-fn)
-              ;; :hunter, :pack, :aggressive — all melee for now
-              (hunt-melee world entity-id pos player-pos attack-fn))
+            (if (nil? target)
+              ;; lost target this turn (e.g. friendly killed last hostile) —
+              ;; idle this tick, update-ai-state will rotate to investigate
+              ;; or sleep on the next pass.
+              world
+              (case behavior
+                :ranged (hunt-ranged world entity-id pos target-id target-pos
+                                     attack-fn ranged-attack-fn)
+                (hunt-melee world entity-id pos target-id target-pos attack-fn)))
 
             :investigate
-            (if (and target (not= pos target))
-              (let [[dx dy] (step-toward pos target)]
+            (if (and last-known (not= pos last-known))
+              (let [[dx dy] (step-toward pos last-known)]
                 (try-move world entity-id dx dy))
               (random-step world entity-id))
 
             :flee
-            (let [dist (distance pos player-pos)
-                  [ex ey] pos [px py] player-pos]
-              (cond
-                ;; ranged creatures try to shoot while fleeing
-                (and (= behavior :ranged)
-                     (let [spell-data (get-in entity [:spells :ranged])
-                           max-range (or (:range spell-data) 6)]
-                       (and (<= dist max-range)
-                            (has-clear-line? world ex ey px py))))
-                (ranged-attack-fn world entity-id :player)
+            (if (nil? target)
+              (if (status/has-status? world entity-id :burning)
+                (random-step world entity-id)
+                world)
+              (let [dist (distance pos target-pos)
+                    [ex ey] pos [tx ty] target-pos]
+                (cond
+                  (and (= behavior :ranged)
+                       (let [spell-data (get-in entity [:spells :ranged])
+                             max-range (or (:range spell-data) 6)]
+                         (and (<= dist max-range)
+                              (has-clear-line? world ex ey tx ty))))
+                  (ranged-attack-fn world entity-id target-id)
 
-                ;; cornered — fight back
-                (adjacent? pos player-pos)
-                (attack-fn world entity-id :player)
+                  (adjacent? pos target-pos)
+                  (attack-fn world entity-id target-id)
 
-                ;; run — random if burning (panic), away from player otherwise
-                :else
-                (if (status/has-status? world entity-id :burning)
-                  (random-step world entity-id)
-                  (let [[dx dy] (step-away pos player-pos)]
-                    (try-move world entity-id dx dy)))))
+                  :else
+                  (if (status/has-status? world entity-id :burning)
+                    (random-step world entity-id)
+                    (let [[dx dy] (step-away pos target-pos)]
+                      (try-move world entity-id dx dy))))))
 
-            ;; default
             world))))))
 
 ;; --- Process All Creatures ---

--- a/xsofy/check_gen.lg
+++ b/xsofy/check_gen.lg
@@ -281,6 +281,19 @@
           (ent/spawn world :goblin pos)
           world)))))
 
+(def gen-rich-world-with-friendly
+  ;; gen-rich-world-with-creature with :friendly true flipped on the first
+  ;; non-player AI creature. Exercises faction-aware AI: ai-act and
+  ;; process-creatures must handle entities that don't target the player.
+  (c/gen-let [world gen-rich-world-with-creature]
+    (let [cid (->> (vals (:entities world))
+                   (filter (fn [e] (and (:ai e) (not= :player (:id e)))))
+                   (map :id)
+                   first)]
+      (if cid
+        (assoc-in world [:entities cid :friendly] true)
+        world))))
+
 (defn creature-ids
   "All non-player ids that have a :body."
   [world]

--- a/xsofy/check_gen.lg
+++ b/xsofy/check_gen.lg
@@ -282,9 +282,7 @@
           world)))))
 
 (def gen-rich-world-with-friendly
-  ;; gen-rich-world-with-creature with :friendly true flipped on the first
-  ;; non-player AI creature. Exercises faction-aware AI: ai-act and
-  ;; process-creatures must handle entities that don't target the player.
+  ;; rich world with :friendly flipped on the first non-player AI creature.
   (c/gen-let [world gen-rich-world-with-creature]
     (let [cid (->> (vals (:entities world))
                    (filter (fn [e] (and (:ai e) (not= :player (:id e)))))

--- a/xsofy/entities.lg
+++ b/xsofy/entities.lg
@@ -405,6 +405,10 @@
                     (assoc-in [:entities clone-id :body :hp] half-hp)
                     (assoc-in [:entities clone-id :body :max-hp] half-hp)
                     (assoc-in [:entities clone-id :ticks] parent-ticks)
+                    ;; Inherit :friendly — without this, a friendly slime
+                    ;; that gets hit spawns hostile clones in :hunt state
+                    ;; right next to the player. Surfaced in playtest.
+                    (assoc-in [:entities clone-id :friendly] (:friendly entity))
                     (assoc-in [:entities clone-id :ai :state] :hunt)))))))
       nil)))
 

--- a/xsofy/entities.lg
+++ b/xsofy/entities.lg
@@ -222,15 +222,13 @@
   (> (get-in entity [:body :hp] 0) 0))
 
 (defn friendly?
-  "Conjured allies / pets carry :friendly true. Used by the AI to choose
-   whether to chase or ignore an entity, and by player-move / fire-bow
-   to skip them. See xsofy.ai/find-target."
+  "Conjured allies / pets. AI chases hostiles-of-faction; player-move
+   and fire-bow skip them."
   [entity]
   (true? (:friendly entity)))
 
 (defn hostile-to-player?
-  "An :ai-bearing entity that is neither the player nor friendly. AoE
-   spells and creature targeting use this to filter candidate enemies."
+  "An :ai entity that is neither the player nor friendly."
   [entity]
   (and (:ai entity)
        (not= :player (:id entity))
@@ -405,9 +403,7 @@
                     (assoc-in [:entities clone-id :body :hp] half-hp)
                     (assoc-in [:entities clone-id :body :max-hp] half-hp)
                     (assoc-in [:entities clone-id :ticks] parent-ticks)
-                    ;; Inherit :friendly — without this, a friendly slime
-                    ;; that gets hit spawns hostile clones in :hunt state
-                    ;; right next to the player. Surfaced in playtest.
+                    ;; Friendly slime spawns hostile clones without this.
                     (assoc-in [:entities clone-id :friendly] (:friendly entity))
                     (assoc-in [:entities clone-id :ai :state] :hunt)))))))
       nil)))

--- a/xsofy/entities.lg
+++ b/xsofy/entities.lg
@@ -221,6 +221,21 @@
 (defn alive? [entity]
   (> (get-in entity [:body :hp] 0) 0))
 
+(defn friendly?
+  "Conjured allies / pets carry :friendly true. Used by the AI to choose
+   whether to chase or ignore an entity, and by player-move / fire-bow
+   to skip them. See xsofy.ai/find-target."
+  [entity]
+  (true? (:friendly entity)))
+
+(defn hostile-to-player?
+  "An :ai-bearing entity that is neither the player nor friendly. AoE
+   spells and creature targeting use this to filter candidate enemies."
+  [entity]
+  (and (:ai entity)
+       (not= :player (:id entity))
+       (not (:friendly entity))))
+
 ;; --- Entity Modification ---
 
 (defn update-entity [world id f & args]

--- a/xsofy/render.lg
+++ b/xsofy/render.lg
@@ -142,6 +142,11 @@
     (= :item (:entity-type e))  1
     :else                       2))
 
+;; Tint blended into a creature's :visual color when (:friendly e) is
+;; true. Cyan-blue stays clear of player gold [255 220 80], hostile red,
+;; goblin green, fire-orange.
+(def friendly-tint [120 200 255])
+
 (defn render-entity [world r entity]
   (when-let [pos (:pos entity)]
     (let [{:keys [fov]} world
@@ -160,15 +165,23 @@
                     (fx/stain-tint-bg tile-bg (:type stain) (or (:intensity stain) 1) x y)
                     tile-bg)
               bg-lit (if lv (light/apply-light bg0 lv) bg0)
-              ;; entity fg — apply status tint if any
+              ;; entity fg — apply friendly tint first (so an ally on
+              ;; fire still reads as burning), then status tint.
               base-fg (get-in entity [:visual :color] [200 60 60])
+              friendly-fg (if (:friendly entity)
+                            (let [[br bg bb] base-fg
+                                  [fr fgc fb] friendly-tint]
+                              [(quot (+ br fr) 2)
+                               (quot (+ bg fgc) 2)
+                               (quot (+ bb fb) 2)])
+                            base-fg)
               stint (status/entity-status-tint entity)
               fg0 (if stint
                     (let [[sc _] stint
-                          [br bg bb] base-fg
+                          [br bg bb] friendly-fg
                           [sr sg sb] sc]
                       [(quot (+ br sr) 2) (quot (+ bg sg) 2) (quot (+ bb sb) 2)])
-                    base-fg)
+                    friendly-fg)
               bg1 (if stint
                     (let [[_ sbg] stint
                           [br bg bb] bg-lit
@@ -230,10 +243,13 @@
         tpl (:template c)
         eid (:id c)
         cname (if tpl (name tpl) (if eid (name eid) "???"))
-        color (or (get-in c [:visual :color]) [200 60 60])
+        ally-tag (if (:friendly c) " (ally)" "")
+        color (if (:friendly c)
+                friendly-tint
+                (or (get-in c [:visual :color]) [200 60 60]))
         glyph (or (get-in c [:visual :glyph]) "?")]
     (when (< (+ row 1) (:h r))
-      (ui/write-line r row (str " " glyph " " cname) color ui/bg)
+      (ui/write-line r row (str " " glyph " " cname ally-tag) color ui/bg)
       (let [row (inc row)]
         (ui/bar r row (str " " chp "/" cmhp)
                 chp cmhp

--- a/xsofy/render.lg
+++ b/xsofy/render.lg
@@ -142,9 +142,8 @@
     (= :item (:entity-type e))  1
     :else                       2))
 
-;; Tint blended into a creature's :visual color when (:friendly e) is
-;; true. Cyan-blue stays clear of player gold [255 220 80], hostile red,
-;; goblin green, fire-orange.
+;; Cyan-blue — stays clear of player gold, hostile red, goblin green,
+;; fire-orange.
 (def friendly-tint [120 200 255])
 
 (defn render-entity [world r entity]
@@ -165,8 +164,8 @@
                     (fx/stain-tint-bg tile-bg (:type stain) (or (:intensity stain) 1) x y)
                     tile-bg)
               bg-lit (if lv (light/apply-light bg0 lv) bg0)
-              ;; entity fg — apply friendly tint first (so an ally on
-              ;; fire still reads as burning), then status tint.
+              ;; friendly tint first so an ally on fire still reads as
+              ;; burning, then status tint.
               base-fg (get-in entity [:visual :color] [200 60 60])
               friendly-fg (if (:friendly entity)
                             (let [[br bg bb] base-fg

--- a/xsofy/spell.lg
+++ b/xsofy/spell.lg
@@ -338,7 +338,14 @@
             before (set (keys (:entities world)))
             w (ent/spawn world species pos)
             new-id (first (filter #(not (contains? before %))
-                                  (keys (:entities w))))]
+                                  (keys (:entities w))))
+            ;; Inherit caster's :ticks so the summon doesn't start at 0
+            ;; while everyone else on the floor sits at hundreds. Without
+            ;; this, run-until-player-turn has to catch the summon up,
+            ;; and pulls all other low-ticks actors forward with it —
+            ;; hostiles get multi-tile "jump" turns per player step.
+            caster-ticks (or (get-in world [:entities (:caster ctx) :ticks]) 0)
+            w (assoc-in w [:entities new-id :ticks] caster-ticks)]
         (-> ctx
             (assoc :world w)
             (assoc :last-conjured-id new-id))))))

--- a/xsofy/spell.lg
+++ b/xsofy/spell.lg
@@ -344,15 +344,15 @@
             (assoc :last-conjured-id new-id))))))
 
 (defn r-friend
-  "Stub. Faction-aware AI doesn't exist yet — the AI in xsofy.ai always
-   targets the player — so a creature marked :friendly would still
-   attack the caster and the player would be summoning a confusingly-
-   named enemy. Until the faction work lands as a separate PR, :friend
-   stays in the rune vocabulary as a no-op so inscriptions don't
-   backfire (that was the original bug in nooga/xsofy#32), it just
-   doesn't do anything visible. Per #32 review (Oakwhisper)."
+  "Mark the last conjured creature as :friendly. xsofy.ai/find-target
+   reads the flag — friendlies seek the nearest hostile instead of the
+   player, hostiles treat friendlies as candidate targets. Without a
+   prior conjure in this spell, no-op."
   [ctx]
-  ctx)
+  (let [id (:last-conjured-id ctx)]
+    (if (and id (get-in ctx [:world :entities id]))
+      (assoc-in ctx [:world :entities id :friendly] true)
+      ctx)))
 
 (def rune-primitives
   {:self     r-self

--- a/xsofy/spell.lg
+++ b/xsofy/spell.lg
@@ -339,11 +339,10 @@
             w (ent/spawn world species pos)
             new-id (first (filter #(not (contains? before %))
                                   (keys (:entities w))))
-            ;; Inherit caster's :ticks so the summon doesn't start at 0
-            ;; while everyone else on the floor sits at hundreds. Without
-            ;; this, run-until-player-turn has to catch the summon up,
-            ;; and pulls all other low-ticks actors forward with it —
-            ;; hostiles get multi-tile "jump" turns per player step.
+            ;; Inherit caster :ticks; otherwise the summon's :ticks 0
+            ;; pulls every other low-ticks actor forward in
+            ;; run-until-player-turn (hostiles "jump" multiple tiles
+            ;; per player step).
             caster-ticks (or (get-in world [:entities (:caster ctx) :ticks]) 0)
             w (assoc-in w [:entities new-id :ticks] caster-ticks)]
         (-> ctx
@@ -351,10 +350,8 @@
             (assoc :last-conjured-id new-id))))))
 
 (defn r-friend
-  "Mark the last conjured creature as :friendly. xsofy.ai/find-target
-   reads the flag — friendlies seek the nearest hostile instead of the
-   player, hostiles treat friendlies as candidate targets. Without a
-   prior conjure in this spell, no-op."
+  "Mark the last conjured creature as :friendly. No-op without a prior
+   conjure in this spell."
   [ctx]
   (let [id (:last-conjured-id ctx)]
     (if (and id (get-in ctx [:world :entities id]))

--- a/xsofy/test/combat_prop.lg
+++ b/xsofy/test/combat_prop.lg
@@ -173,3 +173,142 @@
   [world g/gen-rich-world]
   (g/world-invariants?
     (ai/process-creatures world w/melee-attack w/ranged-attack)))
+
+;; ============================================================================
+;; Faction-aware AI — :friendly creatures hunt hostiles, not the player.
+;; ============================================================================
+
+(defn- minimal-with-player
+  "Tiny room + a fully-shaped player at pos. fov gets populated by
+   the caller via w/update-fov so find-target's in-fov? gate works."
+  [pos]
+  (-> (g/minimal-stone-room)
+      (assoc-in [:entities :player]
+        {:id :player :template :player :pos pos
+         :ticks 0 :status {} :statuses {} :inventory []
+         :body {:hp 30 :max-hp 30 :strength 2 :armor 0}})))
+
+(deftest friendly-creature-does-not-attack-player
+  (testing "A creature flagged :friendly ignores the player even when
+            adjacent and in :hunt. Pre-faction code would melee-attack."
+    (let [world (-> (minimal-with-player [3 3])
+                    (assoc-in [:entities :rat-1]
+                      {:id :rat-1 :template :rat :pos [4 3]
+                       :ticks 0 :status {} :statuses {}
+                       :friendly true
+                       :ai {:state :hunt :behavior :hunter :speed 1
+                            :target [3 3]}
+                       :body {:hp 6 :max-hp 6 :strength 1 :armor 0}})
+                    w/update-fov)
+          hp-before (get-in world [:entities :player :body :hp])
+          w' (ai/ai-act world :rat-1 w/melee-attack w/ranged-attack)
+          hp-after (get-in w' [:entities :player :body :hp])]
+      (is (= hp-before hp-after)))))
+
+(deftest hostile-targets-friendly-when-closer-than-player
+  (testing "find-target for a hostile prefers a visible friendly over
+            the player when the friendly is closer."
+    (let [world (-> (minimal-with-player [1 1])
+                    (assoc-in [:entities :friend-1]
+                      {:id :friend-1 :template :rat :pos [5 5]
+                       :ticks 0 :status {} :statuses {}
+                       :friendly true
+                       :ai {:state :hunt :behavior :hunter :speed 1}
+                       :body {:hp 6 :max-hp 6 :strength 1 :armor 0}})
+                    (assoc-in [:entities :goblin-1]
+                      {:id :goblin-1 :template :goblin :pos [6 5]
+                       :ticks 0 :status {} :statuses {}
+                       :ai {:state :hunt :behavior :hunter :speed 1}
+                       :body {:hp 15 :max-hp 15 :strength 2 :armor 0}})
+                    w/update-fov)
+          target (ai/find-target world (get-in world [:entities :goblin-1]))]
+      (is (some? target))
+      (is (= :friend-1 (:id target))))))
+
+(deftest fire-bow-skips-friendlies
+  (testing "find-nearest-enemy (drives fire-bow auto-aim) skips
+            entities flagged :friendly even when they're closer."
+    (let [world (-> (minimal-with-player [2 3])
+                    (assoc-in [:entities :friend-1]
+                      {:id :friend-1 :template :rat :pos [4 3]
+                       :friendly true
+                       :ai {:state :hunt :behavior :hunter :speed 1}
+                       :body {:hp 6 :max-hp 6}})
+                    (assoc-in [:entities :goblin-1]
+                      {:id :goblin-1 :template :goblin :pos [6 3]
+                       :ai {:state :hunt :behavior :hunter :speed 1}
+                       :body {:hp 15 :max-hp 15}})
+                    w/update-fov)
+          nearest (w/find-nearest-enemy world 10)]
+      (is (some? nearest))
+      (is (= :goblin-1 (:id nearest))))))
+
+(c/defprop friendly-ai-act-doesnt-throw
+  [world g/gen-rich-world-with-friendly]
+  (let [creatures (g/creature-ids world)]
+    (if (empty? creatures)
+      true
+      (do (ai/ai-act world (first creatures)
+                     w/melee-attack w/ranged-attack)
+          true))))
+
+(c/defprop friendly-ai-act-preserves-invariants
+  [world g/gen-rich-world-with-friendly]
+  (let [creatures (g/creature-ids world)]
+    (if (empty? creatures)
+      true
+      (g/world-invariants?
+        (ai/ai-act world (first creatures)
+                   w/melee-attack w/ranged-attack)))))
+
+(c/defprop process-creatures-with-friendlies-preserves-invariants
+  [world g/gen-rich-world-with-friendly]
+  (g/world-invariants?
+    (ai/process-creatures world w/melee-attack w/ranged-attack)))
+
+(deftest hostile-targets-player-when-no-friendly
+  (testing "find-target for a hostile with no visible friendly returns the
+            player. The core invariant the faction rewrite must preserve."
+    (let [world (-> (minimal-with-player [3 3])
+                    (assoc-in [:entities :goblin-1]
+                      {:id :goblin-1 :template :goblin :pos [5 3]
+                       :ticks 0 :status {} :statuses {}
+                       :ai {:state :hunt :behavior :hunter :speed 1}
+                       :body {:hp 15 :max-hp 15 :strength 2 :armor 0}})
+                    w/update-fov)
+          target (ai/find-target world (get-in world [:entities :goblin-1]))]
+      (is (some? target) "hostile has a target")
+      (is (= :player (:id target)) "and it is the player"))))
+
+(deftest find-target-tiebreak-is-deterministic
+  (testing "Among equidistant visible candidates, find-target picks the same
+            one regardless of entity-map insertion order (stable :id tiebreak)."
+    (let [ally  {:id :ally-1 :template :rat :pos [4 4] :friendly true
+                 :ticks 0 :status {} :statuses {}
+                 :ai {:state :hunt :behavior :hunter :speed 1}
+                 :body {:hp 6 :max-hp 6}}
+          gob-a {:id :goblin-a :template :goblin :pos [4 6]   ;; distance 2 from ally
+                 :ticks 0 :status {} :statuses {}
+                 :ai {:state :hunt :behavior :hunter :speed 1}
+                 :body {:hp 15 :max-hp 15}}
+          gob-b {:id :goblin-b :template :goblin :pos [6 4]   ;; distance 2 from ally
+                 :ticks 0 :status {} :statuses {}
+                 :ai {:state :hunt :behavior :hunter :speed 1}
+                 :body {:hp 15 :max-hp 15}}
+          base (-> (g/minimal-stone-room)
+                   (assoc :fov #{[4 4] [4 6] [6 4]})
+                   (assoc-in [:entities :player]
+                     {:id :player :template :player :pos [9 9]
+                      :ticks 0 :status {} :statuses {} :inventory []
+                      :body {:hp 30 :max-hp 30}}))
+          w-ab (-> base (assoc-in [:entities :goblin-a] gob-a)
+                        (assoc-in [:entities :goblin-b] gob-b)
+                        (assoc-in [:entities :ally-1] ally))
+          w-ba (-> base (assoc-in [:entities :ally-1] ally)
+                        (assoc-in [:entities :goblin-b] gob-b)
+                        (assoc-in [:entities :goblin-a] gob-a))
+          t-ab (ai/find-target w-ab (get-in w-ab [:entities :ally-1]))
+          t-ba (ai/find-target w-ba (get-in w-ba [:entities :ally-1]))]
+      (is (some? t-ab) "a target is found")
+      (is (= (:id t-ab) (:id t-ba)) "target is independent of insertion order")
+      (is (= :goblin-a (:id t-ab)) "deterministic pick: lowest :id wins on a tie"))))

--- a/xsofy/test/spell_prop.lg
+++ b/xsofy/test/spell_prop.lg
@@ -230,19 +230,18 @@
                  (<= (math/abs (- ny py)) 1)
                  (not (and (= nx px) (= ny py)))))))))
 
-(deftest conjure-then-friend-stub-is-noop-until-faction-ai
-  (testing "[:conjure :friend] runs cleanly without backfire — the original
-            #32 bug — but the :friend stub deliberately leaves the conjured
-            creature unmarked until faction-aware AI lands. Per #32 review
-            (Oakwhisper). When faction work lands, flip this assertion to
-            check (:friendly entity)."
+(deftest conjure-then-friend-marks-summon-friendly
+  (testing "[:conjure :friend] runs cleanly without backfire (the
+            original #32 bug) and flips :friendly true on the conjured
+            creature. xsofy.ai/find-target then routes the new entity
+            against hostiles instead of the player."
     (let [world  (player-in-room [4 4])
           result (spell/eval-spell world :player [4 4] [:conjure :friend])
           w'     (:world result)
           new-id (first (filter #(not= % :player) (keys (:entities w'))))]
       (is (nil? (:error result)))
       (is (= (inc (count (:entities world))) (count (:entities w'))))
-      (is (nil? (get-in w' [:entities new-id :friendly]))))))
+      (is (true? (get-in w' [:entities new-id :friendly]))))))
 
 (deftest friend-without-prior-conjure-is-a-quiet-noop
   (testing "Bare :friend before any conjure must not backfire — no error,

--- a/xsofy/test/world_prop.lg
+++ b/xsofy/test/world_prop.lg
@@ -108,6 +108,29 @@
       (is (< (:turn world) (:turn w')))
       (is (= [2 2] (get-in w' [:entities :player :pos]))))))
 
+(deftest player-bumping-friendly-swaps-positions
+  (testing "Player walking into a :friendly creature swaps positions
+            (Brogue-style ally swap) instead of attacking, ally HP is
+            unchanged. Calls player-move directly to isolate the swap
+            from the post-turn creature loop."
+    (let [world (-> (g/minimal-stone-room)
+                    (assoc-in [:entities :player]
+                      {:id :player :template :player :pos [2 2]
+                       :ticks 0 :status {} :statuses {} :inventory []
+                       :body {:hp 30 :max-hp 30 :strength 2 :armor 0}})
+                    (assoc-in [:entities :ally-1]
+                      {:id :ally-1 :template :rat :pos [3 2]
+                       :ticks 0 :status {} :statuses {}
+                       :friendly true
+                       :ai {:state :hunt :behavior :hunter :speed 1}
+                       :body {:hp 6 :max-hp 6 :strength 1 :armor 0}}))
+          hp-before (get-in world [:entities :ally-1 :body :hp])
+          w' (w/player-move world 1 0)]
+      (is (= [3 2] (get-in w' [:entities :player :pos])))
+      (is (= [2 2] (get-in w' [:entities :ally-1 :pos])))
+      (is (= hp-before (get-in w' [:entities :ally-1 :body :hp])))
+      (is (< (:turn world) (:turn w'))))))
+
 (deftest burning-low-hp-player-with-expiring-status-doesnt-resurrect
   (testing "Player dies from burning AND has a status about to expire on same tick.
             The remove-status of the expired one must not resurrect a dead player."

--- a/xsofy/util.lg
+++ b/xsofy/util.lg
@@ -14,6 +14,10 @@
   (let [[x1 y1] p1 [x2 y2] p2]
     (+ (math/abs (- x2 x1)) (math/abs (- y2 y1)))))
 
+(defn chebyshev [p1 p2]
+  (let [[x1 y1] p1 [x2 y2] p2]
+    (max (math/abs (- x2 x1)) (math/abs (- y2 y1)))))
+
 (defn sign [n]
   (cond (> n 0) 1 (< n 0) -1 :else 0))
 

--- a/xsofy/world.lg
+++ b/xsofy/world.lg
@@ -1239,7 +1239,9 @@
                    inv))))
 
 (defn find-nearest-enemy [world max-range]
-  "Find nearest visible enemy within range. Returns entity or nil."
+  "Find nearest visible enemy within range. Returns entity or nil.
+   Skips :friendly entities so the fire-bow doesn't target the player's
+   own summons."
   (let [player-pos (get-in world [:entities :player :pos])
         fov (or (:fov world) #{})
         [px py] player-pos
@@ -1247,6 +1249,7 @@
                         (filter (fn [e]
                                   (and (:ai e) (:pos e)
                                        (not= :player (:id e))
+                                       (not (:friendly e))
                                        (get-in e [:body :hp])
                                        (contains? fov (:pos e)))))
                         (vec))]
@@ -1422,6 +1425,39 @@
               update-fov
               (log-msg "You open the door.")))
 
+      ;; Bumping a friendly: swap places (Brogue-style) when both cells
+      ;; are safe, log a block otherwise. Avoids friendly-fire melee and
+      ;; prevents the player from getting stuck behind their own summon
+      ;; in narrow passages. Friendlies on hazard tiles can't be swapped
+      ;; into — player would fall in.
+      ;;
+      ;; Charge the swapped friendly its own per-turn cost too. Without
+      ;; this the swap moves the ally one tile but leaves their :ticks
+      ;; untouched, so run-until-player-turn gives them an immediate
+      ;; full turn — net effect is a 2-tile move per single player
+      ;; step. (quot move-cost speed) preserves speed-2 allies'
+      ;; advantage.
+      (let [c (ent/creature-at world [nx ny])]
+        (and c (:friendly c)))
+      (let [bump (ent/creature-at world [nx ny])
+            bname (or (:item-name bump)
+                      (name (or (:template bump) (:id bump))))
+            ;; Clamp at 1: (or x 1) defaults a missing key, but an
+            ;; explicit :ai {:speed 0} (templated or set by future code)
+            ;; would still divide by zero.
+            bump-speed (max 1 (or (get-in bump [:ai :speed]) 1))
+            bump-cost (quot move-cost bump-speed)]
+        (if (terrain/walkable? terrain width height nx ny)
+          (-> world
+              (assoc-in [:entities :player :pos] [nx ny])
+              (assoc-in [:entities (:id bump) :pos] [px py])
+              (add-ticks :player move-cost)
+              (add-ticks (:id bump) bump-cost)
+              (update :turn inc)
+              update-fov
+              (log-msg (str "You swap places with the " bname ".")))
+          (log-msg world (str "The " bname " is in the way."))))
+
       ;; walkable, reach weapon, or a non-player creature on the
       ;; destination cell — bumping a creature on a hazard tile (e.g.
       ;; wraith over chasm) should attack, not open the leap prompt
@@ -1439,12 +1475,14 @@
             ;; compute all positions this pattern can hit
             positions (when (or has-target can-pattern-attack)
                         (combat/pattern-target-positions world px py dx dy pattern))
-            ;; find creatures at those positions
+            ;; find creatures at those positions — friendlies skipped so
+            ;; reach/skip patterns pass through allies to hostiles beyond.
             targets (when positions
                       (vec (filter some?
                              (map (fn [pos]
                                     (let [c (ent/creature-at world pos)]
-                                      (when (and c (not= :player (:id c)))
+                                      (when (and c (not= :player (:id c))
+                                                 (not (:friendly c)))
                                         {:id (:id c) :pos pos})))
                                   positions))))
             ;; for :reach, only hit the FIRST creature in the line

--- a/xsofy/world.lg
+++ b/xsofy/world.lg
@@ -17,6 +17,7 @@
             [xsofy.bestiary]
             [xsofy.title :as title]
             [xsofy.opcontext :as opctx]
+            [xsofy.util :as u]
             [math]))
 
 (declare player-move log-msg melee-attack ranged-attack update-fov autoexplore-step bfs-path spawn-runestones)
@@ -496,8 +497,119 @@
                         (recur (inc x)))))]
         (if found found (recur (inc y)))))))
 
+;; --- Stairs-follow: pending allies queue ---
+;; When the player takes stairs, every :friendly entity on the floor
+;; is lifted off into :pending-allies on the player, each with a
+;; per-entry :delay = max(1, chebyshev(ally-pos, player-pos)). The
+;; queue rides with the player across floors via inject-player. On
+;; each player turn, decrement every delay; entries whose delay hits
+;; 0 materialize on the current floor near :last-arrival-pos (the
+;; tile the player most recently spawned on). If the player bounces
+;; back to the origin floor before a delay expires, the ally arrives
+;; on whichever floor the player happens to be on — see
+;; nooga/xsofy#37 for the design discussion.
+
+(defn extract-friendlies-to-player
+  "Pull every :friendly entity off :entities, stash on the player as
+   :pending-allies with chebyshev-distance delays from the player's
+   current position. Existing pending entries are preserved (chain
+   descents accumulate). No-op when there's no player (test fixtures
+   without one, post-death state)."
+  [world]
+  (if-let [player-pos (get-in world [:entities :player :pos])]
+    (let [existing (or (get-in world [:entities :player :pending-allies]) [])
+          allies (filter (fn [[id e]]
+                           (and (:friendly e) (:pos e) (not= :player id)))
+                         (:entities world))
+          new-entries (mapv (fn [[id e]]
+                              {:entity (dissoc e :pos)
+                               :id id
+                               :delay (max 1 (u/chebyshev (:pos e) player-pos))})
+                            allies)
+          w (reduce (fn [acc [id _]] (update acc :entities dissoc id))
+                    world allies)]
+      (assoc-in w [:entities :player :pending-allies]
+                (into (vec existing) new-entries)))
+    world))
+
+(defn find-spawn-near
+  "Ring-BFS outward from origin for the first walkable + unoccupied
+   tile, up to chebyshev radius 8. Returns [pos world'] — pos is nil
+   if no cell is found, world' is world unchanged in that case. The
+   adjacent 8-neighbor case is covered at r=1; broader rings handle
+   crowded stairs (corridors, packed rooms).
+
+   Routes the ring pick through det/pick (salted on radius r so each
+   fallback ring gets a distinct sub-chain) — without this, ally
+   materialization couldn't replay from (seed, action-log)."
+  [world origin]
+  (let [{:keys [terrain width height]} world
+        [ox oy] origin]
+    (loop [r 1]
+      (if (> r 8)
+        [nil world]
+        (let [ring (vec (for [dx (range (- r) (inc r))
+                              dy (range (- r) (inc r))
+                              :when (or (= (math/abs dx) r)
+                                        (= (math/abs dy) r))
+                              :let [nx (+ ox dx) ny (+ oy dy)]
+                              :when (terrain/walkable? terrain width height nx ny)
+                              :when (nil? (ent/creature-at world [nx ny]))]
+                          [nx ny]))]
+          (if (seq ring)
+            (det/pick (det/with-context world [:ally-spawn r]) ring)
+            (recur (inc r))))))))
+
+(defn materialize-pending-ally
+  "Place a single pending-allies entry back into :entities at a spawn
+   tile near the player's :last-arrival-pos. Returns the world with
+   :seed advanced for the ring pick (and the entry placed if a spawn
+   cell was found). When the search radius is exhausted with no
+   candidate, returns the world unchanged — caller will retry next
+   turn by holding the entry at delay 0."
+  [world entry]
+  (let [arrival (or (get-in world [:entities :player :last-arrival-pos])
+                    (get-in world [:entities :player :pos]))
+        [spawn-pos w] (find-spawn-near world arrival)]
+    (if (nil? spawn-pos)
+      w
+      (let [ent (-> (:entity entry)
+                    (assoc :pos spawn-pos)
+                    ;; Inherit player's ticks so the new arrival slots
+                    ;; into the scheduler normally — same reason
+                    ;; r-conjure does this.
+                    (assoc :ticks (or (get-in w [:entities :player :ticks]) 0)))
+            ename (or (:template ent) (:id entry))]
+        (-> w
+            (assoc-in [:entities (:id entry)] ent)
+            (log-msg (str "Your " (name ename) " catches up to you.")))))))
+
+(defn tick-pending-allies
+  "Decrement every pending ally's delay. Entries whose delay reaches 0
+   try to materialize this turn; if their spawn cell is blocked, they
+   stay at delay 0 and retry next turn. Called once per player turn.
+   No-op when there's no player or no pending queue."
+  [world]
+  (let [pending (get-in world [:entities :player :pending-allies])]
+    (if (or (nil? (get-in world [:entities :player])) (empty? pending))
+      world
+      (let [decremented (mapv #(update % :delay dec) pending)
+            ready (filter #(<= (:delay %) 0) decremented)
+            still-pending (filter #(> (:delay %) 0) decremented)
+            [w blocked] (reduce (fn [[w blk] entry]
+                                  (let [w' (materialize-pending-ally w entry)
+                                        placed? (some? (get-in w' [:entities (:id entry)]))]
+                                    (if placed?
+                                      [w' blk]
+                                      [w' (conj blk (assoc entry :delay 0))])))
+                                [world []]
+                                ready)
+            new-pending (into (vec still-pending) blocked)]
+        (assoc-in w [:entities :player :pending-allies] new-pending)))))
+
 (defn change-floor [world new-depth]
   (let [{:keys [width height depth]} world
+        world (extract-friendlies-to-player world)
         [player items] (extract-player-items world)
         saved (save-current-floor world)]
     (if (get-in saved [:floors new-depth])
@@ -506,7 +618,7 @@
             spawn-tile (if (> new-depth depth) 14 13)
             spawn-pos (find-tile (:terrain floor) (:width floor) (:height floor) spawn-tile)
             spawn-pos (or spawn-pos [5 5])
-            player (assoc player :ticks 0)
+            player (assoc player :ticks 0 :last-arrival-pos spawn-pos)
             w (restore-floor saved new-depth player items)]
         (-> (assoc-in w [:entities :player :pos] spawn-pos)
             update-fov
@@ -520,7 +632,7 @@
                 spawn-pos (get-in new-world [:entities :player :pos])]
             ;; re-inject with proper items
             ;; reset player ticks to 0 so they act first on new floor
-            (let [player (assoc player :ticks 0)]
+            (let [player (assoc player :ticks 0 :last-arrival-pos spawn-pos)]
               (-> new-world
                   (assoc :log (:log saved)
                          :turn (:turn saved)
@@ -1705,6 +1817,7 @@
                 ;; bench paths catch the same entity-resurrection class
                 ;; of bugs that the non-bench path does.
                 (let [t0 (System/currentTimeMillis)
+                      w (tick-pending-allies w)
                       w2 (run-until-player-turn w)
                       _ (dbg/snapshot! w2 "update-world:after-run-until-player-turn")
                       t1 (System/currentTimeMillis)
@@ -1724,7 +1837,8 @@
                           :ignite (- t3 t2)
                           :drift  (- t4 t3)
                           :fov    (- t5 t4)}))
-                (let [w2 (run-until-player-turn w)
+                (let [w (tick-pending-allies w)
+                      w2 (run-until-player-turn w)
                       _ (dbg/snapshot! w2 "update-world:after-run-until-player-turn")
                       ;; fire simulation + burning entities ignite terrain + water drift
                       w3 (-> w2 fire/step-fire fire/burning-entities-ignite drift-water-items)]

--- a/xsofy/world.lg
+++ b/xsofy/world.lg
@@ -498,23 +498,14 @@
         (if found found (recur (inc y)))))))
 
 ;; --- Stairs-follow: pending allies queue ---
-;; When the player takes stairs, every :friendly entity on the floor
-;; is lifted off into :pending-allies on the player, each with a
-;; per-entry :delay = max(1, chebyshev(ally-pos, player-pos)). The
-;; queue rides with the player across floors via inject-player. On
-;; each player turn, decrement every delay; entries whose delay hits
-;; 0 materialize on the current floor near :last-arrival-pos (the
-;; tile the player most recently spawned on). If the player bounces
-;; back to the origin floor before a delay expires, the ally arrives
-;; on whichever floor the player happens to be on — see
-;; nooga/xsofy#37 for the design discussion.
+;; :friendly entities ride with the player across floors with a
+;; chebyshev-distance delay. Queue lives on the player entity (so it
+;; bounces back automatically). See nooga/xsofy#37.
 
 (defn extract-friendlies-to-player
-  "Pull every :friendly entity off :entities, stash on the player as
-   :pending-allies with chebyshev-distance delays from the player's
-   current position. Existing pending entries are preserved (chain
-   descents accumulate). No-op when there's no player (test fixtures
-   without one, post-death state)."
+  "Pull every :friendly off :entities, stash on the player as
+   :pending-allies with chebyshev-distance delays. Existing pending
+   entries preserved across chain descents. No-op without a player."
   [world]
   (if-let [player-pos (get-in world [:entities :player :pos])]
     (let [existing (or (get-in world [:entities :player :pending-allies]) [])
@@ -533,15 +524,14 @@
     world))
 
 (defn find-spawn-near
-  "Ring-BFS outward from origin for the first walkable + unoccupied
-   tile, up to chebyshev radius 8. Returns [pos world'] — pos is nil
-   if no cell is found, world' is world unchanged in that case. The
-   adjacent 8-neighbor case is covered at r=1; broader rings handle
-   crowded stairs (corridors, packed rooms).
+  "First walkable + unoccupied tile within chebyshev radius 8 of
+   origin. Returns [pos world'] — pos is nil if no cell found, world'
+   carries the seed advance from the ring pick. r=1 covers the
+   8-neighbor case; broader rings for crowded stairs.
 
-   Routes the ring pick through det/pick (salted on radius r so each
-   fallback ring gets a distinct sub-chain) — without this, ally
-   materialization couldn't replay from (seed, action-log)."
+   Ring pick routes through det/pick (salted on r so each fallback
+   ring is its own sub-chain) — without this, ally materialization
+   can't replay from (seed, action-log)."
   [world origin]
   (let [{:keys [terrain width height]} world
         [ox oy] origin]
@@ -561,12 +551,11 @@
             (recur (inc r))))))))
 
 (defn materialize-pending-ally
-  "Place a single pending-allies entry back into :entities at a spawn
-   tile near the player's :last-arrival-pos. Returns the world with
-   :seed advanced for the ring pick (and the entry placed if a spawn
-   cell was found). When the search radius is exhausted with no
-   candidate, returns the world unchanged — caller will retry next
-   turn by holding the entry at delay 0."
+  "Place an entry back into :entities near the player's
+   :last-arrival-pos. Returns world with :seed advanced for the ring
+   pick (and the entry placed if a spawn cell was found). If the search
+   radius is exhausted, world comes back unchanged — caller retries
+   next turn by holding the entry at delay 0."
   [world entry]
   (let [arrival (or (get-in world [:entities :player :last-arrival-pos])
                     (get-in world [:entities :player :pos]))
@@ -575,9 +564,8 @@
       w
       (let [ent (-> (:entity entry)
                     (assoc :pos spawn-pos)
-                    ;; Inherit player's ticks so the new arrival slots
-                    ;; into the scheduler normally — same reason
-                    ;; r-conjure does this.
+                    ;; Inherit player ticks so the arrival slots into
+                    ;; the scheduler (same reason as r-conjure).
                     (assoc :ticks (or (get-in w [:entities :player :ticks]) 0)))
             ename (or (:template ent) (:id entry))]
         (-> w
@@ -585,10 +573,8 @@
             (log-msg (str "Your " (name ename) " catches up to you.")))))))
 
 (defn tick-pending-allies
-  "Decrement every pending ally's delay. Entries whose delay reaches 0
-   try to materialize this turn; if their spawn cell is blocked, they
-   stay at delay 0 and retry next turn. Called once per player turn.
-   No-op when there's no player or no pending queue."
+  "Decrement every pending ally's delay; entries hitting 0 try to
+   materialize, hold at 0 if blocked. Called once per player turn."
   [world]
   (let [pending (get-in world [:entities :player :pending-allies])]
     (if (or (nil? (get-in world [:entities :player])) (empty? pending))
@@ -1537,18 +1523,13 @@
               update-fov
               (log-msg "You open the door.")))
 
-      ;; Bumping a friendly: swap places (Brogue-style) when both cells
-      ;; are safe, log a block otherwise. Avoids friendly-fire melee and
-      ;; prevents the player from getting stuck behind their own summon
-      ;; in narrow passages. Friendlies on hazard tiles can't be swapped
-      ;; into — player would fall in.
+      ;; Bumping a friendly: swap places (Brogue-style) when walkable;
+      ;; log a block on hazards (player would fall in).
       ;;
-      ;; Charge the swapped friendly its own per-turn cost too. Without
-      ;; this the swap moves the ally one tile but leaves their :ticks
-      ;; untouched, so run-until-player-turn gives them an immediate
-      ;; full turn — net effect is a 2-tile move per single player
-      ;; step. (quot move-cost speed) preserves speed-2 allies'
-      ;; advantage.
+      ;; Charge the ally (quot move-cost speed) — without this their
+      ;; :ticks stay put and run-until-player-turn gives them a free
+      ;; turn (net: 2-tile ally move per player step). /speed preserves
+      ;; speed-2 allies' advantage.
       (let [c (ent/creature-at world [nx ny])]
         (and c (:friendly c)))
       (let [bump (ent/creature-at world [nx ny])


### PR DESCRIPTION
Closes #37 (minimum-viable cut).

PR #35 set `:friendly` on freshly conjured creatures, but the flag was inert —
friendlies still targeted the player, took bumps and AoE, and didn't follow
the descent. This PR implements the MVP shape sketched in #37's thread:

- **AI partitions targets by faction.** Hostiles hunt the player and any
  friendly; friendlies hunt hostiles. `:friend` (a stub in #35) now produces
  an entity that actually fights for you. `:conjure` alone still spawns a
  hostile, so `:friend` remains the rune that decides usefulness.
- **Player movement.** Bumping a friendly is a one-tick symmetric swap, not
  an attack. Single-target ranged (fire-bow + reach/skip filter) skips allies.
  AoE deliberately still hits them.
- **Render.** Cyan-blue glyph tint + `(ally)` sidebar marker; status tints
  still override so a burning ally reads as burning.
- **Follow on descent**, modeled as proposed: each friendly records its
  chebyshev distance from the stairs at descent time, then appears on the
  new floor after a delay proportional to that distance. The queue lives on
  the player so it bounces back if they ascend.

Two summon-side bugs surfaced and got fixed in passing: slime split clones
inherit `:friendly` (no more hostile shards from a friendly slime), and
`r-conjure` inherits the caster's `:ticks` (otherwise the summon's `:ticks 0`
dragged every low-tick actor forward, making hostiles "jump" tiles per
player step).

**Out of scope (per the thread):** weighted conjure / OP-summoning tuning
(happy to take it as a follow-up once surrounding pressure systems give us
something to tune against), leaders + orbit-following, loot routing, summon
caps, decay timers.

## Commits

8 commits, sequenced for review: AI partition → world/movement → render →
tests → two summon-side fixes (slime split, conjure ticks) → stairs-follow →
chore. Each is self-contained and passes the suite.


## Design notes

- **Faction flag is `:friendly` boolean** per "simple flag is enough" in #37. Open to renaming if you'd prefer `:faction :player`.
- **AoE deliberately does not filter friendlies.** `r-damage` / `r-fire` / `r-ice` / `r-arc` / `r-push` / `r-web` all hit allies — friendly fire is a feature, forces deliberate aim.
- **Out of scope** (per #37): leaders/orbit-following, loot routing, summon-count caps.

## Testing

- [x] 233 tests, 2145 assertions, 0 fail (baseline 226/2133).
- [x] Local CLI smoke test - conjured friendlies behave as designed

## Caveats
- Tested against let-go release v1.9.0
- Draft for your review pace; happy to split or reshape commits.