### PR TITLE
Reproducible runs: headless-safe render + seed-derived title/quest/scheme

### DIFF
--- a/main.lg
+++ b/main.lg
@@ -14,7 +14,8 @@
             [xsofy.title :as title]
             [xsofy.screenfx :as sfx]
             [xsofy.debug :as dbg]
-            [xsofy.dispatch :as dispatch]))
+            [xsofy.dispatch :as dispatch]
+            [xsofy.seed :as seed]))
 
 
 (defn init-terminal []
@@ -359,10 +360,12 @@
       :else world)))
 
 (defn new-game []
-  (let [{:keys [title scheme]} (title/show-title-screen)
-        quest (title/generate-quest)
+  (let [sd  (seed/boot-seed)
+        rng {:seed sd}
+        {:keys [title scheme rng]} (title/show-title-screen rng)
+        [quest rng] (title/generate-quest rng)
         _ (title/show-descending-screen 1 scheme)]
-    (-> (world/make-world 79 30 (rand-int 1000000000))
+    (-> (world/make-world 79 30 sd)
         (assoc :title title
                :scheme scheme
                :quest-item (:item quest))

--- a/xsofy/render.lg
+++ b/xsofy/render.lg
@@ -17,6 +17,12 @@
 
 (def dim-color u/scale)
 
+;; Terminal dimensions, headless-safe. term/size is nil with no TTY (CI/tests)
+;; and momentarily nil during a resize — both yielded a nil destructure and a
+;; blank/garbled redraw. Fall back to the game's nominal size.
+(defn term-dims []
+  (or (term/size) [ui/game-width ui/game-height]))
+
 ;; --- Tile Rendering ---
 
 (defn style-tile [tile]
@@ -615,7 +621,7 @@
         inv)))))
 
 (defn render-quick-menu [world]
-  (let [[tw th] (term/size)
+  (let [[tw th] (term-dims)
         action (or (:menu-action world) :equip)
         items (menu-filter world action)
         sel (or (:menu-sel world) -1)
@@ -652,7 +658,7 @@
 ;; --- Message Log Screen (modal) ---
 
 (defn render-messages-screen [world]
-  (let [[tw th] (term/size)
+  (let [[tw th] (term-dims)
         r (ui/rect 1 1 tw th)
         inner (ui/box r "Message Log" [180 170 140] ui/bg)
         visible-lines (message-visible-lines th)
@@ -707,7 +713,7 @@
         (swap! row inc)))))
 
 (defn render-help-screen [world]
-  (let [[tw th] (or (term/size) [ui/game-width ui/game-height])
+  (let [[tw th] (term-dims)
         r (ui/rect 1 1 tw th)
         inner (ui/box r "Keybindings" [180 170 140] ui/bg)
         [left right] (ui/rect-split-h inner (quot (:w inner) 2))]
@@ -779,7 +785,7 @@
             (ui/write-line r (inc @rune-row) cmds [120 120 100] ui/bg)))))))
 
 (defn render-inventory-screen [world]
-  (let [[tw th] (term/size)
+  (let [[tw th] (term-dims)
         r (ui/rect 1 1 tw th)
         inner (ui/box r "Inventory" [180 170 140] ui/bg)
         inv (or (get-in world [:entities :player :inventory]) [])
@@ -867,7 +873,7 @@
   (sfx/scatter-runes tw th 30 [200 50 30]))  ;; crimson runes
 
 (defn render-death-screen [world runes scroll-offset frame]
-  (let [[tw th] (term/size)
+  (let [[tw th] (term-dims)
         cx (quot tw 2)
         cy (quot th 2)
         seed (or (:turn world) 0)]
@@ -1005,7 +1011,7 @@
 ;; --- Rune Codex Screen ---
 
 (defn render-rune-codex [world]
-  (let [[tw th] (term/size)
+  (let [[tw th] (term-dims)
         r (ui/rect 1 1 tw th)
         inner (ui/box r "Rune Codex" [170 140 220] ui/bg)
         rune-table (or (:rune-table world) {})
@@ -1037,7 +1043,7 @@
 ;; --- Inscription Screen ---
 
 (defn render-inscribe-screen [world]
-  (let [[tw th] (term/size)
+  (let [[tw th] (term-dims)
         r (ui/rect 1 1 tw th)
         inner (ui/box r "Inscribe Runes" [200 160 240] ui/bg)
         rune-table (or (:rune-table world) {})
@@ -1097,7 +1103,7 @@
 
 (defn render-hazard-prompt [world prompt]
   "Render a hazard confirmation prompt at the bottom of the screen."
-  (let [[tw th] (term/size)
+  (let [[tw th] (term-dims)
         msg (str " " prompt " (y/n)")
         y th]
     (term/move-cursor 1 y)
@@ -1109,7 +1115,7 @@
     (term/flush)))
 
 (defn render-full [world]
-  (let [[tw th] (term/size)
+  (let [[tw th] (term-dims)
         panels (ui/layout tw th)]
     ;; blank entire terminal with bg color
     (ui/apply-bg ui/bg)
@@ -1126,7 +1132,7 @@
     (term/flush)))
 
 (defn render-dirty [world prev-world]
-  (let [[tw th] (term/size)
+  (let [[tw th] (term-dims)
         panels (ui/layout tw th)
         mr (:map panels)
         old-fov (:fov prev-world)

--- a/xsofy/seed.lg
+++ b/xsofy/seed.lg
@@ -1,0 +1,18 @@
+(ns xsofy.seed
+  "Run seed. Precedence: explicit override (tests / *boot-seed*), then the
+   XSOFY_SEED env var (native + browser-via-?seed= bridge), then random.
+   A fixed seed reproduces an entire run — title, quest, scheme, and world."
+  (:require [os]))
+
+(def ^:dynamic *boot-seed* nil)
+
+(defn boot-seed []
+  (or *boot-seed*
+      ;; Validate at the boundary: a malformed XSOFY_SEED (e.g. ?seed=foo / 12.5 /
+      ;; empty) reads as a symbol/float/nil; only accept an integer, else fall
+      ;; through to random rather than surfacing the failure later in the chain.
+      (let [s (os/getenv "XSOFY_SEED")]
+        (when (and s (> (count s) 0))
+          (let [n (read-string s)]
+            (when (integer? n) n))))
+      (rand-int 1000000000)))

--- a/xsofy/test/render_test.lg
+++ b/xsofy/test/render_test.lg
@@ -71,3 +71,9 @@
                                            #{[5 5]})]
     (is (nil? (get result [1 1])))
     (is (= :gold-2 (:id (get result [5 5]))))))
+
+(deftest term-dims-falls-back-to-game-size-when-headless
+  ;; term/size returns nil with no TTY (CI, tests). render entries must not
+  ;; destructure nil — they fall back to the game's default dimensions.
+  (testing "no TTY → [ui/game-width ui/game-height] defaults"
+    (is (= [100 36] (render/term-dims)))))

--- a/xsofy/test/run.lg
+++ b/xsofy/test/run.lg
@@ -12,6 +12,7 @@
             [xsofy.test.world-seed-test]
             [xsofy.test.dispatch-test]
             [xsofy.test.serialize-test]
-            [xsofy.test.dag-test]))
+            [xsofy.test.dag-test]
+            [xsofy.test.seed-test]))
 
 (run-tests)

--- a/xsofy/test/seed_test.lg
+++ b/xsofy/test/seed_test.lg
@@ -1,0 +1,12 @@
+(ns xsofy.test.seed-test
+  (:require [test :refer [deftest is testing]]
+            [xsofy.seed :as seed]))
+
+(deftest boot-seed-prefers-dynamic-override
+  (testing "*boot-seed* wins when bound"
+    (binding [seed/*boot-seed* 777]
+      (is (= 777 (seed/boot-seed))))))
+
+(deftest boot-seed-defaults-to-an-integer
+  (testing "unbound, no env → a random integer (still usable)"
+    (is (integer? (seed/boot-seed)))))

--- a/xsofy/test/title_test.lg
+++ b/xsofy/test/title_test.lg
@@ -1,6 +1,8 @@
 (ns xsofy.test.title-test
   (:require [test :refer [deftest is testing]]
-            [xsofy.screenfx :as sfx]))
+            [xsofy.screenfx :as sfx]
+            [xsofy.title :as title]
+            [xsofy.det :as det]))
 
 ;; nooga/xsofy — particle screens (title + death) must keep animating
 ;; independently of input. The control seam is `drive-until-key`: it renders
@@ -37,3 +39,16 @@
       (is (= "q" k))
       (is (= [7] @rendered))
       (is (= 8 next-frame)))))
+
+(deftest seeded-title-is-deterministic
+  (testing "same seed → same title; known golden for 12345"
+    (is (= (first (title/generate-title {:seed 12345}))
+           (first (title/generate-title {:seed 12345}))))
+    (is (= "Chasms of Infinity" (first (title/generate-title {:seed 12345}))))))
+
+(deftest seeded-quest-is-deterministic
+  (testing "quest threads from the post-title-and-scheme rng (matches new-game order)"
+    (let [[_ r] (title/generate-title {:seed 12345})
+          [_ r] (title/pick-scheme r)
+          [quest _] (title/generate-quest r)]
+      (is (= "Spatula of Unmatched Delimiters" (:item quest))))))

--- a/xsofy/title.lg
+++ b/xsofy/title.lg
@@ -1,6 +1,7 @@
 (ns xsofy.title
   (:require [term]
-            [xsofy.screenfx :as sfx]))
+            [xsofy.screenfx :as sfx]
+            [xsofy.det :as det]))
 
 ;; --- Procedural Title Generation ---
 
@@ -35,10 +36,10 @@
          "Trepidation" "Trouble" "Tuesday" "Undefined Behavior"
          "Understandable Nature" "Varying Utility"])
 
-(defn generate-title []
-  (str (nth xs (rand-int (count xs)))
-       " of "
-       (nth ys (rand-int (count ys)))))
+(defn generate-title [rng]
+  (let [[x rng] (det/pick rng xs)
+        [y rng] (det/pick rng ys)]
+    [(str x " of " y) rng]))
 
 ;; --- Quest Objective ---
 
@@ -71,13 +72,14 @@
    "You wake up hung over on a stone slab. No way out."
    "You just got here. You don't feel like going back yet."])
 
-(defn generate-quest []
-  (let [gate (nth gate-messages (rand-int (count gate-messages)))
-        item (str (nth quest-ps (rand-int (count quest-ps)))
-                  " of "
-                  (nth quest-qs (rand-int (count quest-qs))))]
-    {:item item
-     :messages [gate (str "You must retrieve the " item ".")]}))
+(defn generate-quest [rng]
+  (let [[gate rng] (det/pick rng gate-messages)
+        [p rng]    (det/pick rng quest-ps)
+        [q rng]    (det/pick rng quest-qs)
+        item       (str p " of " q)]
+    [{:item item
+      :messages [gate (str "You must retrieve the " item ".")]}
+     rng]))
 
 ;; --- Rune Glyphs ---
 
@@ -90,6 +92,9 @@
    [170 70 220]    ;; violet
    [70 200 200]    ;; teal
    [220 120 50]])  ;; amber
+
+(defn pick-scheme [rng]
+  (det/pick rng color-schemes))
 
 ;; --- Title Screen ---
 ;; Screen-animation primitives (pause!, scatter-runes, rune-brightness,
@@ -134,22 +139,17 @@
         (term/write subtitle)))
     (term/flush)))
 
-(defn show-title-screen []
-  (let [[tw th] (term/size)
-        title (generate-title)
+(defn show-title-screen [rng]
+  (let [[tw th] (or (term/size) [100 36])
+        [title rng]  (generate-title rng)
         subtitle "Press any key"
-        scheme (nth color-schemes (rand-int (count color-schemes)))
+        [scheme rng] (pick-scheme rng)
         runes (sfx/scatter-runes tw th 40 scheme)]
-    ;; clear once
     (sfx/clear-screen tw th)
-    ;; animate continuously until a key is pressed — runes keep pulsing instead
-    ;; of freezing on a held final frame while a blocking read-key waits.
     (sfx/drive-until-key 0
                          (fn [frame] (draw-frame runes title subtitle tw th frame))
-                         ;; 120ms/frame: a calmer rune pulse (was 80ms). Input
-                         ;; latency at a title screen is imperceptible at this rate.
                          (sfx/make-key-poller 120))
-    {:title title :scheme scheme}))
+    {:title title :scheme scheme :rng rng}))
 
 ;; --- Descending Screen ---
 ;; Shown while terrain generates. Runes rise upward, flicker and fade.


### PR DESCRIPTION
## Reproducible runs (1/5)

Makes a run fully reproducible from its seed, and hardens headless rendering.

- **`render/term-dims`** — headless-safe terminal size (falls back to game dims when `term/size` is nil: CI/tests, or the brief resize gap). Removes nil-destructure crashes and a redraw-glitch source; routes all render entries through it.
- **`xsofy.seed/boot-seed`** — run seed from `*boot-seed*` (tests) / `XSOFY_SEED` env / random fallback.
- **Seed-derived title/quest/scheme** — `generate-title`/`generate-quest`/`pick-scheme` thread the deterministic RNG (`xsofy.det`) so a fixed seed reproduces the *entire* run (title, quest, scheme, world). let-go has no global RNG seeding, so these previously used the unseedable global `rand-int`.

Foundation for the `?seed=` / replay work in the rest of the stack.

### Stack (bottom→top)
1. reproducible-runs
2. repro-test-infra
3. native-xxh3
4. browser-gate
5. seed-and-replay

Tests: full let-go suite green.