### PR TITLE
ci: pin let-go to v1.9.0; add @latest matrix cell for upstream drift smoke

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -29,7 +29,7 @@ jobs:
           go-version: '1.24'
 
       - name: Install let-go
-        run: go install github.com/nooga/let-go@latest
+        run: go install github.com/nooga/let-go@v1.9.0
 
       - name: Build WASM
         run: let-go -w dist main.lg

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,19 @@ permissions:
 
 jobs:
   test:
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - letgo: v1.9.0
+            label: "pinned (deploy floor)"
+            required: true
+          - letgo: latest
+            label: "latest (upstream smoke test)"
+            required: false
+    name: ${{ matrix.label }}
     runs-on: ubuntu-latest
+    continue-on-error: ${{ !matrix.required }}
     steps:
       - uses: actions/checkout@v4
 
@@ -18,8 +30,13 @@ jobs:
         with:
           go-version: '1.24'
 
-      - name: Install let-go
-        run: go install github.com/nooga/let-go@latest
+      - name: Install let-go ${{ matrix.letgo }}
+        run: go install github.com/nooga/let-go@${{ matrix.letgo }}
+
+      - name: Print let-go info
+        run: |
+          which let-go
+          let-go --version 2>/dev/null || true
 
       - name: Run tests
         run: let-go xsofy/test/run.lg


### PR DESCRIPTION
## Why

Both CI workflows currently `go install github.com/nooga/let-go@latest`, which silently floats whatever tag the Go module proxy resolves to. As of today that's `v1.9.0`, paired-compatible with current `main` — but tomorrow could be a breaking minor or a re-tagged version that hasn't been smoke-tested against the game.

This is the same drift shape behind #44 — the published web demo was built against a let-go that lacked the `syscall/js` guard ([let-go#126](https://github.com/nooga/let-go/pull/126)) and broke on browsers without SAB.

## What

- **`deploy-pages.yml`**: pin to `@v1.9.0` (the version `main` currently loads + runs against, verified locally). Stops silent floats on next nooga/let-go release.
- **`test.yml`**: matrix-test against both `@v1.9.0` (required) and `@latest` (advisory via `continue-on-error`). PR pass/fail stays deterministic on the pinned cell; the `@latest` cell surfaces upstream drift in the Checks tab immediately without blocking merges. Diagnostic step prints \`let-go --version\` for triage on a future drift failure.

Tested on my fork — both matrix cells green in ~1m8s each: https://github.com/mparrett/xsofy/actions/runs/26955211152

## Follow-ups (not in this PR)

- \`require-letgo\` (let-go's load-time version assert, merged in \`98a5d21\` via [let-go#164](https://github.com/nooga/let-go/pull/164)) is the language-level fix — but lives only on let-go \`main\` today, not \`v1.9.0\`. When the next let-go release ships with it, bump the pin and add \`(require-letgo ">=X.Y.Z")\` to \`main.lg\`.
- The runtime build-id / xsofy-SHA banner #44 actually asks for is a separate piece of work.

Refs: #44