### PR TITLE
Fix typos in README + procedural-title word lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A roguelike written in my [lisp](https://github.com/nooga/let-go), where the magic system is a lisp. 
 
-> Note: This is not finished! It's playable but mild peril and uscheduled explosions are to be expected.
+> Note: This is not finished! It's playable but mild peril and unscheduled explosions are to be expected.
 
 **[Play in your browser](https://nooga.github.io/xsofy/)**
 

--- a/xsofy/title.lg
+++ b/xsofy/title.lg
@@ -11,7 +11,8 @@
          "Tunnels" "Caves" "Caverns" "Cloisters" "Casemates" "Halls" "Chambers"
          "Shrines" "Temples" "Cisterns" "Containers" "Hells" "Coils"
          "Pitfalls" "Pits" "Cells" "Sewers" "Domains" "Voids" "Cons"
-         "Chambers" "Cellars" "Backrooms" "Basements" "Strata" "Structures" "Gazebos" "Realms" "Dimensions"])
+         "Chambers" "Cellars" "Backrooms" "Basements" "Strata" "Structures" "Gazebos" "Realms" "Dimensions"
+         "Mazes"])
 
 (def ys ["Recursion" "Nil" "Off-By-One" "Eval" "Nesting"
          "Garbage Collection" "Structural Sharing" "Eventual Consistency"

--- a/xsofy/title.lg
+++ b/xsofy/title.lg
@@ -10,7 +10,7 @@
          "Dominions" "Reaches" "Passages" "Chambers" "Shrines"
          "Tunnels" "Caves" "Caverns" "Cloisters" "Casemates" "Halls" "Chambers"
          "Shrines" "Temples" "Cisterns" "Containers" "Hells" "Coils"
-         "Labirynths" "Pitfalls" "Pits" "Cells" "Sewers" "Domains" "Voids" "Cons"
+         "Pitfalls" "Pits" "Cells" "Sewers" "Domains" "Voids" "Cons"
          "Chambers" "Cellars" "Backrooms" "Basements" "Strata" "Structures" "Gazebos" "Realms" "Dimensions"])
 
 (def ys ["Recursion" "Nil" "Off-By-One" "Eval" "Nesting"
@@ -22,14 +22,14 @@
          "Shrubbery" "Pickles" "Time" "Damnation" "Forgetting"
          "Dumplings" "Squelching" "Muttering" "Fumbling"
          "Consternation" "Lament" "Mounting Dread" "Subtlety"
-         "Subterfuge" "Jeopardy" "Trouble" "Melanholy"
+         "Subterfuge" "Jeopardy" "Trouble" "Melancholy"
          "Bewilderment" "Perplexity" "Iron" "Steel" "Felt" "Infinity"
          "Moderate Discomfort" "Lingering Suspicion" "Lazy Evaluation"
          "Early Return" "Technical Debt" "Dependency Hell" "Loose Coupling"
          "Side Effect" "Deadlock" "Decay" "Lukewarm Tea" "Loud Chewing"
          "Tuesday" "Trepidation" "Darkness" "Drab" "Beige" "Questionable Beauty"
          "Mildew" "Moisture" "Understandable Nature" "Varying Utility" "Grotesque"
-         "Terror" "Labirynthian Design" "Boredom" "Bondage" "Procrastination"
+         "Terror" "Labyrinthine Design" "Boredom" "Bondage" "Procrastination"
          "Polite Enquiry" "Measured Response" "Madness" "Inconvenience"
          "Rage Quitting"])
 
@@ -69,7 +69,7 @@
    "The way back vanishes into solid rock."
    "Your guide disappears into the mist. You hear \"Solong, sucker!\" in the distance."
    "Old man shuts the gate behind you. You hear him mutter \"every time, I swear...\""
-   "You wake up hangover on a stone slab. No way out."
+   "You wake up hung over on a stone slab. No way out."
    "You just got here. You don't feel like going back yet."])
 
 (defn generate-quest []

--- a/xsofy/title.lg
+++ b/xsofy/title.lg
@@ -4,35 +4,35 @@
 
 ;; --- Procedural Title Generation ---
 
-(def xs ["Catacombs" "Crypts" "Depths" "Vaults" "Hollows" "Abysses"
-         "Dungeons" "Barrows" "Sanctums" "Citadels" "Spires" "Tombs"
-         "Labyrinths" "Oubliettes" "Sepulchres" "Chasms" "Warrens"
-         "Dominions" "Reaches" "Passages" "Chambers" "Shrines"
-         "Tunnels" "Caves" "Caverns" "Cloisters" "Casemates" "Halls" "Chambers"
-         "Shrines" "Temples" "Cisterns" "Containers" "Hells" "Coils"
-         "Pitfalls" "Pits" "Cells" "Sewers" "Domains" "Voids" "Cons"
-         "Chambers" "Cellars" "Backrooms" "Basements" "Strata" "Structures" "Gazebos" "Realms" "Dimensions"
-         "Mazes"])
+(def xs ["Abysses" "Backrooms" "Barrows" "Basements" "Casemates"
+         "Catacombs" "Caverns" "Caves" "Cellars" "Cells" "Chambers"
+         "Chambers" "Chambers" "Chasms" "Cisterns" "Citadels" "Cloisters"
+         "Coils" "Cons" "Containers" "Crypts" "Depths" "Dimensions"
+         "Domains" "Dominions" "Dungeons" "Gazebos" "Halls" "Hells"
+         "Hollows" "Labyrinths" "Mazes" "Oubliettes" "Passages" "Pitfalls"
+         "Pits" "Reaches" "Realms" "Sanctums" "Sepulchres" "Sewers"
+         "Shrines" "Shrines" "Spires" "Strata" "Structures" "Temples"
+         "Tombs" "Tunnels" "Vaults" "Voids" "Warrens"])
 
-(def ys ["Recursion" "Nil" "Off-By-One" "Eval" "Nesting"
-         "Garbage Collection" "Structural Sharing" "Eventual Consistency"
-         "Persistence" "Premature Optimization" "Scope Creep"
-         "Stack Overflow" "Undefined Behavior" "Mutable State"
-         "Diminishing Returns" "Plausible Deniability" "Mild Peril"
-         "Hindsight" "Hubris" "Regret" "Ennui" "Inevitability" "Pedantry"
-         "Shrubbery" "Pickles" "Time" "Damnation" "Forgetting"
-         "Dumplings" "Squelching" "Muttering" "Fumbling"
-         "Consternation" "Lament" "Mounting Dread" "Subtlety"
-         "Subterfuge" "Jeopardy" "Trouble" "Melancholy"
-         "Bewilderment" "Perplexity" "Iron" "Steel" "Felt" "Infinity"
-         "Moderate Discomfort" "Lingering Suspicion" "Lazy Evaluation"
-         "Early Return" "Technical Debt" "Dependency Hell" "Loose Coupling"
-         "Side Effect" "Deadlock" "Decay" "Lukewarm Tea" "Loud Chewing"
-         "Tuesday" "Trepidation" "Darkness" "Drab" "Beige" "Questionable Beauty"
-         "Mildew" "Moisture" "Understandable Nature" "Varying Utility" "Grotesque"
-         "Terror" "Labyrinthine Design" "Boredom" "Bondage" "Procrastination"
-         "Polite Enquiry" "Measured Response" "Madness" "Inconvenience"
-         "Rage Quitting"])
+(def ys ["Beige" "Bewilderment" "Bondage" "Boredom" "Consternation"
+         "Damnation" "Darkness" "Deadlock" "Decay" "Dependency Hell"
+         "Diminishing Returns" "Drab" "Dumplings" "Early Return" "Ennui"
+         "Eval" "Eventual Consistency" "Felt" "Forgetting" "Fumbling"
+         "Garbage Collection" "Grotesque" "Hindsight" "Hubris"
+         "Inconvenience" "Inevitability" "Infinity" "Iron" "Jeopardy"
+         "Labyrinthine Design" "Lament" "Lazy Evaluation"
+         "Lingering Suspicion" "Loose Coupling" "Loud Chewing"
+         "Lukewarm Tea" "Madness" "Measured Response" "Melancholy"
+         "Mild Peril" "Mildew" "Moderate Discomfort" "Moisture"
+         "Mounting Dread" "Mutable State" "Muttering" "Nesting" "Nil"
+         "Off-By-One" "Pedantry" "Perplexity" "Persistence" "Pickles"
+         "Plausible Deniability" "Polite Enquiry" "Premature Optimization"
+         "Procrastination" "Questionable Beauty" "Rage Quitting"
+         "Recursion" "Regret" "Scope Creep" "Shrubbery" "Side Effect"
+         "Squelching" "Stack Overflow" "Steel" "Structural Sharing"
+         "Subterfuge" "Subtlety" "Technical Debt" "Terror" "Time"
+         "Trepidation" "Trouble" "Tuesday" "Undefined Behavior"
+         "Understandable Nature" "Varying Utility"])
 
 (defn generate-title []
   (str (nth xs (rand-int (count xs)))
@@ -42,25 +42,22 @@
 ;; --- Quest Objective ---
 
 (def quest-ps
-  ["Amulet" "Gauntlet" "Chalice" "Scepter" "Orb" "Crown"
-   "Tiara" "Helm" "Boots" "Cloak" "Rod" "Tome"
-   "Blade" "Sceptre" "Trinket" "Trophy" "Artifact" "Relic" "Treasure"
-   "Grimoire" "Codex"  "Book" "Journal"
-   "Pendant" "Brazier"  "Codpiece" "Paren" "Chalice" "Crystal"
-   "Ladle" "Bucket" "Spatula" "Sock" "Pamphlet" "Invoice"
-   "Cummerbund" "Umbrella" "Gazebo" "Chain" "Seq" "Map" "Key"
-   "Toothpick" "Comb" "Can"])
+  ["Amulet" "Artifact" "Blade" "Book" "Boots" "Brazier" "Bucket" "Can"
+   "Chain" "Chalice" "Chalice" "Cloak" "Codex" "Codpiece" "Comb" "Crown"
+   "Crystal" "Cummerbund" "Gauntlet" "Gazebo" "Grimoire" "Helm" "Invoice"
+   "Journal" "Key" "Ladle" "Map" "Orb" "Pamphlet" "Paren" "Pendant" "Relic"
+   "Rod" "Scepter" "Sceptre" "Seq" "Sock" "Spatula" "Tiara" "Tome"
+   "Toothpick" "Treasure" "Trinket" "Trophy" "Umbrella"])
 
 (def quest-qs
-  ["Yendor" "Splendor" "Closing" "Concern" "Radiance"
-   "Adequate Wine" "Moderate Significance" "Your Cousin"
-   "Selective Hearing" "Early Returns" "Marginal Value"
-   "Questionable Fame" "Pickles" "Good Looks" "Dumb Luck"
-   "Plausible Authority" "Borrowed Confidence" "Forgotten Knowledge"
-   "Vague Importance" "Terms and Conditions" "Pointed Remarks"
-   "Strongly Worded Letters" "Unsorted Collections" "Limited Shelf Life"
-   "Infinite Loops" "Unmatched Delimiters" "Lost Semicolons" "Futility"
-   "Parens"])
+  ["Adequate Wine" "Borrowed Confidence" "Closing" "Concern" "Dumb Luck"
+   "Early Returns" "Forgotten Knowledge" "Futility" "Good Looks"
+   "Infinite Loops" "Limited Shelf Life" "Lost Semicolons" "Marginal Value"
+   "Moderate Significance" "Parens" "Pickles" "Plausible Authority"
+   "Pointed Remarks" "Questionable Fame" "Radiance" "Selective Hearing"
+   "Splendor" "Strongly Worded Letters" "Terms and Conditions"
+   "Unmatched Delimiters" "Unsorted Collections" "Vague Importance"
+   "Yendor" "Your Cousin"])
 
 (def gate-messages
   ["The gate slams shut behind you. No going back."

--- a/xsofy/title.lg
+++ b/xsofy/title.lg
@@ -6,13 +6,13 @@
 
 (def xs ["Abysses" "Backrooms" "Barrows" "Basements" "Casemates"
          "Catacombs" "Caverns" "Caves" "Cellars" "Cells" "Chambers"
-         "Chambers" "Chambers" "Chasms" "Cisterns" "Citadels" "Cloisters"
-         "Coils" "Cons" "Containers" "Crypts" "Depths" "Dimensions"
-         "Domains" "Dominions" "Dungeons" "Gazebos" "Halls" "Hells"
-         "Hollows" "Labyrinths" "Mazes" "Oubliettes" "Passages" "Pitfalls"
-         "Pits" "Reaches" "Realms" "Sanctums" "Sepulchres" "Sewers"
-         "Shrines" "Shrines" "Spires" "Strata" "Structures" "Temples"
-         "Tombs" "Tunnels" "Vaults" "Voids" "Warrens"])
+         "Chasms" "Cisterns" "Citadels" "Cloisters" "Coils" "Cons"
+         "Containers" "Crypts" "Depths" "Dimensions" "Domains" "Dominions"
+         "Dungeons" "Gazebos" "Halls" "Hells" "Hollows" "Labyrinths"
+         "Mazes" "Oubliettes" "Passages" "Pitfalls" "Pits" "Reaches"
+         "Realms" "Sanctums" "Sepulchres" "Sewers" "Shrines" "Spires"
+         "Strata" "Structures" "Temples" "Tombs" "Tunnels" "Vaults" "Voids"
+         "Warrens"])
 
 (def ys ["Beige" "Bewilderment" "Bondage" "Boredom" "Consternation"
          "Damnation" "Darkness" "Deadlock" "Decay" "Dependency Hell"
@@ -43,11 +43,11 @@
 
 (def quest-ps
   ["Amulet" "Artifact" "Blade" "Book" "Boots" "Brazier" "Bucket" "Can"
-   "Chain" "Chalice" "Chalice" "Cloak" "Codex" "Codpiece" "Comb" "Crown"
-   "Crystal" "Cummerbund" "Gauntlet" "Gazebo" "Grimoire" "Helm" "Invoice"
-   "Journal" "Key" "Ladle" "Map" "Orb" "Pamphlet" "Paren" "Pendant" "Relic"
-   "Rod" "Scepter" "Sceptre" "Seq" "Sock" "Spatula" "Tiara" "Tome"
-   "Toothpick" "Treasure" "Trinket" "Trophy" "Umbrella"])
+   "Chain" "Chalice" "Cloak" "Codex" "Codpiece" "Comb" "Crown" "Crystal"
+   "Cummerbund" "Gauntlet" "Gazebo" "Grimoire" "Helm" "Invoice" "Journal"
+   "Key" "Ladle" "Map" "Orb" "Pamphlet" "Paren" "Pendant" "Relic" "Rod"
+   "Scepter" "Sceptre" "Seq" "Sock" "Spatula" "Tiara" "Tome" "Toothpick"
+   "Treasure" "Trinket" "Trophy" "Umbrella"])
 
 (def quest-qs
   ["Adequate Wine" "Borrowed Confidence" "Closing" "Concern" "Dumb Luck"

--- a/xsofy/title.lg
+++ b/xsofy/title.lg
@@ -4,20 +4,21 @@
 
 ;; --- Procedural Title Generation ---
 
-(def xs ["Abysses" "Backrooms" "Barrows" "Basements" "Casemates"
+(def xs ["Abysses" "Alleys" "Backrooms" "Barrows" "Basements" "Casemates"
          "Catacombs" "Caverns" "Caves" "Cellars" "Cells" "Chambers"
          "Chasms" "Cisterns" "Citadels" "Cloisters" "Coils" "Cons"
-         "Containers" "Crypts" "Depths" "Dimensions" "Domains" "Dominions"
-         "Dungeons" "Gazebos" "Halls" "Hells" "Hollows" "Labyrinths"
-         "Mazes" "Oubliettes" "Passages" "Pitfalls" "Pits" "Reaches"
-         "Realms" "Sanctums" "Sepulchres" "Sewers" "Shrines" "Spires"
-         "Strata" "Structures" "Temples" "Tombs" "Tunnels" "Vaults" "Voids"
-         "Warrens"])
+         "Containers" "Corridors" "Crypts" "Cycles" "Depths" "Dimensions"
+         "Domains" "Dominions" "Dungeons" "Gazebos" "Halls" "Hells"
+         "Hollows" "Labyrinths" "Mazes" "Oubliettes" "Passages" "Pitfalls"
+         "Pits" "Planes" "Reaches" "Realms" "Sanctums" "Sepulchres"
+         "Sewers" "Shrines" "Spires" "Strata" "Structures" "Temples"
+         "Tombs" "Tunnels" "Vaults" "Voids" "Warrens"])
 
 (def ys ["Beige" "Bewilderment" "Bondage" "Boredom" "Consternation"
-         "Damnation" "Darkness" "Deadlock" "Decay" "Dependency Hell"
-         "Diminishing Returns" "Drab" "Dumplings" "Early Return" "Ennui"
-         "Eval" "Eventual Consistency" "Felt" "Forgetting" "Fumbling"
+         "Cosmic Insignificance" "Damnation" "Darkness" "Deadlock" "Decay"
+         "Deferred Maintenance" "Dependency Hell" "Diminishing Returns"
+         "Drab" "Dumplings" "Early Return" "Ennui" "Eval"
+         "Eventual Consistency" "Felt" "Forgetting" "Fumbling"
          "Garbage Collection" "Grotesque" "Hindsight" "Hubris"
          "Inconvenience" "Inevitability" "Infinity" "Iron" "Jeopardy"
          "Labyrinthine Design" "Lament" "Lazy Evaluation"


### PR DESCRIPTION
## Summary

Five-commit stack of text-only changes to `README.md` and `xsofy/title.lg` — no logic or runtime-system changes. Best reviewed commit-by-commit. Cumulative effect:

- **Typos** — `uscheduled`, `Melanholy`, `Labirynthian Design`, accidental misspelled-dupe `Labirynths`, ungrammatical `wake up hangover`. Left `Solong, sucker!` alone as deliberate voice.
- **Add Mazes** to xs — Labyrinths synonym, fits the existing accepted-dupe pattern (Tombs/Crypts/Sepulchres, Caves/Caverns, Halls/Chambers).
- **Sort** all four word-list defs (`xs`, `ys`, `quest-ps`, `quest-qs`) alphabetically — pure reorganization, dupes preserved.
- **Dedupe accidental repeats** — `Chambers` x3→1 and `Shrines` x2→1 in xs, `Chalice` x2→1 in quest-ps. All three sat across different semantic clusters in the source with no marker comment, same pattern as the `Labirynths` typo-dupe. Slight generator behavior shift — `Chambers` was ~5.8% of xs picks, now 2%; corresponding small shifts for the others.
- **6 new entries** — xs gains `Alleys`, `Corridors`, `Cycles`, `Planes`; ys gains `Cosmic Insignificance`, `Deferred Maintenance`. `Cosmic Insignificance` intentionally pairs with the existing quest-qs `Moderate Significance` for serendipitous combos.

Net list counts: xs 52→53, ys 79→81, quest-ps 45→44, quest-qs 29.

## Testing
- `lg -c main.lgb main.lg` clean after each commit
- No runtime behavior change beyond the dedup probability shift noted above