### PR TITLE
balance: tame slimes, throttle ranged fire rate, soften spider webs

### DIFF
--- a/xsofy/ai.lg
+++ b/xsofy/ai.lg
@@ -13,6 +13,11 @@
 (def distance u/distance)
 (def adjacent? u/adjacent?)
 
+;; Default per-turn chance a ranged creature fires when in range + LOS.
+;; Creatures may override via their spell's :fire-chance (e.g. spider: 15).
+;; Kept below 100 so ranged enemies don't shoot every single turn.
+(def default-ranged-fire-chance 60)
+
 ;; --- Simple Pathfinding ---
 
 (defn step-toward [from to]
@@ -324,7 +329,7 @@
         in-range-with-los (and (<= dist max-range) los)
         fire-pair (if (and (not too-close) in-range-with-los)
                     (det/percent? (det/with-context world [:ai :ranged-fire entity-id])
-                                  (or (:fire-chance spell-data) 100))
+                                  (or (:fire-chance spell-data) default-ranged-fire-chance))
                     [false world])
         fires-now (first fire-pair)
         world (second fire-pair)]

--- a/xsofy/bestiary.lg
+++ b/xsofy/bestiary.lg
@@ -75,9 +75,9 @@
 (defcreature spider
   (visual "S" [80 60 40])
   (body {:hp 12 :strength 2})
-  (ai :ranged {:preferred-range 3 :speed 2})
+  (ai :ranged {:preferred-range 3})
   (melee 3)
-  ;; spider shoots webs at range, casts cone web on hit (30% chance per turn)
+  ;; spider shoots webs at range, casts cone web on hit (15% chance per turn)
   (spell :ranged {:damage 1 :range 4 :fire-chance 15 :glyph "*" :color [220 220 230]})
   {:spell-runes [:web]
    :properties {:web-immune true}}
@@ -91,8 +91,8 @@
 
 (defcreature slime
   (visual "s" [100 200 100])
-  (body {:hp 50 :strength 1 :regen 0})
-  (ai :hunter {:speed 2})
+  (body {:hp 24 :strength 1 :regen 0})
+  (ai :hunter)
   (melee 2)
   {:properties {:splits-on-hit true}}
   (sounds {:death {:near "The slime dissolves with a hiss."

--- a/xsofy/world.lg
+++ b/xsofy/world.lg
@@ -1650,7 +1650,7 @@
                       w (if (and (fire/on-web? w nx ny)
                                  (not (fire/web-immune? w :player)))
                           (-> w
-                              (status/apply-status :player :webbed 3)
+                              (status/apply-status :player :webbed 2)
                               (log-msg "You walk into a web!"))
                           w)
                       ;; tile effects (water extinguishes fire, etc.)


### PR DESCRIPTION
## What

Tuning pass on early-dungeon difficulty. Three creature families were disproportionately lethal:

- **Slimes** were the standout killer — tanky (50 HP), fast (`speed 2` = acts *twice* per player turn), **and** splitting on every hit. The triple-combo snowballed out of control.
- **Every ranged enemy except the spider** omitted `:fire-chance`, which `hunt-ranged` defaulted to **100%** — so archer/goblin-shaman/fire-imp/ice-elemental/dragon all shot every single turn.
- **Spiders** acted twice per turn (`speed 2`) and rooted the player with `webbed 3`, keeping you in the kill zone while they kept firing.

## Changes

| Creature | Change | File |
|---|---|---|
| Slime | HP `50→24`, speed `2→1` (keeps splits-on-hit) | `xsofy/bestiary.lg` |
| All ranged | New `default-ranged-fire-chance` constant = `60` (was hardcoded 100% default) | `xsofy/ai.lg` |
| Spider | speed `2→1` | `xsofy/bestiary.lg` |
| Player web-root | `webbed 3→2` on stepping into a web (enemy-side `:web` rune potency left at 3) | `xsofy/world.lg` |

## Measured effect

60-run seeded balance sweep (`starter` loadout, `greedy-melee` policy, seed 1000):

| Metric | Before | After |
|---|---|---|
| Deaths | 51/60 | 42/60 |
| Mean turns survived | 158 | 288 |
| slime kills | 18 | 4 |
| spider kills | 11 | 4 |
| archer kills | 9 | 14 |

Slime and spider kills both dropped ~70%; overall survival nearly doubled. Archer kills rose, but that's a survivorship + test-bot artifact: players now survive the early game and reach more archers, and the melee-only sim bot has no ranged counterplay (no kiting/cover). Per-shot archer lethality genuinely dropped (60% vs 100%).

## Testing

- Full test suite passes (2233 assertions).
- `balance.lg` is a pure runtime sim harness — no hardcoded stats, nothing to break.

🤖 Generated with [Claude Code](https://claude.com/claude-code)