### PR TITLE
ci: add browser smoke gate (Part C-lite) before Pages deploy

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Install smoke dependencies
         working-directory: tests/browser
         run: |
-          npm install --no-audit --no-fund
+          npm ci --no-audit --no-fund
           npx playwright install --with-deps chromium
 
       - name: Browser smoke (must boot to title screen)

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -37,6 +37,29 @@ jobs:
       - name: Patch COI startup guard
         run: let-go tools/patch_wasm_coi.lg
 
+      - name: Set up Node (smoke gate)
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install smoke dependencies
+        working-directory: tests/browser
+        run: |
+          npm install --no-audit --no-fund
+          npx playwright install --with-deps chromium
+
+      - name: Browser smoke (must boot to title screen)
+        working-directory: tests/browser
+        run: node smoke.mjs --dir ../../dist
+
+      - name: Upload smoke failure artifacts
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: smoke-failure
+          path: tests/browser/smoke-failure.png
+          if-no-files-found: ignore
+
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@v3
         with:

--- a/tests/browser/package-lock.json
+++ b/tests/browser/package-lock.json
@@ -1,0 +1,57 @@
+{
+  "name": "xsofy-browser-smoke",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "xsofy-browser-smoke",
+      "dependencies": {
+        "playwright": "^1.50.0"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}

--- a/tests/browser/package.json
+++ b/tests/browser/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "xsofy-browser-smoke",
+  "private": true,
+  "type": "module",
+  "description": "Pre-deploy browser smoke gate. Boots the built WASM bundle in headless Chromium, waits for the deterministic 'Press any key' title-screen sentinel, and fails if it never appears or if any console.error / uncaught exception fires.",
+  "scripts": {
+    "smoke": "node smoke.mjs"
+  },
+  "dependencies": {
+    "playwright": "^1.50.0"
+  }
+}

--- a/tests/browser/smoke.mjs
+++ b/tests/browser/smoke.mjs
@@ -57,7 +57,7 @@ const page = await browser.newPage();
 const consoleErrs = [];
 const exceptions = [];
 page.on('console', msg => {
-  if (msg.type() === 'error' || msg.type() === 'warning') {
+  if (msg.type() === 'error') {
     consoleErrs.push(`[${msg.type()}] ${msg.text()}`);
   }
 });

--- a/tests/browser/smoke.mjs
+++ b/tests/browser/smoke.mjs
@@ -1,0 +1,109 @@
+// Pre-deploy browser smoke gate.
+//
+// Boots the built WASM bundle in headless Chromium and asserts:
+//   1. #terminal becomes visible within --timeout
+//   2. The deterministic title-screen sentinel "Press any key" appears in
+//      the rendered terminal text within --title-timeout
+//   3. Zero console.error / no uncaught exceptions during the window
+//
+// Runs its own static server with COOP/COEP headers so SharedArrayBuffer
+// works directly (no service-worker dance needed in CI).
+//
+// Empirically validated against xsofy@78e2350 (passes ~5.3s) and
+// xsofy@ffebbb3 (consistently fails — "Press any key" never renders).
+
+import { chromium } from 'playwright';
+import http from 'node:http';
+import fs from 'node:fs';
+import path from 'node:path';
+import { parseArgs } from 'node:util';
+
+const { values: args } = parseArgs({
+  options: {
+    dir: { type: 'string', default: 'dist' },
+    port: { type: 'string', default: '8765' },
+    timeout: { type: 'string', default: '10000' },
+    'title-timeout': { type: 'string', default: '10000' },
+    sentinel: { type: 'string', default: 'Press any key' },
+    screenshot: { type: 'string', default: 'smoke-failure.png' },
+  },
+});
+
+const port = parseInt(args.port);
+const timeout = parseInt(args.timeout);
+const titleTimeout = parseInt(args['title-timeout']);
+const serveDir = path.resolve(args.dir);
+
+const mimeTypes = {
+  '.html': 'text/html', '.js': 'application/javascript', '.json': 'application/json',
+  '.css': 'text/css', '.wasm': 'application/wasm', '.png': 'image/png',
+};
+const server = http.createServer((req, res) => {
+  res.setHeader('Cross-Origin-Opener-Policy', 'same-origin');
+  res.setHeader('Cross-Origin-Embedder-Policy', 'require-corp');
+  let urlPath = req.url.split('?')[0];
+  if (urlPath.endsWith('/')) urlPath += 'index.html';
+  fs.readFile(path.join(serveDir, urlPath), (err, data) => {
+    if (err) { res.writeHead(404); res.end(); return; }
+    res.setHeader('Content-Type', mimeTypes[path.extname(urlPath)] || 'application/octet-stream');
+    res.end(data);
+  });
+});
+await new Promise(r => server.listen(port, '127.0.0.1', r));
+
+const browser = await chromium.launch({ headless: true });
+const page = await browser.newPage();
+
+const consoleErrs = [];
+const exceptions = [];
+page.on('console', msg => {
+  if (msg.type() === 'error' || msg.type() === 'warning') {
+    consoleErrs.push(`[${msg.type()}] ${msg.text()}`);
+  }
+});
+page.on('pageerror', err => exceptions.push(err.message));
+
+const start = Date.now();
+let bootMs = -1, sentinelMs = -1, waitErr = null;
+
+try {
+  await page.goto(`http://127.0.0.1:${port}/`, { timeout });
+  await page.waitForSelector('#terminal', { state: 'visible', timeout });
+  bootMs = Date.now() - start;
+
+  await page.waitForFunction(
+    (sentinel) => {
+      const el = document.querySelector('.xterm-rows');
+      return el && el.textContent.includes(sentinel);
+    },
+    args.sentinel,
+    { timeout: titleTimeout, polling: 200 },
+  );
+  sentinelMs = Date.now() - start;
+} catch (err) {
+  waitErr = err;
+}
+
+const failures = [];
+if (waitErr) failures.push(`wait failed: ${waitErr.message.split('\n')[0]}`);
+if (exceptions.length) failures.push(`${exceptions.length} uncaught exception(s)`);
+if (consoleErrs.length) failures.push(`${consoleErrs.length} console error(s)`);
+
+if (failures.length === 0) {
+  console.log(`OK: #terminal at ${bootMs}ms, "${args.sentinel}" at ${sentinelMs}ms`);
+  await browser.close();
+  server.close();
+  process.exit(0);
+}
+
+if (args.screenshot) {
+  try { await page.screenshot({ path: args.screenshot }); console.error(`wrote ${args.screenshot}`); }
+  catch { /* ignore */ }
+}
+for (const f of failures) console.error(`FAIL: ${f}`);
+for (const e of exceptions) console.error(`EXCEPTION: ${e}`);
+for (const e of consoleErrs) console.error(`CONSOLE: ${e}`);
+
+await browser.close();
+server.close();
+process.exit(1);


### PR DESCRIPTION
Browser smoke gate (Part C-lite from the discussion in #58). Stacks on #59's tag-based deploy trigger.

Adds a deterministic boot/title-render gate before the `upload-pages-artifact` step. The smoke launches headless Chromium against the built `dist/`, waits for the literal "Press any key" subtitle from `xsofy.title` to appear in the rendered terminal text within 10s, and fails the deploy if it doesn't (or if any `console.error` / uncaught exception fires).

## Why "Press any key" as sentinel

It's a literal string in `xsofy/title.lg`, so the assertion is deterministic across the random seeding that varies room layout, enemies, and quest names every boot. Golden-snapshot row comparison was tested locally and is brittle for this reason — three boots of the same dist produce three completely different worlds.

## Empirical validation

- `xsofy@78e2350` (the v0.0.1 baseline): 3/3 pass, sentinel visible at ~5.3s
- `xsofy@ffebbb3` (current tip): 3/3 fail — sentinel never renders within 10s. "Press any key broken on tip" is part of the visible regression class.

## Implementation notes

- Playwright. `tests/browser/smoke.mjs` + `package.json` + `package-lock.json` (committed for reproducibility via `npm ci`).
- Only `console.error` and uncaught exceptions are fatal — `console.warning` was intentionally dropped during local review since browser/CDN warnings are too noisy for a deploy gate.
- Failed runs upload `smoke-failure.png` as a workflow artifact.
- ~30s added to deploy CI on cold install.

Doesn't catch the full xterm-render-correctness class — that's Part B territory (separate work, deferred).

Refs #58.
