### PR TITLE
Seed display + shareable replay codes (?replay=)

### DIFF
--- a/main.lg
+++ b/main.lg
@@ -360,17 +360,51 @@
 
       :else world)))
 
+(defn assemble-world
+  "Build the starting world for `seed` and graft on its (seed-derived) title,
+   scheme, and quest. Title/scheme/quest are cosmetic — they don't touch the
+   gameplay seed chain — so this world replays identically to one made by
+   new-game from the same seed."
+  [seed title scheme quest]
+  (-> (world/make-world 79 30 seed)
+      (assoc :title title
+             :scheme scheme
+             :quest-item (:item quest))
+      (#(reduce world/log-msg % (:messages quest)))))
+
 (defn new-game []
   (let [sd  (seed/boot-seed)
         rng {:seed sd}
         {:keys [title scheme rng]} (title/show-title-screen rng)
         [quest rng] (title/generate-quest rng)
         _ (title/show-descending-screen 1 scheme)]
-    (-> (world/make-world 79 30 sd)
-        (assoc :title title
-               :scheme scheme
-               :quest-item (:item quest))
-        (#(reduce world/log-msg % (:messages quest))))))
+    (assemble-world sd title scheme quest)))
+
+(defn build-game
+  "Reconstruct a run's starting world from its seed, without the interactive
+   title screen (same pick order as new-game: title -> scheme -> quest)."
+  [seed]
+  (let [rng {:seed seed}
+        [title rng]  (title/generate-title rng)
+        [scheme rng] (title/pick-scheme rng)
+        [quest rng]  (title/generate-quest rng)]
+    (assemble-world seed title scheme quest)))
+
+(defn play-replay
+  "Decode a replay code, reconstruct the run, and step through its actions with
+   a short delay so the run plays out on screen. Returns the final world so the
+   caller can hand control back to the player at the recorded end-state."
+  [code]
+  (let [{:keys [seed actions]} (replay/decode code)
+        w0 (build-game seed)]
+    (render/render-full w0)
+    (sfx/pause! 400)
+    (reduce (fn [w action]
+              (let [w' (dispatch/dispatch w action)]
+                (render/render-full w')
+                (sfx/pause! 90)
+                w'))
+            w0 actions)))
 
 (defn game-loop
   ([world]
@@ -568,7 +602,8 @@
 (defn -main []
   (init-terminal)
   (try
-    (game-loop (new-game))
+    (let [code (seed/boot-replay)]
+      (game-loop (if code (play-replay code) (new-game))))
     (catch e
            (dbg/log "FATAL ERROR:" e)
            (dbg/dump-crash! e)

--- a/main.lg
+++ b/main.lg
@@ -15,7 +15,8 @@
             [xsofy.screenfx :as sfx]
             [xsofy.debug :as dbg]
             [xsofy.dispatch :as dispatch]
-            [xsofy.seed :as seed]))
+            [xsofy.seed :as seed]
+            [xsofy.replay :as replay]))
 
 
 (defn init-terminal []
@@ -434,6 +435,7 @@
          :death
          (let [[tw th] (term/size)
                runes (render/death-runes tw th)  ;; scatter ONCE — stable across frames
+               replay-code (replay/encode-run world)  ;; compute ONCE — encode is O(n) per call
                poll! (sfx/make-key-poller 120)  ;; calmer death-screen pulse (was 80ms)
                _ (sfx/clear-screen tw th)  ;; clear ONCE, not per-frame — was the flicker source
                result (loop [scroll 0 frame 0]
@@ -441,7 +443,7 @@
                         ;; pulsing while we wait for a key instead of freezing.
                         (let [[k nf] (sfx/drive-until-key
                                        frame
-                                       (fn [f] (render/render-death-screen world runes scroll f))
+                                       (fn [f] (render/render-death-screen world runes scroll f replay-code))
                                        poll!)]
                           (cond
                             (or (= k "n") (= k "\r") (= k "\n") (= k " "))

--- a/tests/e2e/boot-smoke.spec.js
+++ b/tests/e2e/boot-smoke.spec.js
@@ -28,6 +28,19 @@ async function waitForServer(port = 8123, timeout = 5000) {
   throw new Error(`Server did not start within ${timeout}ms`);
 }
 
+// Wait for the child to release the port before resolving — a bare srv.kill()
+// can leave 8123 in TIME_WAIT and flake the next test / retry.
+function stopServer(srv) {
+  return new Promise((resolve) => { srv.on('exit', () => resolve()); srv.kill(); });
+}
+
+function watchConsole(page) {
+  const errors = [];
+  page.on('console', (m) => { if (m.type() === 'error') errors.push(m.text()); });
+  page.on('pageerror', (e) => errors.push(String(e)));
+  return errors;
+}
+
 // xterm.js renders into .xterm-rows; its text is in textContent (NOT #terminal
 // innerText, which comes back empty).
 function termText(page) {
@@ -44,13 +57,11 @@ function waitForTermText(page, needle, timeout = 30000) {
 
 // The title text renders from frame 0, so it's present even if the animation
 // loop is frozen. (The "Press any key" subtitle is frame-30-gated — see below.)
-const TITLE_FRAGMENT = 'Chasms';   // seed-independent: every title is "X of Y"; this seed yields "Chasms of Infinity"
+const TITLE_FRAGMENT = 'Chasms';   // seed-SPECIFIC: fragment for the boot seed; different seeds → different titles
 
 test('worker-mode boot: cross-origin isolated, renders the title, console-clean', async ({ page }) => {
   const srv = serve();
-  const errors = [];
-  page.on('console', m => { if (m.type() === 'error') errors.push(m.text()); });
-  page.on('pageerror', e => errors.push(String(e)));
+  const errors = watchConsole(page);
   try {
     await waitForServer();
     await page.goto('/?seed=12345');
@@ -59,17 +70,16 @@ test('worker-mode boot: cross-origin isolated, renders the title, console-clean'
     await waitForTermText(page, TITLE_FRAGMENT);
     expect(await termText(page)).not.toContain('Interactive input requires a local server');
     expect(errors, errors.join('\n')).toEqual([]);
-  } finally { srv.kill(); }
+  } finally { await stopServer(srv); }
 });
 
 // Animation gate. The "Press any key" subtitle only renders once the title
-// animation reaches frame > 30. On builds with the WASM title-poll deadlock
-// (nooga/xsofy#61: make-key-poller's (go (term/read-key)) hits Atomics.wait,
-// which blocks the whole worker and freezes the animation loop at frame 0), the
-// subtitle never paints. This asserts the animation runs — un-fixme once #61
-// (or its fix) is on the base branch.
-test.fixme('title animation runs (subtitle paints + frames change) — pending nooga/xsofy#61', async ({ page }) => {
+// animation reaches frame > 30 — which requires a WASM-safe input poll. Before
+// nooga/xsofy#61, make-key-poller's (go (term/read-key)) hit Atomics.wait and
+// froze the worker (and the animation) at frame 0; #61 (key-pending?) fixed it.
+test('title animation runs (subtitle paints + frames change)', async ({ page }) => {
   const srv = serve();
+  const errors = watchConsole(page);
   try {
     await waitForServer();
     await page.goto('/?seed=12345');
@@ -79,5 +89,6 @@ test.fixme('title animation runs (subtitle paints + frames change) — pending n
     await page.waitForTimeout(700);
     const b = await page.locator('#terminal').screenshot();
     expect(Buffer.compare(a, b)).not.toBe(0);
-  } finally { srv.kill(); }
+    expect(errors, errors.join('\n')).toEqual([]);
+  } finally { await stopServer(srv); }
 });

--- a/tests/e2e/regression.spec.js
+++ b/tests/e2e/regression.spec.js
@@ -24,24 +24,61 @@ async function waitForServer(port = 8123, timeout = 5000) {
   throw new Error(`Server did not start within ${timeout}ms`);
 }
 
+// Wait for the child to actually release the port before the test resolves —
+// a bare srv.kill() can leave 8123 in TIME_WAIT and flake the next test/retry.
+function stopServer(srv) {
+  return new Promise((resolve) => { srv.on('exit', () => resolve()); srv.kill(); });
+}
+
+// Collect console.error / pageerror so each test can assert console-clean, not
+// just the first boot test.
+function watchConsole(page) {
+  const errors = [];
+  page.on('console', (m) => { if (m.type() === 'error') errors.push(m.text()); });
+  page.on('pageerror', (e) => errors.push(String(e)));
+  return errors;
+}
+
 // Golden title for seed 12345 (computed natively from the word lists). Seeing
 // it render in-browser proves the whole determinism chain: ?seed= reached the
 // game via go.env, AND wasm-xxh3 == native-xxh3 (a divergence in either would
 // produce a different title).
 const TITLE = 'Chasms of Infinity';
 
+function waitForTermText(page, needle, timeout = 30000) {
+  return page.waitForFunction(
+    (t) => { const el = document.querySelector('.xterm-rows'); return !!el && el.textContent.includes(t); },
+    needle, { timeout, polling: 200 });
+}
+
 test('seed 12345 reproduces the title (proves ?seed bridge + wasm xxh3 parity)', async ({ page }) => {
   const srv = serve();
+  const errors = watchConsole(page);
   try {
     await waitForServer();
     await page.goto('/?seed=12345');
     expect(await page.evaluate(() => self.crossOriginIsolated)).toBe(true);
     await expect(page.locator('#terminal')).toBeVisible({ timeout: 20000 });
-    await page.waitForFunction(
-      (t) => {
-        const el = document.querySelector('.xterm-rows');
-        return !!el && el.textContent.includes(t);
-      },
-      TITLE, { timeout: 30000, polling: 200 });
-  } finally { srv.kill(); }
+    await waitForTermText(page, TITLE);
+    expect(errors, errors.join('\n')).toEqual([]);
+  } finally { await stopServer(srv); }
+});
+
+// Replay code for seed 12345 + [:wait :wait :down :wait] (xsofy.replay/encode).
+// Regenerate with: lg -e '(require (quote [xsofy.replay :as r])) (println (r/encode 12345 [...]))'
+const REPLAY_CODE = 'AQAAAAAAADA5AgR3YWl0BGRvd24AAAADAAIBAQAB';
+
+test('?replay= plays back the run (decode + animated playback + xxh3 parity)', async ({ page }) => {
+  const srv = serve();
+  const errors = watchConsole(page);
+  try {
+    await waitForServer();
+    await page.goto('/?replay=' + encodeURIComponent(REPLAY_CODE));
+    expect(await page.evaluate(() => self.crossOriginIsolated)).toBe(true);
+    await expect(page.locator('#terminal')).toBeVisible({ timeout: 20000 });
+    // Playback skips the title screen and renders the game; the HUD seed line
+    // proves the code decoded to seed 12345 and the run was rebuilt + rendered.
+    await waitForTermText(page, 'Seed 12345');
+    expect(errors, errors.join('\n')).toEqual([]);
+  } finally { await stopServer(srv); }
 });

--- a/tools/patch_wasm_seed.lg
+++ b/tools/patch_wasm_seed.lg
@@ -1,5 +1,6 @@
 (ns tools.patch-wasm-seed
-  "Bridge ?seed= → worker go.env.XSOFY_SEED in the generated WASM index.html.
+  "Bridge ?seed= → go.env.XSOFY_SEED and ?replay= → go.env.XSOFY_REPLAY in the
+   generated WASM index.html, so the game's os/getenv sees them in the browser.
    Idempotent and fail-closed, like patch_wasm_coi."
   (:require [string :as str]
             [os]))
@@ -19,35 +20,44 @@
                             (abort! (str "missing anchor: " needle)))
       :else (abort! (str "anchor appears more than once: " needle)))))
 
-;; 1) Main thread: read ?seed= and include it in the worker init message.
+;; 1) Main thread: read ?seed= / ?replay= and include them in the worker init.
 (def post-before
   "worker.postMessage({ t: 'init', sab, wasmGzB64: WASM_GZ_B64, wasmExecJS: WASM_EXEC_JS });")
 (def post-after
-  (str "const __lgSeed = new URLSearchParams(location.search).get('seed');\n"
-       "  worker.postMessage({ t: 'init', sab, wasmGzB64: WASM_GZ_B64, wasmExecJS: WASM_EXEC_JS, seed: __lgSeed });"))
+  (str "const __lgParams = new URLSearchParams(location.search);\n"
+       "  const __lgSeed = __lgParams.get('seed');\n"
+       "  const __lgReplay = __lgParams.get('replay');\n"
+       "  worker.postMessage({ t: 'init', sab, wasmGzB64: WASM_GZ_B64, wasmExecJS: WASM_EXEC_JS, seed: __lgSeed, replay: __lgReplay });"))
 
-;; 2) Worker: destructure the seed out of the init message.
+;; 2) Worker: destructure seed + replay out of the init message.
 (def destr-before "const { sab, wasmGzB64, wasmExecJS } = e.data;")
-(def destr-after  "const { sab, wasmGzB64, wasmExecJS, seed } = e.data;")
+(def destr-after  "const { sab, wasmGzB64, wasmExecJS, seed, replay } = e.data;")
 
-;; 3) Worker: set go.env from the seed before running. Anchored on the unique
+;; 3) Worker: set go.env from seed/replay before running. Anchored on the unique
 ;;    "// Run Go WASM" comment so it can't match the main-thread new Go().
 (def go-before  "// Run Go WASM\n      const go = new Go();")
 (def go-after
   (str "// Run Go WASM\n      const go = new Go();\n"
-       "      if (seed != null && seed !== '') go.env = Object.assign({}, go.env, { XSOFY_SEED: String(seed) });"))
+       "      { const __lgEnv = Object.assign({}, go.env);\n"
+       "        if (seed != null && seed !== '') __lgEnv.XSOFY_SEED = String(seed);\n"
+       "        if (replay != null && replay !== '') __lgEnv.XSOFY_REPLAY = String(replay);\n"
+       "        go.env = __lgEnv; }"))
 
 ;; Early idempotency guard: anchor 3's needle ("// Run Go WASM\n      const go =
 ;; new Go();") survives its own append (the patch only adds lines after it), so
 ;; re-running would inject the go.env line twice. Bail out cleanly if the bundle
 ;; is already bridged.
-(let [html (slurp index-path)]
-  (if (str/includes? html "XSOFY_SEED")
-    (println (str "already seed-bridged " index-path))
+(let [html (slurp index-path)
+      bridged? (fn [h] (and (str/includes? h "XSOFY_SEED")
+                            (str/includes? h "XSOFY_REPLAY")))]
+  (if (bridged? html)
+    (println (str "already url-bridged " index-path))
     (let [html (replace-exact html post-before post-after)
           html (replace-exact html destr-before destr-after)
           html (replace-exact html go-before go-after)]
-      (when-not (str/includes? html "XSOFY_SEED")
-        (abort! "failed to inject seed bridge"))
+      ;; gate on BOTH injected vars — a bundle patched by the seed-only version of
+      ;; this script (and not rebuilt) must still receive the replay bridge.
+      (when-not (bridged? html)
+        (abort! "failed to inject seed/replay bridge"))
       (spit index-path html)
-      (println (str "seed-bridged " index-path)))))
+      (println (str "url-bridged " index-path)))))

--- a/xsofy/render.lg
+++ b/xsofy/render.lg
@@ -875,7 +875,7 @@
   [tw th]
   (sfx/scatter-runes tw th 30 [200 50 30]))  ;; crimson runes
 
-(defn render-death-screen [world runes scroll-offset frame]
+(defn render-death-screen [world runes scroll-offset frame replay-code]
   (let [[tw th] (term-dims)
         cx (quot tw 2)
         cy (quot th 2)
@@ -983,7 +983,25 @@
             (term/move-cursor (max 1 (- cx (quot (count sline) 2))) sy)
             (term/set-fg 110 105 90)
             (term/set-bg 10 10 10)
-            (term/write sline)))))
+            (term/write sline)
+            ;; replay code — wrapped across the lower rows. The full code replays
+            ;; the exact run via ?replay=; long codes may overflow (share the seed).
+            (when (and replay-code (> (count replay-code) 0))
+              (let [cw (max 24 (- tw 4))
+                    lines (loop [s replay-code acc []]
+                            (if (<= (count s) cw)
+                              (conj acc s)
+                              (recur (subs s cw) (conj acc (subs s 0 cw)))))
+                    ly0 (min (- th 2) (+ sy 2))]
+                (term/move-cursor 2 ly0)
+                (term/set-fg 70 85 75) (term/set-bg 10 10 10)
+                (term/write "replay code (paste into ?replay=):")
+                (loop [i 0 ls lines]
+                  (when (and (seq ls) (< (+ ly0 1 i) th))
+                    (term/move-cursor 2 (+ ly0 1 i))
+                    (term/set-fg 110 125 105) (term/set-bg 10 10 10)
+                    (term/write (first ls))
+                    (recur (inc i) (rest ls))))))))))
     ;; message log — scrollable
     (let [log (or (:log world) [])
           log-count (count log)

--- a/xsofy/render.lg
+++ b/xsofy/render.lg
@@ -301,6 +301,9 @@
       ;; depth
       (ui/write-line r @row (str " Depth " (:depth world)) [100 100 100] ui/bg)
       (swap! row inc)
+      ;; seed — enables ?seed= reproducible runs (#44)
+      (ui/write-line r @row (str " Seed " (:seed-input world)) [80 80 95] ui/bg)
+      (swap! row inc)
       ;; separator
       (ui/write-line r @row (apply str (repeat (:w r) "-")) [40 40 40] ui/bg)
       (swap! row inc)
@@ -972,7 +975,15 @@
           (term/move-cursor (max 1 (- cx (quot (count dmsg) 2))) msg-y)
           (term/set-fg 200 60 40)
           (term/set-bg 10 10 10)
-          (term/write dmsg))))
+          (term/write dmsg)
+          ;; seed line — note/share to replay this exact run via ?seed=
+          (let [sd (:seed-input world)
+                sline (str "seed " sd "  ·  ?seed=" sd " to replay")
+                sy (min (- th 1) (+ msg-y 2))]
+            (term/move-cursor (max 1 (- cx (quot (count sline) 2))) sy)
+            (term/set-fg 110 105 90)
+            (term/set-bg 10 10 10)
+            (term/write sline)))))
     ;; message log — scrollable
     (let [log (or (:log world) [])
           log-count (count log)

--- a/xsofy/replay.lg
+++ b/xsofy/replay.lg
@@ -1,0 +1,204 @@
+(ns xsofy.replay
+  "Shareable replay codes.
+
+   SCOPE — a replay code captures (seed, :action-log) and reproduces only the
+   KEYWORD-DISPATCH portion of a run: turns that flow through xsofy.dispatch. The
+   seed reproduces the opening state (title/quest/scheme/world generation), and
+   :action-log reproduces dispatch-routed turns. Runs that involve inventory,
+   menu, inscribe, or hazard-confirm interactions are NOT fully reproducible from
+   the code today — those handlers mutate the world outside dispatch (widening
+   that contract is a follow-up). So a code is faithful for keyword-only
+   gameplay, and reproduces the opening state for everything else.
+
+   This packs (seed, action-log) into a compact, URL-safe base64 string suitable
+   for a ?replay= link or XSOFY_REPLAY env var.
+
+   Wire format (bytes, then url-safe base64, no padding):
+     1   version (= 1; v1-exact — future versions reject v1 codes by default)
+     8   seed                       (i64 big-endian)
+     1   dict size D                (distinct action keywords, < 256)
+     D*  for each: 1 len + ASCII name bytes   (self-describing dictionary)
+     4   run count R                (u32 big-endian)
+     R*  for each run: 1 dict-index + varint run-length
+
+   Runs are run-length-encoded over the dictionary indices, which compresses the
+   long streaks of repeated movement typical of a roguelike. Only keyword actions
+   are supported (the action-log contains bare keywords); names must be ASCII.
+
+   ABI — action keywords are wire-format ABI. Renaming an action keyword breaks
+   all existing replay codes; the format does not migrate.")
+
+(def ^:private VERSION 1)
+
+;; --- url-safe base64 (RFC 4648 §5, no padding) ---
+
+(def ^:private b64-alphabet
+  "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_")
+
+(def ^:private b64-decode-map
+  (reduce (fn [m i] (assoc m (int (nth b64-alphabet i)) i))
+          {} (range (count b64-alphabet))))
+
+(defn b64-encode
+  "Encode a vector of int byte values [0,255] to a url-safe base64 string."
+  [bytes]
+  (let [n (count bytes)]
+    (loop [i 0 out []]
+      (if (>= i n)
+        (apply str out)
+        (let [b0 (nth bytes i)
+              b1 (if (< (+ i 1) n) (nth bytes (+ i 1)) 0)
+              b2 (if (< (+ i 2) n) (nth bytes (+ i 2)) 0)
+              rem (- n i)
+              c0 (bit-and (unsigned-bit-shift-right b0 2) 0x3F)
+              c1 (bit-and (bit-or (bit-shift-left b0 4) (unsigned-bit-shift-right b1 4)) 0x3F)
+              c2 (bit-and (bit-or (bit-shift-left b1 2) (unsigned-bit-shift-right b2 6)) 0x3F)
+              c3 (bit-and b2 0x3F)
+              chs (cond
+                    (= rem 1) [c0 c1]
+                    (= rem 2) [c0 c1 c2]
+                    :else     [c0 c1 c2 c3])]
+          (recur (+ i 3) (into out (map (fn [c] (nth b64-alphabet c)) chs))))))))
+
+(defn b64-decode
+  "Decode a url-safe base64 string to a vector of int byte values. Rejects any
+   character outside the url-safe base64 alphabet with one controlled error
+   (rather than crashing later in the bit math on a nil)."
+  [s]
+  (let [vals (mapv (fn [c]
+                     (or (get b64-decode-map (int c))
+                         (throw (ex-info "replay: invalid character in replay code"
+                                         {:char c}))))
+                   s)
+        n (count vals)]
+    (loop [i 0 out []]
+      (if (>= i n)
+        out
+        (let [v0 (nth vals i)
+              v1 (if (< (+ i 1) n) (nth vals (+ i 1)) 0)
+              v2 (if (< (+ i 2) n) (nth vals (+ i 2)) 0)
+              v3 (if (< (+ i 3) n) (nth vals (+ i 3)) 0)
+              rem (- n i)
+              b0 (bit-and (bit-or (bit-shift-left v0 2) (unsigned-bit-shift-right v1 4)) 0xFF)
+              b1 (bit-and (bit-or (bit-shift-left v1 4) (unsigned-bit-shift-right v2 2)) 0xFF)
+              b2 (bit-and (bit-or (bit-shift-left v2 6) v3) 0xFF)
+              bs (cond
+                   (<= rem 1) []
+                   (= rem 2)  [b0]
+                   (= rem 3)  [b0 b1]
+                   :else      [b0 b1 b2])]
+          (recur (+ i 4) (into out bs)))))))
+
+;; --- byte helpers ---
+
+(defn- i64-be [n]
+  (mapv (fn [sh] (bit-and (unsigned-bit-shift-right n sh) 0xFF)) [56 48 40 32 24 16 8 0]))
+
+(defn- read-i64-be [bytes off]
+  (reduce (fn [acc i] (bit-or (bit-shift-left acc 8) (nth bytes (+ off i)))) 0 (range 8)))
+
+(defn- u32-be [n]
+  (mapv (fn [sh] (bit-and (unsigned-bit-shift-right n sh) 0xFF)) [24 16 8 0]))
+
+(defn- read-u32-be [bytes off]
+  (reduce (fn [acc i] (bit-or (bit-shift-left acc 8) (nth bytes (+ off i)))) 0 (range 4)))
+
+(defn- varint [n]
+  (loop [n n out []]
+    (if (< n 0x80)
+      (conj out n)
+      (recur (unsigned-bit-shift-right n 7) (conj out (bit-or 0x80 (bit-and n 0x7F)))))))
+
+(defn- read-varint [bytes off]
+  (loop [off off shift 0 acc 0]
+    (let [b (nth bytes off)
+          acc (bit-or acc (bit-shift-left (bit-and b 0x7F) shift))]
+      (if (zero? (bit-and b 0x80))
+        [acc (inc off)]
+        (recur (inc off) (+ shift 7) acc)))))
+
+(defn- name-bytes [kw]
+  ;; action keyword names must be ASCII — the dictionary stores raw codepoint
+  ;; bytes, so a non-ASCII name would produce a code that crashes on decode.
+  (let [bs (mapv int (name kw))]
+    (when-not (every? (fn [b] (< b 128)) bs)
+      (throw (ex-info "replay: action keyword name is not ASCII" {:keyword kw})))
+    bs))
+
+;; --- RLE over a sequence ---
+
+(defn- rle [xs]
+  (loop [xs (seq xs) out []]
+    (if (nil? xs)
+      out
+      (let [x (first xs)
+            run (count (take-while (fn [y] (= y x)) xs))]
+        (recur (drop run xs) (conj out [x run]))))))
+
+;; --- encode / decode ---
+
+(defn encode
+  "Pack [seed actions] into a url-safe base64 replay code. `actions` is a vector
+   of action keywords (the world's :action-log)."
+  [seed actions]
+  (let [dict (vec (distinct actions))
+        _    (when (>= (count dict) 256)
+               (throw (ex-info "replay: too many distinct actions; dict size must fit one byte (< 256)"
+                               {:count (count dict)})))
+        idx  (reduce (fn [m i] (assoc m (nth dict i) i)) {} (range (count dict)))
+        runs (rle (map idx actions))
+        head (into (into [VERSION] (i64-be seed)) [(count dict)])
+        dict-bytes (reduce (fn [acc kw]
+                             (let [nb (name-bytes kw)]
+                               (into (conj acc (count nb)) nb)))
+                           [] dict)
+        run-bytes (reduce (fn [acc [i run]]
+                            (into (conj acc i) (varint run)))
+                          [] runs)
+        bytes (into (into (into head dict-bytes) (u32-be (count runs))) run-bytes)]
+    (b64-encode bytes)))
+
+(defn decode
+  "Decode a replay code back to {:seed seed :actions [kw ...]}."
+  [code]
+  (let [bytes (b64-decode code)
+        version (nth bytes 0)
+        seed (read-i64-be bytes 1)
+        dict-n (nth bytes 9)]
+    (when (not= version VERSION)
+      (throw (ex-info "replay: unknown code version" {:version version})))
+    (let [[dict off]
+          (loop [k 0 off 10 dict []]
+            (if (>= k dict-n)
+              [dict off]
+              (let [len (nth bytes off)
+                    nm (apply str (map char (subvec bytes (inc off) (+ off 1 len))))]
+                (recur (inc k) (+ off 1 len) (conj dict (keyword nm))))))
+          run-count (read-u32-be bytes off)
+          _ (when (>= run-count 1000000)
+              (throw (ex-info "replay: implausible run count" {:run-count run-count})))
+          off (+ off 4)
+          actions (loop [r 0 off off acc []]
+                    (if (>= r run-count)
+                      acc
+                      (let [di (nth bytes off)
+                            [run off2] (read-varint bytes (inc off))]
+                        (when (>= di (count dict))
+                          (throw (ex-info "replay: dict index out of range" {:index di})))
+                        (when (>= run 1000000)
+                          (throw (ex-info "replay: implausible run length" {:run run})))
+                        (recur (inc r) off2
+                               (into acc (repeat run (nth dict di)))))))]
+      {:seed seed :actions actions})))
+
+(defn encode-run
+  "Convenience: replay code for a finished world (its :seed-input + :action-log).
+   The action-log must be keyword-only — dispatch can log parameterized map
+   actions (e.g. {:type :use-item :id …}), which the v1 wire format does not yet
+   carry, so guard rather than crash deep in name-bytes."
+  [world]
+  (let [actions (or (:action-log world) [])]
+    (when-not (every? keyword? actions)
+      (throw (ex-info "replay/encode-run: action-log contains a non-keyword action; replay codes currently support keyword-only logs"
+                      {:non-keyword (filterv (fn [a] (not (keyword? a))) actions)})))
+    (encode (:seed-input world) actions)))

--- a/xsofy/seed.lg
+++ b/xsofy/seed.lg
@@ -16,3 +16,13 @@
           (let [n (read-string s)]
             (when (integer? n) n))))
       (rand-int 1000000000)))
+
+(def ^:dynamic *boot-replay* nil)
+
+(defn boot-replay
+  "A replay code to play back at boot, or nil. From *boot-replay* (tests) or the
+   XSOFY_REPLAY env var (native + browser-via-?replay= bridge)."
+  []
+  (or *boot-replay*
+      (let [s (os/getenv "XSOFY_REPLAY")]
+        (when (and s (> (count s) 0)) s))))

--- a/xsofy/test/replay_test.lg
+++ b/xsofy/test/replay_test.lg
@@ -1,0 +1,49 @@
+(ns xsofy.test.replay-test
+  (:require [test :refer [deftest is testing]]
+            [xsofy.replay :as replay]
+            [xsofy.dispatch :as dispatch]
+            [xsofy.world :as world]))
+
+(deftest base64-round-trips-arbitrary-bytes
+  (testing "url-safe base64 encode/decode is identity for byte vectors"
+    (doseq [bytes [[] [0] [255] [0 1 2 3 4 5] [72 105 33] [200 100 50 25 12 6 3 1 0]]]
+      (is (= bytes (replay/b64-decode (replay/b64-encode bytes)))))))
+
+(deftest replay-code-round-trips-seed-and-actions
+  (testing "decode . encode = identity on (seed, actions)"
+    (let [seed 12345
+          actions [:up :up :up :down :left :right :wait :wait :fire :pickup :descend]
+          {:keys [seed actions] :as back} (replay/decode (replay/encode seed actions))]
+      (is (= 12345 (:seed back)))
+      (is (= [:up :up :up :down :left :right :wait :wait :fire :pickup :descend]
+             (:actions back))))))
+
+(deftest replay-code-reconstructs-the-same-world
+  (testing "a decoded code replays to the identical world as the original"
+    (let [actions [:up :right :right :fire :wait :pickup :down :down]
+          live (dispatch/replay 79 30 9999 actions)
+          {:keys [seed actions]} (replay/decode (replay/encode 9999 actions))
+          rebuilt (dispatch/replay 79 30 seed actions)]
+      (is (= (:seed live) (:seed rebuilt)))
+      (is (= (:action-log live) (:action-log rebuilt)))
+      (is (= (vec (:terrain live)) (vec (:terrain rebuilt))))
+      ;; not just seed/log/terrain — assert the full reconstructed world matches,
+      ;; so drift in entity/fov/turn state can't slip past the round-trip.
+      (is (= (:entities live) (:entities rebuilt)))
+      (is (= (:fov live) (:fov rebuilt)))
+      (is (= (:turn live) (:turn rebuilt))))))
+
+(deftest rle-compresses-long-runs
+  (testing "200 identical moves encode far shorter than 200 actions"
+    (let [actions (vec (repeat 200 :up))
+          code (replay/encode 1 actions)]
+      ;; one dictionary entry + one run → tiny, regardless of length
+      (is (< (count code) 40))
+      (is (= actions (:actions (replay/decode code)))))))
+
+(deftest encode-run-uses-seed-input-and-action-log
+  (testing "encode-run packs a finished world's origin seed + log"
+    (let [w (dispatch/replay 79 30 555 [:up :down :wait])
+          {:keys [seed actions]} (replay/decode (replay/encode-run w))]
+      (is (= 555 seed))
+      (is (= [:up :down :wait] actions)))))

--- a/xsofy/test/run.lg
+++ b/xsofy/test/run.lg
@@ -13,6 +13,7 @@
             [xsofy.test.dispatch-test]
             [xsofy.test.serialize-test]
             [xsofy.test.dag-test]
-            [xsofy.test.seed-test]))
+            [xsofy.test.seed-test]
+            [xsofy.test.replay-test]))
 
 (run-tests)

--- a/xsofy/test/smoke.lg
+++ b/xsofy/test/smoke.lg
@@ -10,9 +10,9 @@
 
 ;; Title: two animation ticks must differ (frozen-title guard).
 (let [runes (sfx/scatter-runes 80 24 30 [200 50 30])]
-  (title/draw-frame runes "SMOKE TITLE" "subtitle" 80 24 0)
+  (title/draw-frame runes "SMOKE TITLE" "subtitle" 80 24 0 12345)
   (println "\n@@T0@@")
-  (title/draw-frame runes "SMOKE TITLE" "subtitle" 80 24 50)
+  (title/draw-frame runes "SMOKE TITLE" "subtitle" 80 24 50 12345)
   (println "\n@@T50@@"))
 
 ;; Game screen renders, then survives a few scripted turns and re-renders.

--- a/xsofy/title.lg
+++ b/xsofy/title.lg
@@ -101,7 +101,7 @@
 ;; clear-screen, rune-glyphs) live in xsofy.screenfx, shared with the death
 ;; screen.
 
-(defn draw-frame [runes title subtitle tw th frame]
+(defn draw-frame [runes title subtitle tw th frame seed]
   (let [cx (quot tw 2)
         cy (quot th 2)
         tx (max 1 (- cx (quot (count title) 2)))
@@ -137,17 +137,26 @@
         (term/set-fg bright bright bright)
         (term/set-bg 10 10 10)
         (term/write subtitle)))
+    ;; seed — dim, under the subtitle. Note it to replay this run via ?seed=.
+    (when (and seed (> frame 30))
+      (let [sline (str "seed " seed)
+            ssx (max 1 (- cx (quot (count sline) 2)))]
+        (term/move-cursor ssx (+ cy 4))
+        (term/set-fg 90 85 70)
+        (term/set-bg 10 10 10)
+        (term/write sline)))
     (term/flush)))
 
 (defn show-title-screen [rng]
-  (let [[tw th] (or (term/size) [100 36])
+  (let [seed (:seed rng)   ;; capture before picks advance the rng — this is the run seed
+        [tw th] (or (term/size) [100 36])
         [title rng]  (generate-title rng)
         subtitle "Press any key"
         [scheme rng] (pick-scheme rng)
         runes (sfx/scatter-runes tw th 40 scheme)]
     (sfx/clear-screen tw th)
     (sfx/drive-until-key 0
-                         (fn [frame] (draw-frame runes title subtitle tw th frame))
+                         (fn [frame] (draw-frame runes title subtitle tw th frame seed))
                          (sfx/make-key-poller 120))
     {:title title :scheme scheme :rng rng}))
 


### PR DESCRIPTION
## Seed display + replay codes (5/5)

- **Show the run seed** on the title screen, in-game HUD, and death screen (it enables `?seed=` reproducibility — serves #44).
- **`xsofy.replay`** — pack a run (seed + `:action-log`) into a compact, URL-safe base64 **replay code** (self-describing action dictionary + RLE of the movement streaks; e.g. 200 `:up` → <40 chars). Round-trips and reconstructs the identical world via `dispatch/replay`.
- **Death screen** shows the replay code, wrapped.
- **Playback** — `XSOFY_REPLAY` / `?replay=CODE` decodes a code, rebuilds the run, and steps through the actions with a short delay so it plays out, then hands control back at the end-state. `?replay=` is bridged into `go.env` like `?seed=`.
- Enables the e2e title-animation gate now that nooga/xsofy#61 (WASM-safe input poll) is on main.

Depends on the rest of the stack.

### Stack (bottom→top)
1. reproducible-runs (#62)
2. repro-test-infra
3. native-xxh3
4. browser-gate
5. seed-and-replay

Tests: let-go suite green (incl. replay round-trip/reconstruction); e2e 4/4 green incl. `?replay=` playback.