### PR TITLE
fix(title): WASM-safe input poll via key-pending? (deploy regression)

### DIFF
--- a/xsofy/screenfx.lg
+++ b/xsofy/screenfx.lg
@@ -15,37 +15,28 @@
 
 ;; --- Non-blocking input for animated screens ---
 ;; `term/read-key` is blocking, so a screen that calls it directly freezes its
-;; animation until a key is pressed. To keep particles running, we read keys on
-;; a goroutine and select between that channel and a frame timer.
+;; animation until a key is pressed. To keep particles running we sleep one
+;; frame, then peek the input via the non-blocking `term/key-pending?` and only
+;; consume a key when one is queued.
 ;;
-;; The reader is ONE-SHOT: it reads a single key, delivers it, and exits. A
-;; goroutine blocked inside `read-key` cannot be cancelled, so a looping reader
-;; would survive past the screen and steal the next keypress from the game loop.
-;; One-shot + lazy re-arming guarantees at most one reader is ever blocked on
-;; stdin, and none is left behind once a screen exits on a key.
-
-(defn read-key-chan
-  "Spawn a goroutine that reads exactly one key and delivers it on the returned
-   channel, then exits. EOF (nil from read-key) is delivered as :eof."
-  []
-  (let [ch (async/chan)]
-    (go (async/>! ch (or (term/read-key) :eof)))
-    ch))
+;; Why not a goroutine + async/alts! on read-key: in WASM, `term/read-key` calls
+;; `Atomics.wait` on the SharedArrayBuffer, which blocks the entire worker
+;; thread (not just the calling goroutine). That freezes the timer goroutine
+;; backing `async/timeout`, so `alts!` never returns nil and the animation loop
+;; never advances past frame 0 — exactly the "Press any key" never-renders
+;; symptom observed on deployed builds. `key-pending?` is the let-go primitive
+;; provided for this idiom.
 
 (defn make-key-poller
-  "Return a 0-arg poll fn for animation loops. Each call waits up to `ms` for a
-   keypress: returns the key string, :eof, or nil if none arrived in time.
-   Arms a one-shot reader lazily and disarms once a key is delivered, so when a
-   screen stops polling (after its terminating key) no reader is left blocked."
+  "Return a 0-arg poll fn for animation loops. Each call yields ~ms then returns
+   the next pending key, or nil if no key was queued during the wait. Safe in
+   both native and WASM — `term/read-key` is only entered when a key is already
+   pending, so it returns immediately without blocking the runtime."
   [ms]
-  (let [armed (atom nil)]
-    (fn []
-      (when (nil? @armed)
-        (reset! armed (read-key-chan)))
-      (let [[v _] (async/alts! [@armed (async/timeout ms)])]
-        (when (some? v)
-          (reset! armed nil))
-        v))))
+  (fn []
+    (pause! ms)
+    (when (term/key-pending?)
+      (or (term/read-key) :eof))))
 
 (defn drive-until-key
   "Animation control loop. Render successive frames starting at `start-frame`,


### PR DESCRIPTION
## Summary

- Bisected the deploy regression visible on https://nooga.github.io/xsofy/ to **3ce4813** ("fix: keep title and death-screen particles animating without input"). The new `make-key-poller` uses `(go (term/read-key))` + `async/alts!` against a timeout. In WASM, `term/read-key` calls `Atomics.wait` on the SharedArrayBuffer, which **blocks the entire worker thread** (not just the calling goroutine) — freezing the timer goroutine backing `async/timeout` and pinning the animation loop at frame 0 forever. The frame-30-gated \"Press any key\" subtitle never renders.
- Rewrites `make-key-poller` to use the let-go `term/key-pending?` primitive (provided precisely for this idiom — see term.go docstring) plus the existing `pause!`. Drops the now-unused `read-key-chan`. `drive-until-key` is unchanged; the `title_test` seam stays valid.
- Native behavior is functionally equivalent. The death screen (uses the same poller via `main.lg`) gets the same fix.

## Why the goroutine pattern broke specifically in WASM

`term/read-key` source:
```go
// pkg/rt/term_wasm.go
atomics.Call(\"wait\", keyInt32, 0, 0)   // ← blocks worker thread, not just goroutine
```

Native `read` is goroutine-cooperative; WASM `Atomics.wait` is not. The let-go term module ships `key-pending?` (non-blocking Atomics.load probe) for exactly this idiom — and the native `pkg/rt/term.go` comment even calls it out: *\"makes the `(when (key-pending?) (read-key))` idiom honest for animation / poll loops.\"*

## Validation

Built bundle of each at `78e2350` (last-known-good baseline = v0.0.1), `ffebbb3` (broken deploy tip), and this PR's tip; ran the Part C-lite Playwright smoke from #60 10 times each.

| | v001 (good) | ffebbb3 (broken) | this PR |
|---|---|---|---|
| Smoke pass (n=10) | 10/10 | 0/10 | **10/10** |
| Boot ms (mean) | 734 | timeout | 659 |
| Sentinel ms (mean) | 5,739 | never paints | 6,624 |
| Gameplay frames (5 moves) | 5–6/6 distinct | 0 — can't advance | **6/6 distinct** |
| Console errors / page exceptions | 0 / 0 | 0 / 0 | 0 / 0 |
| Title JS heap Δ (MB) | 1.80 | 1.35 | **0.62** |

Sentinel delta vs v001 is +885ms, which is **less than** the intentional +1,200ms cadence change in 3ce4813 (30 frames × (120ms − 80ms) of \"calmer particle motion\"); no per-frame overhead is added by the fix. JS heap allocation is strictly lower than both — no `(go ...)` channel allocs per keypress arming.

Headless key-spam against the broken build (focused `#terminal`, 50+ space presses over 25s) never advances the title screen, confirming the deadlock is total — not a timing race.

Full lg test suite (260 tests, 2,227 assertions) passes against the fix branch.

## Test plan

- [x] Local Playwright smoke (`tests/browser/smoke.mjs` from #60): 10/10 pass; sentinel renders at 6.3–7.3s
- [x] Local lg test suite: 260/260 pass, 0 fail
- [x] Manual Safari on phone (Tailscale-served): title → \"Press any key\" → space → world renders → hjkl moves track 1:1
- [x] Compared perf vs v001 baseline: matches within design parameters, lower heap
- [ ] CI test.yml passes on the PR (lg test suite cell)
- [ ] On merge → tag → deploy, the Part C-lite gate (#60) will independently re-validate the sentinel before the bundle goes live

## Notes

- Once this merges, a fresh tag on top of main (v0.0.2 or moved v0.0.1) picks up the new deploy workflow (#59) + smoke gate (#60) naturally — no cherry-pick or history rewrite needed to recover the live URL.
- The bisect range was 6 commits (`78e2350..ffebbb3`); `ffebbb3` itself is docs-only (#55) so the effective range was 5 code commits. `3ce4813` reproduced FAIL on first spot-check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)