### PR TITLE
feat(vfx): tint-flash on melee hits (Brogue-style)

### DIFF
--- a/xsofy/render.lg
+++ b/xsofy/render.lg
@@ -482,17 +482,25 @@
 
             :flash
             (let [[x y] (:pos event)
-                  i2 (* intensity intensity)]
+                  i2 (* intensity intensity)
+                  tint (or (:color event) [255 255 255])
+                  ent-at-pos (core/some (fn [[_ e]] (when (= (:pos e) [x y]) e))
+                                        (:entities world))]
               (when (and (>= x 0) (< x (:w r)) (>= y 0) (< y (:h r)))
                 (let [tile (terrain/tget (:terrain world) (:width world) x y)
                       style (style-tile tile)
-                      white [255 255 255]
-                      fg (boost-color (:fg style) white i2)
-                      bg (boost-color (:bg style) white (* i2 0.8))
-                      ch (get terrain/tile-chars tile ".")]
+                      bg-lit (let [lv (light/light-at x y lights)]
+                               (if lv (light/apply-light (:bg style) lv) (:bg style)))
+                      base-fg (if ent-at-pos
+                                (get-in ent-at-pos [:visual :color] [200 60 60])
+                                (:fg style))
+                      fg (boost-color base-fg tint i2)
+                      ch (if ent-at-pos
+                           (get-in ent-at-pos [:visual :glyph] "?")
+                           (get terrain/tile-chars tile "."))]
                   (term/move-cursor (+ (:x r) x) (+ (:y r) y))
                   (let [[fr fg_ fb] fg] (term/set-fg fr fg_ fb))
-                  (let [[br bg_ bb] bg] (term/set-bg br bg_ bb))
+                  (let [[br bg_ bb] bg-lit] (term/set-bg br bg_ bb))
                   (term/write ch))))
 
             nil)))

--- a/xsofy/world.lg
+++ b/xsofy/world.lg
@@ -817,6 +817,11 @@
                     w (if target-pos
                         (splatter-blood w2 (first target-pos) (second target-pos) dmg hp-before killed)
                         w2)
+                    w (if target-pos
+                        (update w :vfx #(conj (or % [])
+                                              {:type :flash :pos target-pos
+                                               :color [255 80 80] :decay 3}))
+                        w)
                     ;; trigger runes on hit (weapon runes or creature runes)
                     wep (ent/get-weapon world attacker-id)
                     hit-runes (or (when wep (:runes wep))


### PR DESCRIPTION
## Summary

Symmetric hit feedback for melee attacks. Previously only ranged/projectile and weapon-pattern attacks emitted a `:flash` vfx, producing an asymmetry where:

- enemy archer hits player → player tile flashes
- player sword hits goblin → no flash

Both directions now produce a brief tile-tint on hit.

While there, the `:flash` renderer got a small rework toward Brogue's hit-tint convention:

- **Respect the event's `:color` field as the boost target.** It was hardcoded to white; the existing `launch-projectile` and weapon-pattern emissions already declared meaningful colors (warm yellow for projectile impact, gray for projectile miss, white for cleave) that the renderer was discarding. Now those declared colors render as intended.
- **Render the entity glyph when one occupies the flashed tile**, instead of overwriting it with the terrain glyph. The `render-vfx-frame` docstring (\"Render vfx as color overlays on existing tiles. Does not overwrite glyphs.\") now actually holds for tiles with entities on them — previously a flashed enemy tile briefly displayed the floor glyph beneath it, which read as a blocky pulse rather than a hit on the creature.
- **Drop the background boost.** A foreground-only tint reads cleaner than the full block flash and matches Brogue's damage-tint feel.

Melee emits red `[255 80 80]` for 3 frames. Projectile and weapon-pattern flashes keep their existing color/decay values.

## What changed

- `xsofy/world.lg` — `melee-attack` emits a `:flash` event at `target-pos` on hit (5 lines)
- `xsofy/render.lg` — `:flash` case in `render-vfx-frame` uses event color + entity glyph, drops bg boost (~13 lines net)

## Test plan

- [x] `make test` — 268 tests, 2292 assertions, 0 fail/error
- [x] TUI manual: bump goblins, observe red tint on hit
- [x] WASM manual: same, in browser
- [x] Screencaps attached

## Notes for reviewers

- No new test added — the change is purely additive vfx with no sim impact. Happy to add a coverage test on the melee `:flash` emission if you'd prefer.
- The color-respecting renderer change applies to *all* `:flash` emissions, not just the new melee one. Strictly more faithful to what the emission code already declared, but worth noting in case it changes the feel of projectile/weapon-pattern flashes vs what you remember.

Draft: holding for design input; does this direction makes sense?

<img width="819" height="638" alt="t-rec_5" src="https://github.com/user-attachments/assets/bd4c71f4-185a-4ffa-9fe0-a8e0341530be" />
