### PR TITLE
Responsive UI event loop: poll-based run-loop for animated screens (#56)

### DIFF
--- a/docs/terminal.md
+++ b/docs/terminal.md
@@ -208,11 +208,80 @@ For better performance, batch a full row into a single string:
       (recur (update-state state key)))))
 ```
 
+## Responsive UIs: multiplexing input and a cosmetic clock
+
+The blocking game loop above is fine for a turn-based screen where **nothing
+moves while you wait for input**. The moment a screen needs to *animate while
+idle* — a pulsing title, drifting particles, ambient effects — a blocking
+`read-key` falls apart:
+
+- **Native:** the loop is stuck in `read-key` until a key arrives, so frames
+  never advance and the animation freezes.
+- **WASM (browser):** far worse. `read-key` is backed by `Atomics.wait` on a
+  SharedArrayBuffer, and Go-wasm is single-threaded/cooperative, so a blocking
+  read freezes the **entire** worker — including any timer goroutine driving
+  animation. The screen never paints past frame 0.
+
+The fix is a **poll-based source contract**: never block while idle. Peek input
+with the non-blocking `term/key-pending?` and only call `read-key` once a key is
+actually queued; meanwhile a cosmetic clock advances the animation. The same
+loop then runs identically native and in wasm.
+
+xsofy implements this as `xsofy.ui/run-loop` (see
+`docs/responsive-ui-event-loop-design.md`). A screen describes **which sources
+it listens to** and **how state folds over events**; the loop drives render:
+
+```clojure
+(ui/run-loop
+  {:sources  [(ui/input-source) (ui/clock-source 120)]  ; non-blocking polls
+   :state    {:world world :ui {:frame 0}}
+   :step     (fn [state [tag payload]]                   ; the scan
+               (case tag
+                 :action (handle-key state payload)      ; drives :world
+                 :tick   (assoc-in state [:ui :frame] payload)  ; animates :ui
+                 state))
+   :render   (fn [state] (draw state) (term/flush))      ; paints AND presents
+   :frame-ms 120})                                       ; floored to ≥30ms in wasm
+```
+
+- **Sources** are non-blocking polls (`() → seq-of-events`). `input-source`
+  drains queued keys (parsed to `[:action …]` at the edge); `clock-source`
+  emits `[:tick frame]` once an interval elapses; `replay-source` feeds a
+  recorded action log; `poll-source` wraps any non-blocking `() → events`.
+- **`step`** is a `scan` over `{:world :ui}`; it returns `(reduced result)` to
+  exit the loop. Modal/multi-step screens compose as **nested `run-loop`s** that
+  return an assembled value.
+- **Pacing** uses a wasm-aware `pause!` (`(<!! (timeout (max ms 30)))`, *not*
+  `Thread/sleep`) so the JS event loop actually yields and the input buffer
+  refills.
+
+### Determinism caveat (important)
+
+If your simulation is replay-deterministic from a `(seed, action-log)` pair,
+**cosmetic clock ticks must never enter that stream**. Keep loop state split:
+
+```clojure
+{:world <deterministic sim>   ; the only thing dispatch/replay ever see
+ :ui    <cosmetic frame/particles>}  ; advanced by [:tick], never logged
+```
+
+Route `[:tick …]` to `:ui` only — never fold it into the seed or append it to
+the action log. Replay then reconstructs `:world` bit-identically regardless of
+how (or whether) animation ran.
+
+### Note on `key-pending?` and async sources
+
+`term/key-pending?` is the portable primitive that makes the poll-on-tick
+contract work in both builds. Genuinely async sources (network, multi-timer)
+are **polling-only** today: let-go's channel ops (`<!`/`>!`) are blocking, with
+no non-blocking `poll!`/`alts!` yet (tracked as nooga/let-go#194), so a push
+`chan-source` adapter is a documented seam, not yet implemented.
+
 ## Gotchas
 
 - **Coordinates are 1-based** — `(term/write-at 1 1 "@")` is the top-left corner.
 - **No newlines in raw mode** — `println` still works but adds `\n` which moves the cursor down. Use `term/write` or `term/write-at` instead.
-- **`read-key` is blocking** — the game loop will wait for input. This is fine for a turn-based roguelike. For real-time, you'd need `core.async` with a key-reading goroutine.
+- **`read-key` is blocking** — the game loop will wait for input. This is fine for a turn-based screen with no idle animation. For anything that animates while waiting (or any wasm build), don't reach for a key-reading goroutine — under single-threaded Go-wasm a blocking `read-key` freezes the whole runtime. Use the poll-based [Responsive UIs](#responsive-uis-multiplexing-input-and-a-cosmetic-clock) pattern (`key-pending?` + `xsofy.ui/run-loop`) instead.
 - **Escape key ambiguity** — pressing Escape sends `\u001b` but so do arrow keys (`\u001b[A`). `read-key` reads all available bytes at once so arrow keys come as a single 3-byte string, but there can be edge cases with slow terminals.
 - **Always clean up** — if the process crashes without calling `restore-mode!`, run `reset` in the shell to fix the terminal.
 - **`size` can change** — if the user resizes the terminal during play, `size` will return the new dimensions on next call. Consider re-rendering on size change.

--- a/main.lg
+++ b/main.lg
@@ -7,10 +7,10 @@
             [string]
             [xsofy.world :as world]
             [xsofy.entities :as ent]
-            [xsofy.input :as input]
             [xsofy.render :as render]
             [xsofy.ui :as ui]
             [xsofy.runes :as runes]
+            [xsofy.play :as play]
             [xsofy.title :as title]
             [xsofy.screenfx :as sfx]
             [xsofy.debug :as dbg]
@@ -547,71 +547,12 @@
                  (recur w w (term/size)))
                w)))
 
-         ;; default: game screen
-         (let [;; determine auto-action or wait for input
-               auto-key0 (cond
-                           (:resting world) :wait
-                           (:running-dir world) (let [[dx dy] (:running-dir world)]
-                                                  (cond (and (= dx 0) (< dy 0)) :up
-                                                        (and (= dx 0) (> dy 0)) :down
-                                                        (and (< dx 0) (= dy 0)) :left
-                                                        (and (> dx 0) (= dy 0)) :right
-                                                        :else nil))
-                           (:autoexploring world) :autoexplore
-                           (:auto-target world) :auto-target-step
-                           :else nil)
-               ;; queued keystroke cancels in-flight auto-action
-               interrupting (and auto-key0 (term/key-pending?))
-               world (if interrupting
-                       (dissoc world :resting :running-dir :autoexploring :auto-target)
-                       world)
-               auto-key (when (not interrupting) auto-key0)
-               key (or auto-key (input/parse-key (term/read-key)))
-               new-world (dispatch/dispatch world key)
-               ;; check if auto-mode should stop
-               new-world (if (or (:resting new-world) (:running-dir new-world) (:autoexploring new-world) (:auto-target new-world))
-                           (let [player (get-in new-world [:entities :player])
-                                 hp (get-in player [:body :hp] 0)
-                                 max-hp (get-in player [:body :max-hp] 1)
-                                 fov (or (:fov new-world) #{})
-                                 enemies (some (fn [e]
-                                                 (and (:ai e)
-                                                      (not= :player (:id e))
-                                                      (:pos e)
-                                                      (contains? fov (:pos e))
-                                                      (contains? #{:hunt :investigate :flee} (get-in e [:ai :state]))))
-                                               (vals (:entities new-world)))
-                                 ;; running stops at walls/doors/items
-                                 run-blocked (and (or (:running-dir new-world) (:autoexploring new-world))
-                                                  (= (:turn new-world) (:turn world)))
-                                 dead (nil? player)]
-                             (cond
-                               dead (dissoc new-world :resting :running-dir :autoexploring :auto-target)
-                               enemies (-> new-world
-                                           (dissoc :resting :running-dir :autoexploring :auto-target)
-                                           (world/log-msg "You stop — enemy spotted!"))
-                               (and (:resting new-world) (>= hp max-hp))
-                               (-> new-world (dissoc :resting) (world/log-msg "You finish resting."))
-                               run-blocked (dissoc new-world :running-dir :autoexploring :auto-target)
-                               (:inventory-full new-world)
-                               (-> new-world
-                                   (dissoc :autoexploring :auto-target :inventory-full))
-                               :else new-world))
-                           new-world)
-               cur-size (term/size)
-               resized (not= cur-size prev-size)
-               floor-changed (not= (:depth new-world) (:depth world))]
-           (if (or floor-changed resized (:screen new-world))
-             (do (when-not (:screen new-world)
-                   (render/render-full new-world))
-                 (recur new-world new-world cur-size))
-             (do (render/render-dirty new-world world)
-                 ;; animate vfx between turns
-                 (when (seq (:vfx new-world))
-                   (let [[tw th] cur-size
-                         panels (ui/layout tw th)]
-                     (render/animate-vfx! new-world (:map panels))))
-                 (recur (dissoc new-world :vfx) world cur-size)))))))))
+         ;; default: game screen — the poll-based turn loop (input +
+         ;; clock-driven auto-actions / ambient animation); see run-play-loop.
+         (let [result (play/run-play-loop world prev-size)]
+           (if (:running result)
+             (recur result result (term/size))
+             result)))))))
 
 (defn -main []
   (init-terminal)

--- a/main.lg
+++ b/main.lg
@@ -470,36 +470,50 @@
          (let [[tw th] (term/size)
                runes (render/death-runes tw th)  ;; scatter ONCE — stable across frames
                replay-code (replay/encode-run world)  ;; compute ONCE — encode is O(n) per call
-               poll! (sfx/make-key-poller 120)  ;; calmer death-screen pulse (was 80ms)
                _ (sfx/clear-screen tw th)  ;; clear ONCE, not per-frame — was the flicker source
-               result (loop [scroll 0 frame 0]
-                        ;; animate the death screen continuously; the runes keep
-                        ;; pulsing while we wait for a key instead of freezing.
-                        (let [[k nf] (sfx/drive-until-key
-                                       frame
-                                       (fn [f] (render/render-death-screen world runes scroll f replay-code))
-                                       poll!)]
-                          (cond
-                            (or (= k "n") (= k "\r") (= k "\n") (= k " "))
-                            :new-game
-                            (= k :eof) (assoc world :running false)
-                            (= k "\u001b")
-                            (if *in-wasm*
-                              (do
-                                (render/render-hazard-prompt world "Start a new game?")
-                                (let [confirm (term/read-key)]
-                                  (if (= confirm "y")
-                                    :new-game
-                                    (recur scroll nf))))
-                              (assoc world :running false))
-                            (or (= k "j") (= k "\u001b[B")) (recur (max 0 (dec scroll)) nf)
-                            (or (= k "k") (= k "\u001b[A")) (recur (inc scroll) nf)
-                            :else (recur scroll nf))))]
-           (if (= result :new-game)
+               ;; Animate the death screen via the poll-based event loop: a
+               ;; cosmetic clock pulses the runes each tick while we wait for a
+               ;; key, instead of freezing on a blocking read (see xsofy.ui /
+               ;; #56). :ui carries {:frame :scroll}; raw keys drive scroll/exit.
+               step (fn [st ev]
+                      (let [[tag payload] ev]
+                        (case tag
+                          :tick (assoc st :frame payload)
+                          :action
+                          (let [k payload]
+                            (cond
+                              (or (= k "n") (= k "\r") (= k "\n") (= k " ")) (reduced :new-game)
+                              (= k :eof)                  (reduced :quit)
+                              (= k "\u001b")               (reduced :esc)
+                              (or (= k "j") (= k "\u001b[B")) (update st :scroll (fn [s] (max 0 (dec s))))
+                              (or (= k "k") (= k "\u001b[A")) (update st :scroll inc)
+                              :else st))
+                          st)))
+               result (ui/run-loop
+                        {:sources  [(ui/input-source ui/raw-key->event) (ui/clock-source 0)]
+                         :state    {:frame 0 :scroll 0}
+                         :step     step
+                         :render   (fn [st] (render/render-death-screen world runes (:scroll st) (:frame st) replay-code))
+                         :frame-ms 120})]
+           (cond
+             (= result :new-game)
              (let [w (new-game)]
                (render/render-full w)
                (recur w w (term/size)))
-             result))
+             ;; esc: wasm offers a restart confirm (declining re-enters the death
+             ;; screen); native esc quits.
+             (= result :esc)
+             (if *in-wasm*
+               (do
+                 (render/render-hazard-prompt world "Start a new game?")
+                 (if (= (term/read-key) "y")
+                   (let [w (new-game)]
+                     (render/render-full w)
+                     (recur w w (term/size)))
+                   (recur world world prev-size)))
+               (assoc world :running false))
+             ;; :quit (EOF)
+             :else (assoc world :running false)))
 
          :confirm-hazard
          (do

--- a/xsofy/dispatch.lg
+++ b/xsofy/dispatch.lg
@@ -23,7 +23,7 @@
 ;; or a stray keystroke or a window resize would advance the seed and grow the
 ;; :action-log, silently breaking (seed, action-log) replay determinism.
 (def ^:private ignored-actions
-  #{:unknown :resize})
+  #{:unknown :resize :eof})
 
 (defn action-type
   "The dispatch key for an action: a bare keyword as-is, or the :type of a

--- a/xsofy/play.lg
+++ b/xsofy/play.lg
@@ -1,0 +1,122 @@
+(ns xsofy.play
+  "The core play-screen turn loop, on the unified poll-based event loop
+   (xsofy.ui). Extracted from main so it is testable without launching the
+   game (requiring xsofy.main runs -main)."
+  (:require [term]
+            [xsofy.world :as world]
+            [xsofy.render :as render]
+            [xsofy.ui :as ui]
+            [xsofy.dispatch :as dispatch]))
+
+;; --- Play loop (poll-based; #56) ------------------------------------------
+;; The core turn loop runs on the unified event loop (xsofy.ui/run-loop):
+;;   - input-source feeds parsed [:action] events; play-step dispatches each
+;;     through the deterministic dispatch contract (seed + :action-log).
+;;   - a cosmetic clock-source ticks each frame: it advances an in-flight
+;;     auto-action (rest/run/autoexplore/auto-target) one step per tick and is
+;;     the seam for future idle/ambient animation. Ticks are NEVER dispatched
+;;     or logged, so replay stays bit-identical.
+;; A real keypress in the same batch is folded before the tick, so it cancels
+;; in-flight auto-mode (the interrupt) before the tick's auto-step fires. The
+;; loop exits (reduced world') when a screen opens or the game ends; the outer
+;; game-loop then dispatches that screen.
+
+(defn auto-key-for
+  "The implicit action for an in-flight auto-mode, or nil if not auto-moving."
+  [world]
+  (cond
+    (:resting world) :wait
+    (:running-dir world) (let [[dx dy] (:running-dir world)]
+                           (cond (and (= dx 0) (< dy 0)) :up
+                                 (and (= dx 0) (> dy 0)) :down
+                                 (and (< dx 0) (= dy 0)) :left
+                                 (and (> dx 0) (= dy 0)) :right
+                                 :else nil))
+    (:autoexploring world) :autoexplore
+    (:auto-target world) :auto-target-step
+    :else nil))
+
+(defn apply-auto-stops
+  "Stop an active auto-mode when something interesting happens — death, a
+   visible threatening enemy, finished resting, a blocked run, or a full
+   inventory. `world` is the pre-turn world (for the run-blocked turn check)."
+  [new-world world]
+  (if (or (:resting new-world) (:running-dir new-world) (:autoexploring new-world) (:auto-target new-world))
+    (let [player (get-in new-world [:entities :player])
+          hp (get-in player [:body :hp] 0)
+          max-hp (get-in player [:body :max-hp] 1)
+          fov (or (:fov new-world) #{})
+          enemies (some (fn [e]
+                          (and (:ai e)
+                               (not= :player (:id e))
+                               (:pos e)
+                               (contains? fov (:pos e))
+                               (contains? #{:hunt :investigate :flee} (get-in e [:ai :state]))))
+                        (vals (:entities new-world)))
+          run-blocked (and (or (:running-dir new-world) (:autoexploring new-world))
+                           (= (:turn new-world) (:turn world)))
+          dead (nil? player)]
+      (cond
+        dead (dissoc new-world :resting :running-dir :autoexploring :auto-target)
+        enemies (-> new-world
+                    (dissoc :resting :running-dir :autoexploring :auto-target)
+                    (world/log-msg "You stop — enemy spotted!"))
+        (and (:resting new-world) (>= hp max-hp))
+        (-> new-world (dissoc :resting) (world/log-msg "You finish resting."))
+        run-blocked (dissoc new-world :running-dir :autoexploring :auto-target)
+        (:inventory-full new-world)
+        (-> new-world
+            (dissoc :autoexploring :auto-target :inventory-full))
+        :else new-world))
+    new-world))
+
+(defn play-advance
+  "Dispatch one turn (`key` against `world`), apply auto-stops, then present the
+   frame (full render on floor-change/resize, else dirty + between-turn vfx).
+   Returns the run-loop state, or (reduced world') when a screen opens / the game
+   ends so the outer game-loop can take over."
+  [state world key]
+  (let [prev (:world state)
+        new-world (apply-auto-stops (dispatch/dispatch world key) world)
+        cur-size (term/size)
+        resized (not= cur-size (:size state))
+        floor-changed (not= (:depth new-world) (:depth prev))]
+    (if (or (not (:running new-world)) (:screen new-world))
+      (reduced new-world)
+      (do
+        (if (or floor-changed resized)
+          (render/render-full new-world)
+          (do (render/render-dirty new-world prev)
+              (when (seq (:vfx new-world))
+                (let [[tw th] cur-size
+                      panels (ui/layout tw th)]
+                  (render/animate-vfx! new-world (:map panels))))))
+        (assoc state :world (dissoc new-world :vfx) :size cur-size)))))
+
+(defn play-step
+  "The play loop's scan. [:action] dispatches an explicit key (cancelling any
+   auto-mode first); [:tick] advances ambient :ui and, if auto-moving, dispatches
+   one auto-step. Both route through play-advance / the deterministic dispatch."
+  [state ev]
+  (let [[tag payload] ev
+        world (:world state)]
+    (case tag
+      :action (play-advance state
+                            (dissoc world :resting :running-dir :autoexploring :auto-target)
+                            payload)
+      :tick (let [st (update-in state [:ui :frame] (fn [f] (inc (or f 0))))
+                  ak (auto-key-for world)]
+              (if ak (play-advance st world ak) st))
+      state)))
+
+(defn run-play-loop
+  "Drive the play screen on the unified poll-based loop. Returns the world when a
+   screen opens (so game-loop dispatches it) or when the game ends. Never blocks
+   while idle (input is polled), so it stays responsive in native + wasm."
+  [world size]
+  (ui/run-loop
+    {:sources  [(ui/input-source) (ui/clock-source 0)]
+     :state    {:world world :size size :ui {:frame 0}}
+     :step     play-step
+     :render   (fn [_])          ;; rendering is turn-aware; done in play-advance
+     :frame-ms 30}))

--- a/xsofy/screenfx.lg
+++ b/xsofy/screenfx.lg
@@ -13,45 +13,10 @@
   [ms]
   (async/<!! (async/timeout (if *in-wasm* (max ms 30) ms))))
 
-;; --- Non-blocking input for animated screens ---
-;; `term/read-key` is blocking, so a screen that calls it directly freezes its
-;; animation until a key is pressed. To keep particles running we sleep one
-;; frame, then peek the input via the non-blocking `term/key-pending?` and only
-;; consume a key when one is queued.
-;;
-;; Why not a goroutine + async/alts! on read-key: in WASM, `term/read-key` calls
-;; `Atomics.wait` on the SharedArrayBuffer, which blocks the entire worker
-;; thread (not just the calling goroutine). That freezes the timer goroutine
-;; backing `async/timeout`, so `alts!` never returns nil and the animation loop
-;; never advances past frame 0 — exactly the "Press any key" never-renders
-;; symptom observed on deployed builds. `key-pending?` is the let-go primitive
-;; provided for this idiom.
-
-(defn make-key-poller
-  "Return a 0-arg poll fn for animation loops. Each call yields ~ms then returns
-   the next pending key, or nil if no key was queued during the wait. Safe in
-   both native and WASM — `term/read-key` is only entered when a key is already
-   pending, so it returns immediately without blocking the runtime."
-  [ms]
-  (fn []
-    (pause! ms)
-    (when (term/key-pending?)
-      (or (term/read-key) :eof))))
-
-(defn drive-until-key
-  "Animation control loop. Render successive frames starting at `start-frame`,
-   calling (render! frame) then (poll!) after each. (poll!) returns a key (the
-   loop ends) or nil (keep animating — frame advances). Returns [key next-frame]
-   so callers can resume animation continuously across handled keypresses.
-   Pure with respect to the injected render!/poll! — the seam tested in
-   title_test."
-  [start-frame render! poll!]
-  (loop [frame start-frame]
-    (render! frame)
-    (let [k (poll!)]
-      (if (some? k)
-        [k (inc frame)]
-        (recur (inc frame))))))
+;; Non-blocking animated-screen input — the `key-pending?` poll-peek idiom that
+;; superseded a goroutine + read-key (which froze under wasm) — now lives in the
+;; general poll-based event loop: xsofy.ui/input-source + run-loop (#56). The
+;; title and death screens drive that loop directly.
 
 (def rune-glyphs
   ["ᚠ" "ᚢ" "ᚦ" "ᚨ" "ᚱ" "ᚲ" "ᚷ" "ᚹ" "ᚺ" "ᚾ" "ᛁ" "ᛃ"

--- a/xsofy/test/dispatch_test.lg
+++ b/xsofy/test/dispatch_test.lg
@@ -43,10 +43,10 @@
     (is (not (dispatch/replay-action? :equip-menu)))))
 
 (deftest ignored-actions-are-noops
-  (testing "unknown / resize / nil inputs touch neither world, seed, nor log"
+  (testing "unknown / resize / eof / nil inputs touch neither world, seed, nor log"
     (let [w0 (world/make-world 79 30 7)
           s0 (:seed w0)]
-      (doseq [a [:unknown :resize nil]]
+      (doseq [a [:unknown :resize :eof nil]]
         (let [w1 (dispatch/dispatch w0 a)]
           (is (= s0 (:seed w1)) (str a ": seed unchanged"))
           (is (= [] (:action-log w1)) (str a ": nothing logged"))
@@ -54,6 +54,7 @@
   (testing "ignored-action? predicate"
     (is (dispatch/ignored-action? :unknown))
     (is (dispatch/ignored-action? :resize))
+    (is (dispatch/ignored-action? :eof))
     (is (dispatch/ignored-action? nil))
     (is (not (dispatch/ignored-action? :up)))
     (is (not (dispatch/ignored-action? :inventory)))))

--- a/xsofy/test/play_test.lg
+++ b/xsofy/test/play_test.lg
@@ -1,0 +1,64 @@
+(ns xsofy.test.play-test
+  "Tests for the poll-based play loop (xsofy.play, PR3a of #56). The headline
+   guarantee: routing turns through the unified event loop preserves the
+   deterministic (seed, :action-log) contract — explicit keys dispatch, cosmetic
+   ticks never touch :world, and an in-flight auto-mode advances one step per
+   tick (cancelled by an explicit key in the same batch)."
+  (:require [test :refer [deftest is testing]]
+            [xsofy.world :as world]
+            [xsofy.dispatch :as dispatch]
+            [xsofy.play :as play]))
+
+(defn- state [w] {:world w :size [100 36] :ui {:frame 0}})
+(defn- world-of [st] (if (reduced? st) (deref st) (:world st)))
+
+(deftest play-step-dispatches-explicit-action
+  (testing "an explicit [:action] dispatches a turn and keeps looping"
+    (let [st' (play/play-step (state (world/make-world 79 30 4242)) [:action :wait])]
+      (is (not (reduced? st')) "no screen opened → not a loop exit")
+      (is (= [:wait] (get-in st' [:world :action-log])) "the action was dispatched + logged"))))
+
+(deftest play-step-exits-when-a-screen-opens
+  (testing "a UI action opens a screen → the loop exits (reduced) so game-loop dispatches it"
+    (let [st' (play/play-step (state (world/make-world 79 30 4242)) [:action :inventory])]
+      (is (reduced? st') "screen-open is a loop exit")
+      (is (= :inventory (:screen (deref st'))) "the opened screen is handed back"))))
+
+(deftest tick-without-auto-mode-never-touches-the-world
+  (testing "a cosmetic [:tick] advances ambient :ui only — :world untouched"
+    (let [w  (world/make-world 79 30 4242)
+          st' (play/play-step (state w) [:tick 5])]
+      (is (= (:seed w) (get-in st' [:world :seed])) "seed unchanged")
+      (is (= [] (get-in st' [:world :action-log])) "nothing dispatched/logged")
+      (is (= 1 (get-in st' [:ui :frame])) "ambient frame advanced"))))
+
+(deftest tick-with-auto-mode-advances-one-step
+  (testing "an in-flight auto-mode (resting) dispatches its implicit action on a tick"
+    (let [w   (assoc (world/make-world 79 30 4242) :resting true)
+          st' (play/play-step (state w) [:tick 0])]
+      (is (= [:wait] (:action-log (world-of st'))) "resting auto-dispatched :wait"))))
+
+(deftest explicit-key-cancels-in-flight-auto-mode
+  (testing "a real keypress cancels auto-mode and acts (the interrupt)"
+    (let [w   (assoc (world/make-world 79 30 4242) :resting true)
+          w'  (world-of (play/play-step (state w) [:action :left]))]
+      (is (not (:resting w')) "resting was cancelled")
+      (is (= [:left] (:action-log w')) "the explicit key was dispatched"))))
+
+(deftest play-loop-preserves-replay-determinism
+  (testing "driving play-step with actions (interleaved with noise ticks) yields
+            the same (seed, action-log, entities) as a pure dispatch/replay —
+            ticks never perturb the deterministic world"
+    (let [actions [:right :wait :down :left :wait :up :pickup :down-right]
+          seed    777
+          ref     (dispatch/replay 79 30 seed actions)
+          final   (reduce (fn [st a]
+                            (let [st (play/play-step st [:tick 0])      ;; cosmetic noise
+                                  st (play/play-step st [:action a])]
+                              st))
+                          (state (world/make-world 79 30 seed))
+                          actions)
+          w       (:world final)]
+      (is (= (:seed ref) (:seed w)) "seed bit-identical")
+      (is (= (:action-log ref) (:action-log w)) "action-log bit-identical")
+      (is (= (:entities ref) (:entities w)) "entity state bit-identical"))))

--- a/xsofy/test/run.lg
+++ b/xsofy/test/run.lg
@@ -14,6 +14,7 @@
             [xsofy.test.serialize-test]
             [xsofy.test.dag-test]
             [xsofy.test.seed-test]
-            [xsofy.test.replay-test]))
+            [xsofy.test.replay-test]
+            [xsofy.test.ui-test]))
 
 (run-tests)

--- a/xsofy/test/run.lg
+++ b/xsofy/test/run.lg
@@ -15,6 +15,7 @@
             [xsofy.test.dag-test]
             [xsofy.test.seed-test]
             [xsofy.test.replay-test]
-            [xsofy.test.ui-test]))
+            [xsofy.test.ui-test]
+            [xsofy.test.play-test]))
 
 (run-tests)

--- a/xsofy/test/title_test.lg
+++ b/xsofy/test/title_test.lg
@@ -1,44 +1,13 @@
 (ns xsofy.test.title-test
   (:require [test :refer [deftest is testing]]
-            [xsofy.screenfx :as sfx]
-            [xsofy.title :as title]
-            [xsofy.det :as det]))
+            [xsofy.title :as title]))
 
-;; nooga/xsofy — particle screens (title + death) must keep animating
-;; independently of input. The control seam is `drive-until-key`: it renders
-;; successive frames, polling for a key between frames, and only stops when a
-;; key arrives. Frames MUST advance while the poll returns nil (no key yet) —
-;; that is precisely the behaviour that was missing (screens froze on a
-;; blocking read-key until a key was pressed).
-
-(deftest drive-until-key-advances-frames-while-no-key
-  (testing "frames keep rendering while poll returns nil, then the key ends it"
-    (let [rendered (atom [])
-          ;; poll: nil for the first 3 ticks, then a key on the 4th
-          remaining (atom [nil nil nil "x"])
-          poll! (fn []
-                  (let [v (first @remaining)]
-                    (swap! remaining rest)
-                    v))
-          [k next-frame] (sfx/drive-until-key 0
-                                              (fn [frame] (swap! rendered conj frame))
-                                              poll!)]
-      ;; the key that arrived is returned
-      (is (= "x" k))
-      ;; frames 0,1,2,3 were all rendered — animation advanced without input
-      (is (= [0 1 2 3] @rendered))
-      ;; the loop reports the next frame so callers can keep continuity
-      (is (= 4 next-frame)))))
-
-(deftest drive-until-key-stops-immediately-when-key-already-ready
-  (testing "a key available on the first poll ends after one rendered frame"
-    (let [rendered (atom [])
-          [k next-frame] (sfx/drive-until-key 7
-                                              (fn [frame] (swap! rendered conj frame))
-                                              (fn [] "q"))]
-      (is (= "q" k))
-      (is (= [7] @rendered))
-      (is (= 8 next-frame)))))
+;; Particle screens (title + death) must keep animating independently of input —
+;; frames advance while no key is pending, the screen ends when a key arrives.
+;; That control seam is now the general poll-based event loop (xsofy.ui/run-loop
+;; + input-source + clock-source); its frame-advance-then-exit behaviour is
+;; covered by xsofy.test.ui-test (run-loop-animates-then-exits-on-key). These
+;; tests cover the title's own deterministic content generation.
 
 (deftest seeded-title-is-deterministic
   (testing "same seed → same title; known golden for 12345"

--- a/xsofy/test/ui_test.lg
+++ b/xsofy/test/ui_test.lg
@@ -1,0 +1,152 @@
+(ns xsofy.test.ui-test
+  "Tests for the xsofy.ui event-loop surface (#56): the poll-based source
+   contract (input/clock/replay/poll sources), the event fold (apply-events),
+   and the run-loop driver. The headline property is determinism: cosmetic
+   [:tick] events advance :ui only and must NEVER perturb :world or the
+   (seed, :action-log) replay stream."
+  (:require [test :refer [deftest is testing]]
+            [xsofy.ui :as ui]
+            [xsofy.world :as world]
+            [xsofy.dispatch :as dispatch]))
+
+;; --- input-source ---------------------------------------------------------
+;; input-source drains all keys queued this tick (≤16), parsing each to an
+;; [:action act] event at the source edge. It is injectable (pending?/read!)
+;; so it can be tested without redefining the term globals.
+
+(deftest input-source-empty-when-nothing-pending
+  (testing "no key queued → no events (never blocks)"
+    (let [src (ui/input-source ui/default-key->event (fn [] false) (fn [] nil))]
+      (is (= [] (src))))))
+
+(deftest input-source-parses-queued-keys-to-actions
+  (testing "each queued key is parsed to an [:action act] at the edge"
+    (let [keys   (atom ["k" "j" "."])
+          pending? (fn [] (boolean (seq @keys)))
+          read!  (fn [] (let [k (first @keys)] (swap! keys rest) k))
+          src    (ui/input-source ui/default-key->event pending? read!)]
+      (is (= [[:action :up] [:action :down] [:action :wait]] (src))))))
+
+(deftest input-source-maps-eof-to-action
+  (testing "a nil key (EOF) becomes [:action :eof] without calling parse-key"
+    (let [fired (atom false)
+          pending? (fn [] (if @fired false (do (reset! fired true) true)))
+          read!  (fn [] nil)
+          src    (ui/input-source ui/default-key->event pending? read!)]
+      (is (= [[:action :eof]] (src))))))
+
+(deftest input-source-caps-at-16-per-frame
+  (testing "a key flood is capped at 16/frame so one tick can't stall"
+    (let [src (ui/input-source ui/default-key->event (fn [] true) (fn [] "k"))]
+      (is (= 16 (count (src)))))))
+
+;; --- clock-source ---------------------------------------------------------
+;; clock-source emits [:tick frame] only after ms elapsed; frame counter is
+;; monotonic. Injectable now-ms makes the cadence deterministic in tests.
+
+(deftest clock-source-emits-only-after-interval
+  (testing "no tick until ms elapsed, then a tick, then quiet again"
+    (let [t   (atom 0)
+          src (ui/clock-source 100 (fn [] @t))]
+      (is (= [] (src)) "t=0: nothing yet")
+      (reset! t 50)
+      (is (= [] (src)) "t=50: still under the interval")
+      (reset! t 100)
+      (is (= [[:tick 0]] (src)) "t=100: first tick, frame 0")
+      (is (= [] (src)) "t=100 again: last-emit reset, under interval"))))
+
+(deftest clock-source-frame-counter-is-monotonic
+  (testing "successive ticks increment the frame counter"
+    (let [t   (atom 0)
+          src (ui/clock-source 10 (fn [] @t))]
+      (reset! t 10) (is (= [[:tick 0]] (src)))
+      (reset! t 20) (is (= [[:tick 1]] (src)))
+      (reset! t 30) (is (= [[:tick 2]] (src))))))
+
+;; --- replay-source --------------------------------------------------------
+
+(deftest replay-source-yields-actions-then-drains
+  (testing "recorded actions arrive as [:action act], one per tick, then []"
+    (let [src (ui/replay-source [:up :wait :fire])]
+      (is (= [[:action :up]] (src)))
+      (is (= [[:action :wait]] (src)))
+      (is (= [[:action :fire]] (src)))
+      (is (= [] (src)) "drained")
+      (is (= [] (src)) "stays drained"))))
+
+;; --- poll-source ----------------------------------------------------------
+
+(deftest poll-source-normalizes-its-return
+  (testing "nil → [], a single [tag …] event → [event], a seq → as-is"
+    (is (= [] ((ui/poll-source (fn [] nil)))))
+    (is (= [[:tick 3]] ((ui/poll-source (fn [] [:tick 3])))) "single event wrapped")
+    (is (= [[:action :x] [:tick 1]]
+           ((ui/poll-source (fn [] [[:action :x] [:tick 1]]))))
+        "seq passed through")))
+
+;; --- apply-events / determinism (the core property) -----------------------
+;; A step mirroring the real play-loop routing: [:action] drives :world via the
+;; deterministic dispatch contract; [:tick] advances :ui only.
+
+(defn- play-step [state ev]
+  (let [[tag payload] ev]
+    (case tag
+      :action (update state :world dispatch/dispatch payload)
+      :tick   (assoc-in state [:ui :frame] payload)
+      state)))
+
+(defn- interleave-ticks [actions]
+  ;; weave a [:tick n] before and after every action — arbitrary positions
+  (loop [out [] as actions n 0]
+    (if (seq as)
+      (recur (conj out [:tick n] [:action (first as)]) (rest as) (inc n))
+      (conj out [:tick n]))))
+
+(deftest ticks-never-perturb-the-world
+  (testing "folding the same actions with vs without interleaved ticks yields a
+            bit-identical :world (seed, action-log, entities); only :ui differs"
+    (let [actions [:right :wait :down :fire :left :wait :up :pickup]
+          seed    4242
+          init    {:world (world/make-world 79 30 seed) :ui {:frame -1}}
+          clean-events  (map (fn [a] [:action a]) actions)
+          ticked-events (interleave-ticks actions)
+          clean  (ui/apply-events play-step init clean-events)
+          ticked (ui/apply-events play-step init ticked-events)]
+      (is (= (get-in clean [:world :seed]) (get-in ticked [:world :seed]))
+          "seed bit-identical")
+      (is (= (get-in clean [:world :action-log]) (get-in ticked [:world :action-log]))
+          "action-log bit-identical")
+      (is (= (get-in clean [:world :entities]) (get-in ticked [:world :entities]))
+          "entity state bit-identical")
+      (is (= -1 (get-in clean [:ui :frame])) "no ticks → :ui untouched")
+      (is (= 8  (get-in ticked [:ui :frame])) "ticks advanced :ui only"))))
+
+(deftest apply-events-stops-on-reduced
+  (testing "a step returning (reduced x) halts the fold and yields the wrapper"
+    (let [step (fn [st ev] (if (= ev :stop) (reduced :halted) (conj st ev)))
+          out  (ui/apply-events step [] [:a :b :stop :c])]
+      (is (reduced? out) "still a reduced wrapper (not auto-unwrapped by reduce)")
+      (is (= :halted (deref out))))))
+
+;; --- run-loop -------------------------------------------------------------
+;; Fake clock + scripted input drive the loop; it animates :ui on ticks and
+;; exits on the sentinel action, returning the reduced result.
+
+(deftest run-loop-animates-then-exits-on-key
+  (testing "frames advance on [:tick] while idle, then an action exits with a result"
+    (let [batches (atom [[[:tick 0]] [[:tick 1]] [[:tick 2]] [[:action :go]]])
+          source  (fn [] (let [b (first @batches)] (swap! batches rest) (or b [])))
+          rendered (atom [])
+          step (fn [st ev]
+                 (let [[tag payload] ev]
+                   (case tag
+                     :tick   (assoc st :frame payload)
+                     :action (reduced {:exit :go :final-frame (:frame st)})
+                     st)))
+          result (ui/run-loop {:sources  [source]
+                               :state    {:frame -1}
+                               :step     step
+                               :render   (fn [st] (swap! rendered conj (:frame st)))
+                               :frame-ms 0})]
+      (is (= {:exit :go :final-frame 2} result) "returns the reduced result")
+      (is (= [-1 0 1 2] @rendered) "each animated frame was rendered before exit"))))

--- a/xsofy/title.lg
+++ b/xsofy/title.lg
@@ -1,6 +1,7 @@
 (ns xsofy.title
   (:require [term]
             [xsofy.screenfx :as sfx]
+            [xsofy.ui :as ui]
             [xsofy.det :as det]))
 
 ;; --- Procedural Title Generation ---
@@ -155,9 +156,20 @@
         [scheme rng] (pick-scheme rng)
         runes (sfx/scatter-runes tw th 40 scheme)]
     (sfx/clear-screen tw th)
-    (sfx/drive-until-key 0
-                         (fn [frame] (draw-frame runes title subtitle tw th frame seed))
-                         (sfx/make-key-poller 120))
+    ;; Animate via the poll-based event loop: a cosmetic clock advances the
+    ;; particle frame each tick; any key ends the screen. Never blocks while
+    ;; idle, so it stays responsive in native + wasm (see xsofy.ui / #56).
+    (ui/run-loop
+      {:sources  [(ui/input-source ui/raw-key->event) (ui/clock-source 0)]
+       :state    {:frame 0}
+       :step     (fn [st ev]
+                   (let [[tag payload] ev]
+                     (case tag
+                       :tick   (assoc st :frame payload)
+                       :action (reduced st)   ;; any key ends the title
+                       st)))
+       :render   (fn [st] (draw-frame runes title subtitle tw th (:frame st) seed))
+       :frame-ms 120})
     {:title title :scheme scheme :rng rng}))
 
 ;; --- Descending Screen ---

--- a/xsofy/ui.lg
+++ b/xsofy/ui.lg
@@ -167,6 +167,13 @@
   [k]
   (if (nil? k) [:action :eof] [:action (input/parse-key k)]))
 
+(defn raw-key->event
+  "Edge normalization for screens that match raw keys rather than game actions
+   (e.g. the death screen's scroll/new-game keys, or an 'any key' prompt): a raw
+   key → [:action <raw-key-string>]; a nil key (EOF) → [:action :eof]."
+  [k]
+  (if (nil? k) [:action :eof] [:action k]))
+
 (defn input-source
   "A source that drains all keys queued this tick (capped ≤16/frame so an input
    flood can't stall a frame), each normalized to an event by `key->event` at the

--- a/xsofy/ui.lg
+++ b/xsofy/ui.lg
@@ -1,6 +1,7 @@
 (ns xsofy.ui
   (:require [term]
             [async :refer [timeout <!!]]
+            [xsofy.input :as input]
             [xsofy.util :as u]))
 
 ;; --- Timing ---
@@ -138,3 +139,131 @@
      :sidebar sidebar
      :log log-area
      :status status}))
+
+;; --- Event Loop (#56) -----------------------------------------------------
+;; A small, composable, poll-based event loop for terminal UIs. A screen
+;; describes which sources it listens to (input, a cosmetic clock) and how state
+;; folds over events (a pure `step`); the loop drives `render`. The poll-based
+;; source contract NEVER blocks while idle, so the exact same loop runs in a
+;; native terminal and in the browser (wasm) without freezing — and cosmetic
+;; [:tick] events advance :ui only, never the deterministic (seed, :action-log)
+;; world stream, so animated screens never corrupt replay.
+;;
+;; Event shape — a tagged vector [tag payload]:
+;;   [:action act]  a domain action (a keyword like :move-left, or a map like
+;;                  {:type :use-item :id …}); the only thing `dispatch` sees.
+;;   [:tick frame]  a cosmetic frame tick; `frame` is owned by the clock source.
+;; A source is a non-blocking poll: a 0-arg fn (or {:poll fn}) returning a
+;; (possibly empty) seq of events. A source's poll MUST NOT block.
+
+;; Monotonic wall clock in ms. let-go `now` → go.time.Time; `.Sub` → ns (Int).
+(def ^:private clock-epoch (now))
+(defn millis [] (quot (.Sub (now) clock-epoch) 1000000))
+
+(defn default-key->event
+  "Edge normalization: a raw key → an [:action act] event. A nil key (EOF) maps
+   to [:action :eof] without parsing; any other key is parsed to its action.
+   Key→action parsing lives in the source, never in `step`."
+  [k]
+  (if (nil? k) [:action :eof] [:action (input/parse-key k)]))
+
+(defn input-source
+  "A source that drains all keys queued this tick (capped ≤16/frame so an input
+   flood can't stall a frame), each normalized to an event by `key->event` at the
+   edge. It polls `pending?`, then `read!` only once a key is ready, so it never
+   blocks while idle — mandatory under single-threaded wasm, harmless natively.
+   The 3-arity injects pending?/read! for tests; 0/1-arities use `term`."
+  ([] (input-source default-key->event term/key-pending? term/read-key))
+  ([key->event] (input-source key->event term/key-pending? term/read-key))
+  ([key->event pending? read!]
+   (fn []
+     (loop [out []]
+       (if (and (< (count out) 16) (pending?))
+         (recur (conj out (key->event (read!))))
+         out)))))
+
+(defn clock-source
+  "A cosmetic source emitting [:tick frame] once `ms` has elapsed since its last
+   emit; `frame` is a monotonically increasing integer (from 0) the source owns.
+   The 2-arity injects a now-ms fn for deterministic tests."
+  ([ms] (clock-source ms millis))
+  ([ms now-ms]
+   (let [last  (atom (now-ms))
+         frame (atom 0)]
+     (fn []
+       (let [t (now-ms)]
+         (if (>= (- t @last) ms)
+           (do (reset! last t)
+               (let [f @frame] (reset! frame (inc f)) [[:tick f]]))
+           []))))))
+
+(defn replay-source
+  "A source that yields recorded `actions` as [:action act] events, one per
+   tick, then nothing once drained. No clock — the same shape live input
+   produces, so it is interchangeable for headless replay."
+  [actions]
+  (let [remaining (atom (seq actions))]
+    (fn []
+      (if-let [a (first @remaining)]
+        (do (swap! remaining rest) [[:action a]])
+        []))))
+
+(defn poll-source
+  "The generic polling source: `f` is a non-blocking () → event | events | nil
+   called once per tick; input-source/clock-source are specializations. A single
+   [tag …] event is wrapped; a seq of events passes through; nil → no events.
+
+   (A future async/network source would feed a channel and consume it here once
+   let-go gains a non-blocking channel take — nooga/let-go#194. A polling source
+   owns no goroutine, so there is nothing to cancel; that is the leak-free path.
+   The push `chan-source` adapter from the spec is deferred until that primitive
+   exists — its blocking-only `<!`/`>!` can't be polled without parking.)"
+  [f]
+  (fn []
+    (let [x (f)]
+      (cond
+        (nil? x) []
+        (and (vector? x) (keyword? (first x))) [x]   ;; a single [tag …] event
+        :else x))))                                  ;; already a seq of events
+
+(defn- poll-1 [src] (if (map? src) ((:poll src)) (src)))
+
+(defn apply-events
+  "Fold `events` through `step` from `state`. Unlike core `reduce` — which
+   unwraps a (reduced x) — this PRESERVES the wrapper so `run-loop` can tell a
+   normal state from a loop exit. Returns the new state, or a reduced wrapper
+   once `step` signals exit."
+  [step state events]
+  (loop [st state, evs (seq events)]
+    (if (or (reduced? st) (nil? evs))
+      st
+      (recur (step st (first evs)) (next evs)))))
+
+(defn run-loop
+  "Drive a poll-based event loop. opts:
+     :sources  — seq of non-blocking sources (fn or {:poll fn})
+     :state    — initial loop state (typically {:world … :ui …})
+     :step     — (step state event) → state' | (reduced result)   [the scan]
+     :render   — (render state) side-effecting subscriber (paints AND presents,
+                 so the core stays backend-agnostic — it never flushes itself)
+     :xform    — optional transducer shaping each tick's event batch
+     :frame-ms — pacing target (floored under wasm by `pause!`); default 30
+   Each iteration: render the current state, poll every source (non-blocking),
+   fold the batch through `step`, then pace via `pause!`. Exits when `step`
+   returns (reduced result), returning that result.
+
+   No goroutines are owned (input + clock are polling), so there is nothing to
+   tear down — the caller's shutdown-terminal stays the outer finally. A future
+   ctx-aware chan-source would wrap this body in (with-scope …) to drain its
+   producer; not needed today."
+  [{:keys [sources state step render xform frame-ms] :or {frame-ms 30}}]
+  (loop [st state]
+    (render st)
+    ;; poll every source exactly once this tick (eagerly — sources are stateful),
+    ;; then optionally shape the batch through the transducer `xform`.
+    (let [raw   (vec (mapcat poll-1 sources))
+          batch (if xform (vec (sequence xform raw)) raw)
+          st'   (apply-events step st batch)]
+      (if (reduced? st')
+        (deref st')
+        (do (pause! frame-ms) (recur st'))))))


### PR DESCRIPTION
Implements #56 (design: #55 / `docs/responsive-ui-event-loop-design.md`). Stacks on #66.

## Problem
The determinism refactor made the game loop purely input-driven via blocking `read-key`. That froze idle animation (title/death particles), and in wasm it's worse: `read-key` is backed by `Atomics.wait` on a SharedArrayBuffer and Go-wasm is single-threaded, so a blocking read freezes the **entire** worker. mparrett's #61 patched title/death with a one-off `key-pending?` poll-peek; this generalizes that into a small, composable event-loop module so the same loop drives every animated screen, native and wasm, without leaking cosmetic ticks into the deterministic `(seed, action-log)` replay stream.

## What's here (4 commits)
- **PR1 — `xsofy.ui/run-loop` + sources.** A poll-based event loop: a screen lists non-blocking **sources** (`input-source` drains queued keys → `[:action …]`; `clock-source` emits `[:tick frame]`; `replay-source`; `poll-source`) and a `step` scan over `{:world :ui}` that returns `(reduced …)` to exit. Cosmetic `[:tick]` advances `:ui` only — never the seed/log. Includes `ui_test.lg` with a determinism property test (interleaving ticks doesn't change `:world` / `(seed, action-log)`).
- **PR2 — title + death screens** on `run-loop`; deletes the one-off `make-key-poller`/`drive-until-key`.
- **PR3a — core play loop** on `run-loop` (input + clock-driven auto-actions / ambient vfx), folding the between-turn vfx path into the unified `:ui`.
- **PR4 — docs.** `docs/terminal.md` "Responsive UIs" section: the poll-on-tick source contract, why blocking `read-key` freezes wasm, and the determinism caveat.

## Notes
- No let-go `poll!`/`alts!` exists (v1.9.0), so async/channel sources are documented as a seam, not built (FR filed upstream: nooga/let-go). `run-loop` paces via the wasm-aware `pause!` (`<!! (timeout (max ms 30))`).
- **Modal screens** (inventory/quick-menu/messages/help/inscribe/confirm) still use blocking `read-key` — that's the deferred PR3b (modal screens → nested run-loops), a follow-up.

## Verification
`make test` green (259 tests / 0 fail); `make smoke-lg` (frozen-title guard); `make e2e` (title animates in headless wasm — the #61 regression gate).