### PR TITLE
fix: keep title & death-screen particles animating (and calm the pulse)

### DIFF
--- a/main.lg
+++ b/main.lg
@@ -428,12 +428,18 @@
                      (recur w w (term/size))))))
 
          :death
-         (let [result (loop [scroll 0]
-                        (render/render-death-screen world scroll)
-                        (let [k (term/read-key)]
+         (let [poll! (title/make-key-poller 120)  ;; calmer death-screen pulse (was 80ms)
+               result (loop [scroll 0 frame 0]
+                        ;; animate the death screen continuously; the runes keep
+                        ;; pulsing while we wait for a key instead of freezing.
+                        (let [[k nf] (title/drive-until-key
+                                       frame
+                                       (fn [f] (render/render-death-screen world scroll f))
+                                       poll!)]
                           (cond
                             (or (= k "n") (= k "\r") (= k "\n") (= k " "))
                             :new-game
+                            (= k :eof) (assoc world :running false)
                             (= k "\u001b")
                             (if *in-wasm*
                               (do
@@ -441,11 +447,11 @@
                                 (let [confirm (term/read-key)]
                                   (if (= confirm "y")
                                     :new-game
-                                    (recur scroll))))
+                                    (recur scroll nf))))
                               (assoc world :running false))
-                            (or (= k "j") (= k "\u001b[B")) (recur (max 0 (dec scroll)))
-                            (or (= k "k") (= k "\u001b[A")) (recur (inc scroll))
-                            :else (recur scroll))))]
+                            (or (= k "j") (= k "\u001b[B")) (recur (max 0 (dec scroll)) nf)
+                            (or (= k "k") (= k "\u001b[A")) (recur (inc scroll) nf)
+                            :else (recur scroll nf))))]
            (if (= result :new-game)
              (let [w (new-game)]
                (render/render-full w)

--- a/xsofy/render.lg
+++ b/xsofy/render.lg
@@ -878,7 +878,7 @@
    ["So long and"    "thanks for"      "the fish"]
    ["No refunds"     "for the deceased"]])
 
-(defn render-death-screen [world scroll-offset]
+(defn render-death-screen [world scroll-offset frame]
   (let [[tw th] (term/size)
         cx (quot tw 2)
         cy (quot th 2)
@@ -887,9 +887,10 @@
         seed (or (:turn world) 0)]
     ;; clear to black
     (title/clear-screen tw th)
-    ;; draw runes in background
+    ;; draw runes in background — pulse over `frame` so they keep flickering
+    ;; while the screen waits for input (was a static brightness before).
     (doseq [r runes]
-      (let [b (/ (float (+ 15 (rem (:phase r) 30))) 45.0)
+      (let [b (max 0.1 (title/rune-brightness (:phase r) frame))
             [cr cg cb] (:color r)]
         (term/move-cursor (:x r) (:y r))
         (term/set-fg (int (* cr b)) (int (* cg b)) (int (* cb b)))

--- a/xsofy/test/run.lg
+++ b/xsofy/test/run.lg
@@ -3,6 +3,7 @@
             [xsofy.test.check-test]
             [xsofy.test.invariant-test]
             [xsofy.test.render-test]
+            [xsofy.test.title-test]
             [xsofy.test.spell-prop]
             [xsofy.test.world-prop]
             [xsofy.test.combat-prop]

--- a/xsofy/test/title_test.lg
+++ b/xsofy/test/title_test.lg
@@ -1,0 +1,39 @@
+(ns xsofy.test.title-test
+  (:require [test :refer [deftest is testing]]
+            [xsofy.title :as title]))
+
+;; nooga/xsofy — particle screens (title + death) must keep animating
+;; independently of input. The control seam is `drive-until-key`: it renders
+;; successive frames, polling for a key between frames, and only stops when a
+;; key arrives. Frames MUST advance while the poll returns nil (no key yet) —
+;; that is precisely the behaviour that was missing (screens froze on a
+;; blocking read-key until a key was pressed).
+
+(deftest drive-until-key-advances-frames-while-no-key
+  (testing "frames keep rendering while poll returns nil, then the key ends it"
+    (let [rendered (atom [])
+          ;; poll: nil for the first 3 ticks, then a key on the 4th
+          remaining (atom [nil nil nil "x"])
+          poll! (fn []
+                  (let [v (first @remaining)]
+                    (swap! remaining rest)
+                    v))
+          [k next-frame] (title/drive-until-key 0
+                                                (fn [frame] (swap! rendered conj frame))
+                                                poll!)]
+      ;; the key that arrived is returned
+      (is (= "x" k))
+      ;; frames 0,1,2,3 were all rendered — animation advanced without input
+      (is (= [0 1 2 3] @rendered))
+      ;; the loop reports the next frame so callers can keep continuity
+      (is (= 4 next-frame)))))
+
+(deftest drive-until-key-stops-immediately-when-key-already-ready
+  (testing "a key available on the first poll ends after one rendered frame"
+    (let [rendered (atom [])
+          [k next-frame] (title/drive-until-key 7
+                                                (fn [frame] (swap! rendered conj frame))
+                                                (fn [] "q"))]
+      (is (= "q" k))
+      (is (= [7] @rendered))
+      (is (= 8 next-frame)))))

--- a/xsofy/title.lg
+++ b/xsofy/title.lg
@@ -98,6 +98,55 @@
 (defn pause! [ms]
   (async/<!! (async/timeout (if *in-wasm* (max ms 30) ms))))
 
+;; --- Non-blocking input for animated screens ---
+;; `term/read-key` is blocking, so a screen that calls it directly freezes its
+;; animation until a key is pressed. To keep particles running, we read keys on
+;; a goroutine and select between that channel and a frame timer.
+;;
+;; The reader is ONE-SHOT: it reads a single key, delivers it, and exits. A
+;; goroutine blocked inside `read-key` cannot be cancelled, so a looping reader
+;; would survive past the screen and steal the next keypress from the game loop.
+;; One-shot + lazy re-arming guarantees at most one reader is ever blocked on
+;; stdin, and none is left behind once a screen exits on a key.
+
+(defn read-key-chan
+  "Spawn a goroutine that reads exactly one key and delivers it on the returned
+   channel, then exits. EOF (nil from read-key) is delivered as :eof."
+  []
+  (let [ch (async/chan)]
+    (go (async/>! ch (or (term/read-key) :eof)))
+    ch))
+
+(defn make-key-poller
+  "Return a 0-arg poll fn for animation loops. Each call waits up to `ms` for a
+   keypress: returns the key string, :eof, or nil if none arrived in time.
+   Arms a one-shot reader lazily and disarms once a key is delivered, so when a
+   screen stops polling (after its terminating key) no reader is left blocked."
+  [ms]
+  (let [armed (atom nil)]
+    (fn []
+      (when (nil? @armed)
+        (reset! armed (read-key-chan)))
+      (let [[v _] (async/alts! [@armed (async/timeout ms)])]
+        (when (some? v)
+          (reset! armed nil))
+        v))))
+
+(defn drive-until-key
+  "Animation control loop. Render successive frames starting at `start-frame`,
+   calling (render! frame) then (poll!) after each. (poll!) returns a key (the
+   loop ends) or nil (keep animating — frame advances). Returns [key next-frame]
+   so callers can resume animation continuously across handled keypresses.
+   Pure with respect to the injected render!/poll! — the seam tested in
+   title_test."
+  [start-frame render! poll!]
+  (loop [frame start-frame]
+    (render! frame)
+    (let [k (poll!)]
+      (if (some? k)
+        [k (inc frame)]
+        (recur (inc frame))))))
+
 ;; --- Title Screen ---
 
 (defn scatter-runes [w h n base-color]
@@ -177,13 +226,13 @@
         runes (scatter-runes tw th 40 scheme)]
     ;; clear once
     (clear-screen tw th)
-    ;; animate
-    (dotimes [frame 50]
-      (draw-frame runes title subtitle tw th frame)
-      (pause! 80))
-    ;; hold final frame, wait for key
-    (draw-frame runes title subtitle tw th 50)
-    (term/read-key)
+    ;; animate continuously until a key is pressed — runes keep pulsing instead
+    ;; of freezing on a held final frame while a blocking read-key waits.
+    (drive-until-key 0
+                     (fn [frame] (draw-frame runes title subtitle tw th frame))
+                     ;; 120ms/frame: a calmer rune pulse (was 80ms). Input
+                     ;; latency at a title screen is imperceptible at this rate.
+                     (make-key-poller 120))
     {:title title :scheme scheme}))
 
 ;; --- Descending Screen ---


### PR DESCRIPTION
## Summary
The title and death screens froze their rune particles until a key was pressed — `term/read-key` is blocking, so frames only advanced around input. Now keys are read on a one-shot goroutine and the loop selects between that channel and a frame timer, so the particles animate continuously while waiting.

- **title** — `read-key-chan` / `make-key-poller` / `drive-until-key` helpers; animate until a key instead of holding a static final frame.
- **death** — thread a frame counter into `render-death-screen`; pulse the runes via `rune-brightness` while waiting for input.
- **pulse cadence** — 120ms/frame (was 80ms) for a calmer particle motion; input latency at these screens stays imperceptible.

## Test plan
- [x] `lg xsofy/test/run.lg` — 237 tests pass (incl. new `drive-until-key` control-loop coverage in `title_test`)
- [x] `lg -b /tmp/x main.lg` — compiles (exit 0)
- [x] Verified in a PTY that both screens keep animating with no keypress, past the old freeze point

🤖 Generated with [Claude Code](https://claude.com/claude-code)