### PR TITLE
Widen the replay contract: route menu item-actions through dispatch

### DIFF
--- a/main.lg
+++ b/main.lg
@@ -422,7 +422,11 @@
          :death
          (let [[tw th] (term/size)
                runes (render/death-runes tw th)  ;; scatter ONCE — stable across frames
-               replay-code (replay/encode-run world)  ;; compute ONCE — encode is O(n) per call
+               ;; compute ONCE — encode is O(n) per call. encode-run-safe yields
+               ;; nil for runs whose log has map actions (item use/equip/etc via
+               ;; dispatch); the death screen then shows the seed alone, instead
+               ;; of crashing the game on encode-run's keyword-only guard.
+               replay-code (replay/encode-run-safe world)
                poll! (sfx/make-key-poller 120)  ;; calmer death-screen pulse (was 80ms)
                _ (sfx/clear-screen tw th)  ;; clear ONCE, not per-frame — was the flicker source
                result (loop [scroll 0 frame 0]

--- a/main.lg
+++ b/main.lg
@@ -218,7 +218,9 @@
                      :enchant
                      (let [scroll-id (:enchant-scroll-id world)]
                        (if scroll-id
-                         (-> (world/enchant-item world item-id scroll-id)
+                         ;; dispatch the assembled (target, scroll) action so the
+                         ;; enchant + scroll-consume fold into the seed + log
+                         (-> (dispatch/dispatch world {:type :enchant :id item-id :scroll-id scroll-id})
                              (dissoc :enchant-scroll-id))
                          world))
 

--- a/main.lg
+++ b/main.lg
@@ -56,65 +56,37 @@
     (when (and (>= sel 0) (< sel (count inv)))
       (nth inv sel nil))))
 
+;; The inventory-screen item actions, like the quick-menu, route world-mutating
+;; actions through dispatch (seed + :action-log) — guards/messages live in
+;; world's *-action handlers — and only manage the :inventory screen state here.
+
 (defn inv-equip [world]
   (if-let [item-id (sel-item-id world)]
-    (let [item (get-in world [:entities item-id])
-          slot (get-in item [:item :slot])
-          iname (get-item-name world item-id)]
-      (if (and slot (not= slot :consumable))
-        (-> (ent/equip-item world item-id :player)
-            (world/log-msg (str "You equip the " iname "."))
-            (assoc :screen :inventory))
-        (assoc world :screen :inventory)))
+    (-> (dispatch/dispatch world {:type :equip :id item-id})
+        (assoc :screen :inventory))
     (assoc world :screen :inventory)))
 
 (defn inv-unequip [world]
   (if-let [item-id (sel-item-id world)]
-    (let [item (get-in world [:entities item-id])
-          slot (get-in item [:item :slot])
-          iname (get-item-name world item-id)]
-      (if slot
-        (if (ent/cursed? world item-id)
-          (-> world
-              (world/log-msg (str "The " iname " is cursed! You can't remove it."))
-              (assoc :screen :inventory))
-          (-> (ent/unequip-item world :player slot)
-              (world/log-msg (str "You remove the " iname "."))
-              (assoc :screen :inventory)))
-        (assoc world :screen :inventory)))
+    (-> (dispatch/dispatch world {:type :unequip :id item-id})
+        (assoc :screen :inventory))
     (assoc world :screen :inventory)))
 
 (defn inv-drop [world]
   (if-let [item-id (sel-item-id world)]
-    (let [iname (get-item-name world item-id)
-          equipment (or (get-in world [:entities :player :equipment]) {})
-          slot (get-in world [:entities item-id :item :slot])
-          equipped-id (when slot (get equipment slot))
-          ;; can't drop equipped cursed items
-          is-equipped-cursed (and (= equipped-id item-id) (ent/cursed? world item-id))]
-      (if is-equipped-cursed
-        (-> world
-            (world/log-msg (str "The " iname " is cursed! You can't remove it."))
-            (assoc :screen :inventory))
-        (let [w (if (= equipped-id item-id)
-                  (ent/unequip-item world :player slot)
-                  world)]
-          (-> (ent/drop-item w item-id :player)
-              (world/log-msg (str "You drop the " iname "."))
-              (assoc :screen :inventory :inv-sel (max 0 (dec (inv-sel world))))))))
+    (-> (dispatch/dispatch world {:type :drop :id item-id})
+        (assoc :screen :inventory :inv-sel (max 0 (dec (inv-sel world)))))
     (assoc world :screen :inventory)))
 
 (defn inv-use [world]
   (if-let [item-id (sel-item-id world)]
-    (let [item (get-in world [:entities item-id])
-          slot (get-in item [:item :slot])]
-      (if (= slot :consumable)
-        (let [result (world/use-item world item-id)]
-          ;; if use-item opened a submenu (enchant), keep its screen
-          (if (:screen result)
-            (dissoc result :inv-sel)
-            (dissoc result :screen :inv-sel)))
-        (assoc world :screen :inventory)))
+    (if (= :consumable (get-in world [:entities item-id :item :slot]))
+      (let [result (dispatch/dispatch world {:type :use-item :id item-id})]
+        ;; if use-item opened a submenu (enchant), keep its screen
+        (if (:screen result)
+          (dissoc result :inv-sel)
+          (dissoc result :screen :inv-sel)))
+      (assoc world :screen :inventory))
     (assoc world :screen :inventory)))
 
 (defn inv-inscribe [world]
@@ -229,39 +201,18 @@
         old-screen (:screen world)]
     (if (nil? item-id)
       world
-      (let [iname (get-item-name world item-id)
-            equipment (or (get-in world [:entities :player :equipment]) {})
-            item (get-in world [:entities item-id])
-            slot (get-in item [:item :slot])
+      (let [slot (get-in world [:entities item-id :item :slot])
             result (case action
-                     :equip
-                     (if (and slot (not= slot :consumable))
-                       (-> (ent/equip-item world item-id :player)
-                           (world/log-msg (str "You equip the " iname ".")))
-                       world)
-
-                     :unequip
-                     (if slot
-                       (if (ent/cursed? world item-id)
-                         (world/log-msg world (str "The " iname " is cursed! You can't remove it."))
-                         (-> (ent/unequip-item world :player slot)
-                             (world/log-msg (str "You remove the " iname "."))))
-                       world)
-
-                     :drop
-                     (let [equipped-id (when slot (get equipment slot))
-                           is-cursed (and (= equipped-id item-id) (ent/cursed? world item-id))]
-                       (if is-cursed
-                         (world/log-msg world (str "The " iname " is cursed! You can't remove it."))
-                         (let [w (if (= equipped-id item-id)
-                                   (ent/unequip-item world :player slot)
-                                   world)]
-                           (-> (ent/drop-item w item-id :player)
-                               (world/log-msg (str "You drop the " iname "."))))))
+                     ;; world-mutating menu actions go through dispatch so they
+                     ;; fold into the seed + :action-log and replay identically.
+                     ;; Guards/messages live in world's *-action handlers.
+                     :equip   (dispatch/dispatch world {:type :equip :id item-id})
+                     :unequip (dispatch/dispatch world {:type :unequip :id item-id})
+                     :drop    (dispatch/dispatch world {:type :drop :id item-id})
 
                      :use
                      (if (= slot :consumable)
-                       (world/use-item world item-id)
+                       (dispatch/dispatch world {:type :use-item :id item-id})
                        world)
 
                      :enchant

--- a/xsofy/replay.lg
+++ b/xsofy/replay.lg
@@ -1,14 +1,13 @@
 (ns xsofy.replay
   "Shareable replay codes.
 
-   SCOPE — a replay code captures (seed, :action-log) and reproduces only the
-   KEYWORD-DISPATCH portion of a run: turns that flow through xsofy.dispatch. The
-   seed reproduces the opening state (title/quest/scheme/world generation), and
-   :action-log reproduces dispatch-routed turns. Runs that involve inventory,
-   menu, inscribe, or hazard-confirm interactions are NOT fully reproducible from
-   the code today — those handlers mutate the world outside dispatch (widening
-   that contract is a follow-up). So a code is faithful for keyword-only
-   gameplay, and reproduces the opening state for everything else.
+   SCOPE — a replay code captures (seed, :action-log) and reproduces every turn
+   that flows through xsofy.dispatch: bare-keyword turns AND the parameterized
+   item actions (use/equip/unequip/drop/enchant) the menus route through dispatch.
+   The seed reproduces the opening state (title/quest/scheme/world generation).
+   Inscribe and hazard-confirm interactions are still NOT reproducible — those
+   handlers mutate the world outside dispatch, so they never reach :action-log;
+   such a run reproduces its opening state and all dispatch-routed turns.
 
    This packs (seed, action-log) into a compact, URL-safe base64 string suitable
    for a ?replay= link or XSOFY_REPLAY env var.
@@ -16,17 +15,23 @@
    Wire format (bytes, then url-safe base64, no padding):
      1   version (= 1; v1-exact — future versions reject v1 codes by default)
      8   seed                       (i64 big-endian)
-     1   dict size D                (distinct action keywords, < 256)
-     D*  for each: 1 len + ASCII name bytes   (self-describing dictionary)
+     1   dict size D                (distinct actions, < 256)
+     D*  for each entry, a self-describing record:
+           len>0 : 1 len + ASCII name bytes                  (bare keyword)
+           len=0 : sentinel, then type + id keyword fields,
+                   then a scroll-id field (its own len, 0 = absent)
+                   (a parameterized map action {:type :id (:scroll-id)})
      4   run count R                (u32 big-endian)
      R*  for each run: 1 dict-index + varint run-length
 
    Runs are run-length-encoded over the dictionary indices, which compresses the
-   long streaks of repeated movement typical of a roguelike. Only keyword actions
-   are supported (the action-log contains bare keywords); names must be ASCII.
+   long streaks of repeated movement typical of a roguelike. Keyword names and
+   the type/id/scroll-id of map actions must be ASCII. Keyword-only codes are
+   byte-identical to before the map-action support landed (the len=0 sentinel is
+   free because keyword names are never empty) — so no version bump was needed.
 
-   ABI — action keywords are wire-format ABI. Renaming an action keyword breaks
-   all existing replay codes; the format does not migrate.")
+   ABI — action keywords (and map-action :type/:id names) are wire-format ABI.
+   Renaming one breaks all existing replay codes; the format does not migrate.")
 
 (def ^:private VERSION 1)
 
@@ -125,6 +130,43 @@
       (throw (ex-info "replay: action keyword name is not ASCII" {:keyword kw})))
     bs))
 
+;; --- dictionary entries: bare keyword OR parameterized map action ---
+;; A keyword entry is [len name...] with len >= 1 (names are non-empty). That
+;; leaves a 0 length free as the sentinel for a parameterized map action
+;; {:type :id (:scroll-id)} — item use/equip/unequip/drop/enchant routed through
+;; dispatch. Keyword-only codes are byte-identical to before (no version bump).
+
+(defn- kw-field [kw]
+  (let [nb (name-bytes kw)]
+    (into [(count nb)] nb)))
+
+(defn- entry-bytes [action]
+  (if (keyword? action)
+    (kw-field action)
+    (let [{:keys [type id scroll-id]} action]
+      (when-not (and type id)
+        (throw (ex-info "replay: unsupported action shape (need :type and :id)" {:action action})))
+      (into (into (into [0] (kw-field type)) (kw-field id))
+            (if scroll-id (kw-field scroll-id) [0])))))
+
+(defn- read-name [bytes off]
+  (let [len (nth bytes off)]
+    [(apply str (map char (subvec bytes (inc off) (+ off 1 len)))) (+ off 1 len)]))
+
+(defn- read-entry [bytes off]
+  (let [len (nth bytes off)]
+    (if (> len 0)
+      (let [[nm off2] (read-name bytes off)]
+        [(keyword nm) off2])
+      ;; sentinel 0 -> parameterized map action
+      (let [[tnm off2] (read-name bytes (inc off))
+            [inm off3] (read-name bytes off2)
+            slen (nth bytes off3)]
+        (if (> slen 0)
+          (let [[snm off4] (read-name bytes off3)]
+            [{:type (keyword tnm) :id (keyword inm) :scroll-id (keyword snm)} off4])
+          [{:type (keyword tnm) :id (keyword inm)} (inc off3)])))))
+
 ;; --- RLE over a sequence ---
 
 (defn- rle [xs]
@@ -138,8 +180,9 @@
 ;; --- encode / decode ---
 
 (defn encode
-  "Pack [seed actions] into a url-safe base64 replay code. `actions` is a vector
-   of action keywords (the world's :action-log)."
+  "Pack [seed actions] into a url-safe base64 replay code. `actions` is the
+   world's :action-log — bare keywords and/or parameterized map actions
+   ({:type :id (:scroll-id)})."
   [seed actions]
   (let [dict (vec (distinct actions))
         _    (when (>= (count dict) 256)
@@ -148,10 +191,7 @@
         idx  (reduce (fn [m i] (assoc m (nth dict i) i)) {} (range (count dict)))
         runs (rle (map idx actions))
         head (into (into [VERSION] (i64-be seed)) [(count dict)])
-        dict-bytes (reduce (fn [acc kw]
-                             (let [nb (name-bytes kw)]
-                               (into (conj acc (count nb)) nb)))
-                           [] dict)
+        dict-bytes (reduce (fn [acc a] (into acc (entry-bytes a))) [] dict)
         run-bytes (reduce (fn [acc [i run]]
                             (into (conj acc i) (varint run)))
                           [] runs)
@@ -171,9 +211,8 @@
           (loop [k 0 off 10 dict []]
             (if (>= k dict-n)
               [dict off]
-              (let [len (nth bytes off)
-                    nm (apply str (map char (subvec bytes (inc off) (+ off 1 len))))]
-                (recur (inc k) (+ off 1 len) (conj dict (keyword nm))))))
+              (let [[action off2] (read-entry bytes off)]
+                (recur (inc k) off2 (conj dict action)))))
           run-count (read-u32-be bytes off)
           _ (when (>= run-count 1000000)
               (throw (ex-info "replay: implausible run count" {:run-count run-count})))
@@ -193,22 +232,15 @@
 
 (defn encode-run
   "Convenience: replay code for a finished world (its :seed-input + :action-log).
-   The action-log must be keyword-only — dispatch can log parameterized map
-   actions (e.g. {:type :use-item :id …}), which the v1 wire format does not yet
-   carry, so guard rather than crash deep in name-bytes."
+   The log may mix bare keywords and parameterized map actions (item use/equip/
+   unequip/drop/enchant routed through dispatch) — the wire format carries both."
   [world]
-  (let [actions (or (:action-log world) [])]
-    (when-not (every? keyword? actions)
-      (throw (ex-info "replay/encode-run: action-log contains a non-keyword action; replay codes currently support keyword-only logs"
-                      {:non-keyword (filterv (fn [a] (not (keyword? a))) actions)})))
-    (encode (:seed-input world) actions)))
+  (encode (:seed-input world) (or (:action-log world) [])))
 
 (defn encode-run-safe
-  "Like encode-run, but returns nil instead of throwing when the run can't be
-   encoded — i.e. the action-log contains a parameterized map action (item
-   use/equip/drop/enchant routed through dispatch), which the v1 wire format
-   does not yet carry. Callers that merely DISPLAY a code (the death screen)
-   use this and fall back to showing the seed alone for such runs."
+  "Like encode-run, but returns nil instead of throwing if encoding fails for any
+   reason (e.g. an unexpected action shape or a non-ASCII name). Callers that
+   merely DISPLAY a code (the death screen) use this so a corner-case run can
+   never crash the game — it falls back to showing the seed alone."
   [world]
-  (when (every? keyword? (or (:action-log world) []))
-    (encode-run world)))
+  (try (encode-run world) (catch e nil)))

--- a/xsofy/replay.lg
+++ b/xsofy/replay.lg
@@ -202,3 +202,13 @@
       (throw (ex-info "replay/encode-run: action-log contains a non-keyword action; replay codes currently support keyword-only logs"
                       {:non-keyword (filterv (fn [a] (not (keyword? a))) actions)})))
     (encode (:seed-input world) actions)))
+
+(defn encode-run-safe
+  "Like encode-run, but returns nil instead of throwing when the run can't be
+   encoded — i.e. the action-log contains a parameterized map action (item
+   use/equip/drop/enchant routed through dispatch), which the v1 wire format
+   does not yet carry. Callers that merely DISPLAY a code (the death screen)
+   use this and fall back to showing the seed alone for such runs."
+  [world]
+  (when (every? keyword? (or (:action-log world) []))
+    (encode-run world)))

--- a/xsofy/test/menu_dispatch_test.lg
+++ b/xsofy/test/menu_dispatch_test.lg
@@ -57,6 +57,24 @@
       (is (= [{:type :unequip :id weapon} {:type :equip :id weapon}] (:action-log live)) "both logged")
       (is (replays-identically? seed live) "replay reproduces equipment state"))))
 
+(deftest enchant-action-dispatches-and-is-deterministic
+  (testing "{:type :enchant} enchants the target, consumes the scroll, logs, and
+            is a pure deterministic dispatch (the scroll is a spawned item, so we
+            assert dispatch purity rather than replay-from-seed)"
+    (let [w0     (world/make-world 79 30 12345)
+          weapon (item-with-slot w0 :weapon)
+          gi     (world/give-item w0 :scroll-enchant :player)
+          w      (first gi)
+          scroll (second gi)
+          act    {:type :enchant :id weapon :scroll-id scroll}
+          live   (dispatch/dispatch w act)
+          again  (dispatch/dispatch w act)]
+      (is (= 1 (get-in live [:entities weapon :item :enchant])) "target gained +1 enchant")
+      (is (not (some #{scroll} (get-in live [:entities :player :inventory]))) "scroll consumed")
+      (is (= [act] (:action-log live)) "action logged")
+      (is (not= (:seed w) (:seed live)) "seed advanced")
+      (is (= (:entities live) (:entities again)) "dispatch is deterministic (pure fn)"))))
+
 (deftest use-item-action-dispatches-and-replays
   (testing "{:type :use-item} consumes the item, logs it, and replays identically (regression guard)"
     (let [seed   12345

--- a/xsofy/test/menu_dispatch_test.lg
+++ b/xsofy/test/menu_dispatch_test.lg
@@ -1,0 +1,68 @@
+(ns xsofy.test.menu-dispatch-test
+  "Quick-menu mutating actions (use / equip / unequip / drop) must go through the
+   deterministic dispatch contract — folded into the seed, recorded in
+   :action-log, and reproduced bit-identically by replay.
+
+   Before this fix the menu mutated the world directly (xsofy.main's
+   execute-menu-action calling world/use-item, ent/equip-item, ent/drop-item),
+   so item use/equip/drop were INVISIBLE to replay: a recorded run replayed to a
+   different world (the smoking gun — a used potion stayed in the inventory on
+   replay). These tests pin the contract at the dispatch layer: the typed action
+   both mutates and is replayable."
+  (:require [test :refer [deftest is testing]]
+            [xsofy.world :as world]
+            [xsofy.dispatch :as dispatch]))
+
+(defn- item-with-slot [w slot]
+  (first (filter #(= slot (get-in w [:entities % :item :slot]))
+                 (get-in w [:entities :player :inventory]))))
+
+(defn- replays-identically? [seed live]
+  (let [rep (dispatch/replay 79 30 seed (:action-log live))]
+    (and (= (:seed live) (:seed rep))
+         (= (:entities live) (:entities rep)))))
+
+;; Player starts with dagger + leather-armor EQUIPPED and a stacked health
+;; potion (count 2). So equip is tested on a freshly-unequipped item.
+
+(deftest drop-action-dispatches-and-replays
+  (testing "{:type :drop} removes the item, logs it, advances the seed, and replays identically"
+    (let [seed 12345
+          w0   (world/make-world 79 30 seed)
+          potion (item-with-slot w0 :consumable)
+          live (dispatch/dispatch w0 {:type :drop :id potion})]
+      (is (not (some #{potion} (get-in live [:entities :player :inventory]))) "item left the inventory")
+      (is (= [{:type :drop :id potion}] (:action-log live)) "action logged")
+      (is (not= (:seed w0) (:seed live)) "seed advanced")
+      (is (replays-identically? seed live) "replay reproduces entity state"))))
+
+(deftest unequip-action-dispatches-and-replays
+  (testing "{:type :unequip} removes equipped gear, logs it, and replays identically"
+    (let [seed   12345
+          w0     (world/make-world 79 30 seed)
+          weapon (item-with-slot w0 :weapon)
+          live   (dispatch/dispatch w0 {:type :unequip :id weapon})]
+      (is (nil? (get-in live [:entities :player :equipment :weapon])) "weapon slot cleared")
+      (is (= [{:type :unequip :id weapon}] (:action-log live)) "action logged")
+      (is (replays-identically? seed live) "replay reproduces equipment state"))))
+
+(deftest equip-action-dispatches-and-replays
+  (testing "{:type :equip} equips an unequipped item into its slot, logs it, and replays identically"
+    (let [seed   12345
+          w0     (world/make-world 79 30 seed)
+          weapon (item-with-slot w0 :weapon)
+          bare   (dispatch/dispatch w0 {:type :unequip :id weapon})   ; take it off first
+          live   (dispatch/dispatch bare {:type :equip :id weapon})]  ; then re-equip
+      (is (= weapon (get-in live [:entities :player :equipment :weapon])) "item equipped")
+      (is (= [{:type :unequip :id weapon} {:type :equip :id weapon}] (:action-log live)) "both logged")
+      (is (replays-identically? seed live) "replay reproduces equipment state"))))
+
+(deftest use-item-action-dispatches-and-replays
+  (testing "{:type :use-item} consumes the item, logs it, and replays identically (regression guard)"
+    (let [seed   12345
+          w0     (world/make-world 79 30 seed)
+          potion (item-with-slot w0 :consumable)
+          live   (dispatch/dispatch w0 {:type :use-item :id potion})]
+      (is (= 1 (get-in live [:entities potion :item :count])) "stack decremented 2 -> 1")
+      (is (= [{:type :use-item :id potion}] (:action-log live)) "action logged")
+      (is (replays-identically? seed live) "replay reproduces entity state"))))

--- a/xsofy/test/replay_test.lg
+++ b/xsofy/test/replay_test.lg
@@ -47,3 +47,17 @@
           {:keys [seed actions]} (replay/decode (replay/encode-run w))]
       (is (= 555 seed))
       (is (= [:up :down :wait] actions)))))
+
+(deftest encode-run-safe-encodes-keyword-only-runs
+  (testing "encode-run-safe returns a working code for a keyword-only log"
+    (let [w (dispatch/replay 79 30 555 [:up :down :wait])
+          {:keys [seed actions]} (replay/decode (replay/encode-run-safe w))]
+      (is (= 555 seed))
+      (is (= [:up :down :wait] actions)))))
+
+(deftest encode-run-safe-returns-nil-for-map-actions
+  (testing "encode-run-safe degrades to nil (no throw) when the log contains a
+            parameterized map action — e.g. item use/equip routed through
+            dispatch. The death screen shows the seed alone in that case."
+    (let [w {:seed-input 555 :action-log [:up {:type :use-item :id :potion-1} :down]}]
+      (is (nil? (replay/encode-run-safe w))))))

--- a/xsofy/test/replay_test.lg
+++ b/xsofy/test/replay_test.lg
@@ -55,9 +55,33 @@
       (is (= 555 seed))
       (is (= [:up :down :wait] actions)))))
 
-(deftest encode-run-safe-returns-nil-for-map-actions
-  (testing "encode-run-safe degrades to nil (no throw) when the log contains a
-            parameterized map action — e.g. item use/equip routed through
-            dispatch. The death screen shows the seed alone in that case."
+(deftest encode-decode-round-trips-map-actions
+  (testing "the wire format carries parameterized map actions (item use/equip/
+            drop/enchant), not just bare keywords, and decode reproduces them
+            exactly — including enchant's extra :scroll-id field"
+    (let [actions [:up :up
+                   {:type :use-item :id :health-potion-93379127}
+                   :down
+                   {:type :equip :id :rapier-1272135760}
+                   {:type :enchant :id :whip-1872488856 :scroll-id :scroll-enchant-42}
+                   :wait]
+          back (replay/decode (replay/encode 12345 actions))]
+      (is (= 12345 (:seed back)))
+      (is (= actions (:actions back))))))
+
+(deftest encode-run-reproduces-an-item-run
+  (testing "encode-run encodes a finished world whose log has map actions, and
+            decode round-trips its seed + full action-log"
+    (let [w {:seed-input 555
+             :action-log [:up {:type :use-item :id :potion-1} :down
+                          {:type :drop :id :rock-2}]}
+          {:keys [seed actions]} (replay/decode (replay/encode-run w))]
+      (is (= 555 seed))
+      (is (= [:up {:type :use-item :id :potion-1} :down {:type :drop :id :rock-2}]
+             actions)))))
+
+(deftest encode-run-safe-still-guards
+  (testing "encode-run-safe stays a non-throwing wrapper: a real code for a normal
+            run (now incl. item runs), nil only when encoding genuinely fails"
     (let [w {:seed-input 555 :action-log [:up {:type :use-item :id :potion-1} :down]}]
-      (is (nil? (replay/encode-run-safe w))))))
+      (is (some? (replay/encode-run-safe w)) "item runs now encode to a real code"))))

--- a/xsofy/test/run.lg
+++ b/xsofy/test/run.lg
@@ -14,6 +14,7 @@
             [xsofy.test.serialize-test]
             [xsofy.test.dag-test]
             [xsofy.test.seed-test]
-            [xsofy.test.replay-test]))
+            [xsofy.test.replay-test]
+            [xsofy.test.menu-dispatch-test]))
 
 (run-tests)

--- a/xsofy/world.lg
+++ b/xsofy/world.lg
@@ -1780,6 +1780,7 @@
               :equip    (equip-action world (:id action))
               :unequip  (unequip-action world (:id action))
               :drop     (drop-action world (:id action))
+              :enchant  (enchant-item world (:id action) (:scroll-id action))
               :fire (fire-bow world)
               :up    (player-move world 0 -1)
               :down  (player-move world 0 1)

--- a/xsofy/world.lg
+++ b/xsofy/world.lg
@@ -1715,6 +1715,48 @@
   (-> world
       (dissoc :screen :hazard-prompt :hazard-pos :hazard-dx :hazard-dy)))
 
+;; --- Inventory actions (dispatched, replay-safe) ---
+;; These mutate the world (equip/unequip/drop) and so must flow through dispatch
+;; like any other turn action, NOT be applied directly by the menu UI — otherwise
+;; they never enter the seed/:action-log and a recorded run replays to a
+;; different world. update-world routes the parameterized {:type … :id …} actions
+;; here; the quick-menu just assembles + dispatches them.
+
+(defn- item-name* [world item-id]
+  (let [item (get-in world [:entities item-id])]
+    (or (:item-name item) (name (or (:template item) (:id item) :item)))))
+
+(defn equip-action [world item-id]
+  (let [slot (get-in world [:entities item-id :item :slot])]
+    (if (and slot (not= slot :consumable))
+      (if-let [w (ent/equip-item world item-id :player)]
+        (log-msg w (str "You equip the " (item-name* world item-id) "."))
+        world)
+      world)))
+
+(defn unequip-action [world item-id]
+  (let [slot (get-in world [:entities item-id :item :slot])]
+    (if slot
+      (if (ent/cursed? world item-id)
+        (log-msg world (str "The " (item-name* world item-id) " is cursed! You can't remove it."))
+        (if-let [w (ent/unequip-item world :player slot)]
+          (log-msg w (str "You remove the " (item-name* world item-id) "."))
+          world))
+      world)))
+
+(defn drop-action [world item-id]
+  (let [slot        (get-in world [:entities item-id :item :slot])
+        equipment   (or (get-in world [:entities :player :equipment]) {})
+        equipped-id (when slot (get equipment slot))
+        is-cursed   (and (= equipped-id item-id) (ent/cursed? world item-id))]
+    (if is-cursed
+      (log-msg world (str "The " (item-name* world item-id) " is cursed! You can't remove it."))
+      (let [w (if (= equipped-id item-id)
+                (ent/unequip-item world :player slot)
+                world)]
+        (-> (ent/drop-item w item-id :player)
+            (log-msg (str "You drop the " (item-name* world item-id) ".")))))))
+
 ;; --- Turn Processing ---
 
 (defn update-world [world action]
@@ -1735,6 +1777,9 @@
     :use-menu (assoc world :screen :quick-menu :menu-action :use)
     (let [w (case (if (map? action) (:type action) action)
               :use-item (use-item world (:id action))
+              :equip    (equip-action world (:id action))
+              :unequip  (unequip-action world (:id action))
+              :drop     (drop-action world (:id action))
               :fire (fire-bow world)
               :up    (player-move world 0 -1)
               :down  (player-move world 0 1)


### PR DESCRIPTION
## What

Widens the deterministic-replay contract so **menu-driven item actions** flow through `xsofy.dispatch` and are folded into the seed + `:action-log`, instead of mutating the world directly from `main`. Stacks on #66.

Covered actions: `use` (already routed), **`equip`**, **`unequip`**, **`drop`**, **`enchant`**.

## Why

`xsofy/replay.lg` currently documents the gap:

> Runs that involve inventory, menu, inscribe, or hazard-confirm interactions are NOT fully reproducible from the code today — those handlers mutate the world outside dispatch (widening that contract is a follow-up).

Item actions taken from the quick-menu/inventory bypassed dispatch, so they never entered the seed/log and didn't replay. This closes that for equip/unequip/drop/enchant.

## How

- **`world/update-world`** gains typed handlers for parameterized actions: `{:type :equip|:unequip|:drop :id …}` (new `equip-action`/`unequip-action`/`drop-action`) and `{:type :enchant :id target :scroll-id scroll}` (reuses existing `enchant-item`). The cursed/equipped guards + messages move from `main` into `world`.
- **`main`** — `execute-menu-action` and `inv-equip/unequip/drop/use` now just *assemble and dispatch* the typed action and manage screen state; the rules live in `world`.
- Since `:equip/:unequip/:drop/:use-item/:enchant` are **not** UI actions, `dispatch` folds + logs them automatically, so they replay bit-identically.
- **Enchant (two-step)** stays replay-consistent: using the scroll is a dispatched `:use-item` that opens the *pure-UI* target submenu without consuming; only the final `{:type :enchant …}` mutates. Cancelling leaves the scroll unconsumed in both live and replay.

## Tests

`xsofy/test/menu_dispatch_test.lg`: each action mutates correctly, is logged, advances the seed, and `dispatch/replay` reproduces `:entities` exactly; plus a dispatch-purity + consume/enchant test for the two-step flow.

**249 tests / 2246 assertions / 0 fail / 0 error.** `main.lg` compiles; smoke green.

## Scope / follow-up

This widens item actions. The replay docstring also lists **`inscribe-input`** and the **hazard-confirm** handler as bypassing dispatch — those are **not** covered here and remain a follow-up to fully honor the contract. Relates to #56 (PR3b determinism core).