### PR TITLE
ci: deploy Pages from version tags instead of main

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -2,7 +2,7 @@ name: Deploy to GitHub Pages
 
 on:
   push:
-    branches: [main]
+    tags: ['v*']
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
One-line change: switch Pages deploy trigger from `push: branches: [main]` to `push: tags: ['v*']`. Full proposal context + open questions in #58.

## After merge

Pages keeps serving the last deploy (`e14bb958`) until a `v*` tag is cut — no site downtime. Tagging triggers a fresh build and deploy.

Suggested first tag (per #58, since `mparrett` can't push tags to `nooga/xsofy`):

```
git tag -a v0.0.1 78e2350 -m "v0.0.1 — first tagged release"
git push origin v0.0.1
```

`78e2350` is the most recent commit verified to play cleanly against the now-pinned `let-go@v1.9.0`. Bumping to `v0.1.0` / something else is your call.

Closes #58.
Refs #44.
