### PR TITLE
feat: add knot rewind cords

### DIFF
--- a/docs/ai-design.md
+++ b/docs/ai-design.md
@@ -164,3 +164,620 @@ The engine is ~15 lines:
 - How to handle one-shot effects on state entry (e.g., pack alert on entering hunt)?
 - Can the action itself force a state change mid-turn (e.g., attack kills target → investigate)?
 - Per-creature memory (patrol waypoints, home territory) — store in `:ai` map on entity?
+
+## Current Direction: Derived Blackboard + Utility Scoring
+
+The current direction is to move away from a monolithic per-creature state
+machine and toward a deterministic utility-style AI built from:
+
+1. branch-local input history,
+2. normalized perceivable events,
+3. a derived per-creature blackboard,
+4. scored drives / intents,
+5. deterministic action selection.
+
+This fits xsofy's existing replay and time-travel model better than a large
+authoritative AI-state map. Monsters should not carry opaque mutable "mental
+state" that survives independently of the branch. Their working memory should be
+reconstructed for a specific commit from the current branch's visible history.
+
+### Core Pipeline
+
+```clojure
+input-dag
+  -> normalized world events
+  -> perception filter (per creature)
+  -> derived blackboard
+  -> scored intents
+  -> chosen action
+```
+
+The split matters:
+
+- **input DAG** remains canonical history,
+- **state DAG** may cache materialized worlds plus derived AI views,
+- **blackboards are not authoritative world state**,
+- **scores are ephemeral** and are recomputed from the blackboard each turn.
+
+### Determinism Rules
+
+The AI must remain fully replay-safe.
+
+- No raw randomness; all stochastic choices must use the deterministic seed flow.
+- Ties break by stable ordering or deterministic rolls.
+- Blackboards are reconstructed from the active branch only.
+- Rewind / `switch-head` / `branch` / `undo` must never leak knowledge from
+  abandoned or alternate futures.
+- Garbage-collected branches lose their blackboards naturally because the
+  history they were derived from is gone.
+
+### Blackboard Model
+
+Each creature gets a small derived blackboard for a given commit. It should hold
+compact, useful beliefs rather than raw event logs:
+
+```clojure
+{:last-seen-target ...
+ :last-heard-disturbance ...
+ :recent-attacker ...
+ :ally-distress ...
+ :home-pos ...
+ :threat-level ...
+ :safe-route? ...
+ :search-ttl ...}
+```
+
+The blackboard is reconstructed from a bounded event horizon.
+
+### Memory Horizon
+
+Each creature has a memory profile, and that profile is modifiable by
+traits/corruptions.
+
+Suggested knobs:
+
+```clojure
+{:turn-depth 8
+ :event-cap 16
+ :channels #{:sight :sound :harm :ally}
+ :decay :linear}
+```
+
+This allows:
+
+- animals with short tactical memory,
+- intelligent enemies with deeper memory,
+- `:pack`/`:territorial`/`:coward`-style modifiers,
+- late-game corruption or substrate effects that distort memory rules.
+
+### Event Model
+
+Blackboards should be built from **normalized AI-facing events**, not raw action
+history. Example events:
+
+```clojure
+{:type :saw-target :target-id ... :pos [x y] :turn 42}
+{:type :lost-target :target-id ... :turn 45}
+{:type :heard-disturbance :pos [x y] :loudness 6 :turn 43}
+{:type :took-damage :from :player :amount 3 :turn 44}
+{:type :ally-died :ally-id :dog-1 :pos [10 7] :turn 44}
+{:type :door-opened :pos [9 7] :turn 41}
+```
+
+The perception layer decides which creatures could have observed a given event.
+
+### Scored Drives
+
+Instead of hardcoding one FSM per creature family, creatures score a reusable
+set of drives:
+
+- `:self-preserve`
+- `:attack`
+- `:hold-range`
+- `:pursue`
+- `:investigate`
+- `:guard`
+- `:protect-ally`
+- `:rally`
+- `:wander`
+- `:return-home`
+
+Traits and creature templates modify weights, gating, and action availability.
+
+Hard overrides should still exist for true interruptions only:
+
+- dead,
+- stunned/frozen,
+- webbed,
+- other "cannot act normally" conditions.
+
+These are execution constraints, not ordinary utility drives.
+
+## Worked Example: Hunter with a Pack of Dogs
+
+The hunter and the dogs should coordinate without sharing one mind.
+
+### Shared Event Vocabulary
+
+- `:saw-target`
+- `:lost-target`
+- `:heard-disturbance`
+- `:took-damage`
+- `:ally-bit-target`
+- `:ally-died`
+- `:handler-threatened`
+
+### Hunter Blackboard
+
+```clojure
+{:last-seen-target ...
+ :pack-status {:alive 2 :engaged 1}
+ :threat-level ...
+ :safe-range? ...
+ :escape-route? ...}
+```
+
+### Dog Blackboard
+
+```clojure
+{:last-seen-target ...
+ :handler-pos ...
+ :target-engaged-by-pack? ...
+ :recent-pack-distress ...
+ :bite-opportunity? ...}
+```
+
+### Scoring Shape
+
+Hunter priorities:
+
+- `:hold-range`
+- `:focus-fire`
+- `:self-preserve`
+- `:retreat` when the pack collapses
+
+Dog priorities:
+
+- `:protect-handler`
+- `:chase`
+- `:flank`
+- `:finish-wounded`
+- weaker `:self-preserve` unless modified
+
+### Resulting Behavior
+
+- One dog sees the player and emits a local rally signal.
+- Nearby dogs reconstruct "target known / pack engaged" and score `:chase` or
+  `:flank`.
+- The hunter reconstructs "target screened by pack" and scores `:hold-range`.
+- If a dog dies, remaining dogs may shift toward panic, rage, or defense, while
+  the hunter may switch to retreat-and-shoot behavior.
+
+This creates recognizable coordination without a bespoke "hunter-pack FSM."
+
+## Worked Example: Town with Villagers and Shopkeepers
+
+This is a useful stress test because it exercises social behavior rather than
+combat pursuit only.
+
+### Shared Event Vocabulary
+
+- `:saw-stranger`
+- `:heard-theft`
+- `:saw-assault`
+- `:door-broken`
+- `:ally-panicked`
+- `:guard-summoned`
+- `:trade-started`
+
+### Villager Blackboard
+
+```clojure
+{:home-pos ...
+ :known-safe-spots [...]
+ :recent-threat ...
+ :crowd-panic-level ...
+ :known-shopkeeper-distress ...}
+```
+
+### Shopkeeper Blackboard
+
+```clojure
+{:shop-pos ...
+ :owned-area ...
+ :suspicious-target ...
+ :theft-reported ...
+ :guards-alerted? ...}
+```
+
+### Scoring Shape
+
+Villager priorities:
+
+- `:routine`
+- `:avoid-threat`
+- `:flee-to-safe-spot`
+- `:warn-others`
+- `:return-home`
+
+Shopkeeper priorities:
+
+- `:tend-shop`
+- `:watch-suspicious-target`
+- `:protect-goods`
+- `:call-guards`
+- `:flee` when violence escalates
+
+### Resulting Behavior
+
+- In calm conditions, villagers follow routines and shopkeepers stay anchored to
+  owned space.
+- A suspicious arrival changes scores before open combat starts.
+- Theft creates alarm events that propagate socially.
+- Some villagers flee, some warn others, and shopkeepers may stay in place just
+  long enough to escalate to guards.
+
+This lets civic behavior emerge from the same event/blackboard/scoring model
+used for dungeon ecology.
+
+## Implications for Issue #40
+
+This direction aligns with the broader world-design goals in issue #40:
+
+- factions and social groups,
+- pack rally,
+- guarding / patrol / territoriality,
+- support and repair roles,
+- hazard-aware and habitat-aware behavior,
+- corruption overlays that alter perception, memory, or drive weighting.
+
+The key benefit is that new creature families are composed from:
+
+- event channels,
+- memory profile,
+- drive weights,
+- available actions,
+- trait/corruption modifiers,
+
+rather than by adding another special-case branch to a central AI `cond`.
+
+## Communication Vocabulary and Renderers
+
+Ally communication should not be a hidden AI-only side channel. Important
+coordination must exist as perceivable world events with typed semantics and
+payloads.
+
+### Design Rule
+
+Signals should be:
+
+- **typed** — stable gameplay meaning (`:alarm`, `:rally`, `:mark-target`, ...)
+- **payload-capable** — can carry target ids, positions, threat classes, etc.
+- **world-visible** — heard or seen through the normal perception model
+- **renderer-driven** — the player-facing expression is decoupled from the AI
+  semantics
+
+This avoids telepathy while still letting different factions express the same
+ tactical meaning in different ways.
+
+### Core Signal Shape
+
+```clojure
+{:type :mark-target
+ :from :hunter-1
+ :faction :hunters
+ :pos [12 8]
+ :target-id :player
+ :target-pos [15 8]
+ :channel :sound
+ :strength 6
+ :turn 42}
+```
+
+Suggested common fields:
+
+- `:type` — the gameplay intent
+- `:from` — source entity id
+- `:faction` — source alignment/group
+- `:pos` — emission origin
+- `:channel` — `:sound`, `:visual`, possibly later `:rune`/`:machine`
+- `:strength` / `:radius` — how far the signal propagates
+- `:turn` — deterministic recency anchor
+- payload fields like `:target-id`, `:target-pos`, `:threat`, `:safe-pos`,
+  `:focus-pos`, `:area-id`
+
+### Initial Vocabulary
+
+The exact list can grow, but a compact starting set should cover most early
+needs:
+
+- `:alarm` — "something is wrong here"
+- `:rally` — "group up / engage"
+- `:warn` — "danger at this location / from this class"
+- `:help` — "I am under threat"
+- `:mark-target` — "this specific target matters"
+- `:retreat` — "fall back / disengage"
+- `:muster` — "move to this anchor / post"
+- `:panic` — uncontrolled distress, useful for towns/crowds
+
+### Example Signals
+
+```clojure
+{:type :alarm
+ :from :shopkeeper-2
+ :pos [30 11]
+ :channel :sound
+ :radius 10
+ :threat :theft}
+
+{:type :rally
+ :from :dog-1
+ :pos [14 7]
+ :channel :sound
+ :focus-pos [15 8]
+ :target-id :player}
+
+{:type :retreat
+ :from :villager-4
+ :pos [22 5]
+ :channel :visual
+ :safe-pos [18 3]}
+```
+
+### Blackboard Interaction
+
+Signals should be just another normalized event source feeding blackboard
+reconstruction.
+
+Examples:
+
+- `:mark-target` may refresh `:last-seen-target` without direct LOS
+- `:help` may raise `:ally-distress`
+- `:alarm` may raise local `:threat-level`
+- `:muster` may override routine drift and strengthen `:return-home`/`:guard`
+
+Traits and memory channels can control who is receptive to which signals.
+
+### Renderer Split
+
+Signal semantics should not dictate one presentation. Renderers map the same
+signal type onto faction/species-specific player-facing cues.
+
+Examples:
+
+- dogs: bark / howl / growl
+- hunter: whistle / shout / hand signal
+- villagers: scream / point / bell
+- constructs: siren / beacon flash / rune pulse
+- substrate creatures: glitch chirp / bracket flare / state echo
+
+Possible player-facing renderers:
+
+- log text
+- local sound text
+- VFX pulse or flare
+- overhead icon
+- map ping / beacon
+- ambient hint only when partially perceived
+
+This gives one gameplay vocabulary with many expressive skins.
+
+## Worked Example: Territorial Troll
+
+This is the solitary, non-social stress test. The troll should feel rooted in a
+place, not like a generic pursuer.
+
+### Shared Event Vocabulary
+
+- `:saw-target`
+- `:lost-target`
+- `:heard-disturbance`
+- `:took-damage`
+- `:intrusion`
+- `:target-left-territory`
+
+### Troll Blackboard
+
+```clojure
+{:home-pos ...
+ :territory-radius 8
+ :last-seen-target ...
+ :recent-damage ...
+ :intrusion-level ...
+ :target-in-territory? ...
+ :safe-route? ...}
+```
+
+### Scoring Shape
+
+Primary drives:
+
+- `:guard-territory`
+- `:attack-intruder`
+- `:pursue-briefly`
+- `:self-preserve`
+- `:return-home`
+
+Trait or corruption modifiers could shift the shape:
+
+- `:territorial` increases `:guard-territory` and reduces chase range
+- `:berserker` suppresses retreat
+- a corruption may make the troll overextend or ignore home bounds
+
+### Resulting Behavior
+
+- If the player enters the troll's territory, `:intrusion` raises local threat
+  even before melee range.
+- Inside territory, `:attack-intruder` dominates.
+- Outside territory, the troll may pursue briefly, but `:return-home` rises
+  sharply once the target escapes the defended area.
+- If wounded, the troll may fall back toward defensible terrain instead of
+  chasing forever.
+
+This gives a creature that teaches space ownership rather than pure aggression.
+
+## Worked Example: Guard Post
+
+This is the structured coordination case: multiple guards, a defended place,
+alarm propagation, and role differentiation.
+
+### Shared Event Vocabulary
+
+- `:saw-stranger`
+- `:alarm`
+- `:mark-target`
+- `:help`
+- `:muster`
+- `:door-broken`
+- `:ally-died`
+
+### Guard Blackboard
+
+```clojure
+{:post-pos ...
+ :assigned-lane ...
+ :last-seen-target ...
+ :alarm-level ...
+ :ally-distress ...
+ :guard-order ...
+ :fallback-pos ...}
+```
+
+### Role Split
+
+Even within one faction, guards may differ:
+
+- sentry: stronger `:watch` / `:raise-alarm`
+- bruiser: stronger `:hold-line`
+- runner: stronger `:summon-help`
+- captain: stronger `:mark-target` / `:muster`
+
+### Scoring Shape
+
+Primary drives:
+
+- `:watch`
+- `:challenge-stranger`
+- `:raise-alarm`
+- `:hold-post`
+- `:pursue-intruder`
+- `:protect-ally`
+- `:muster-at-post`
+
+### Resulting Behavior
+
+- A sentry sees the player and emits `:alarm` plus `:mark-target`.
+- Nearby guards reconstruct the signal and score `:muster-at-post` or
+  `:hold-post` instead of all stampeding forward.
+- One guard may peel off into `:summon-help`, while another remains to block the
+  corridor.
+- If a guard dies, `:ally-died` can spike aggression, panic, or fallback,
+  depending on faction traits.
+
+This produces readable defense behavior rather than a pile of independent melee
+units.
+
+## Worked Example: Turret Room
+
+This is the machine-coordination case. It tests whether the model works when
+communication is beacons and control channels instead of animal or humanoid
+social cues.
+
+### Shared Event Vocabulary
+
+- `:sensor-trip`
+- `:mark-target`
+- `:alarm`
+- `:muster`
+- `:repair-request`
+- `:line-blocked`
+- `:power-loss`
+
+### Turret Blackboard
+
+```clojure
+{:firing-lane ...
+ :last-marked-target ...
+ :line-clear? ...
+ :overheat-level ...
+ :support-nearby? ...}
+```
+
+### Keeper / Operator Blackboard
+
+```clojure
+{:assigned-room ...
+ :active-turrets [...]
+ :repair-priority ...
+ :breach-pos ...
+ :fallback-switch? ...}
+```
+
+### Scoring Shape
+
+Turret drives:
+
+- `:track-target`
+- `:fire-lane`
+- `:cease-fire` when blocked by allies or geometry
+- `:protect-core`
+
+Keeper drives:
+
+- `:raise-alarm`
+- `:repair-system`
+- `:unblock-lane`
+- `:retreat-to-control-point`
+- `:rearm-defense`
+
+### Resulting Behavior
+
+- A sensor trip emits `:alarm` and `:mark-target`.
+- Turrets that can perceive the signal but not yet see the target may pre-aim
+  or hold lanes.
+- A keeper can react to `:repair-request` or `:power-loss` while avoiding direct
+  melee commitment.
+- If an ally blocks a lane, the turret can score `:cease-fire` instead of
+  friendly-firing blindly.
+
+This demonstrates that the same communication vocabulary and blackboard model
+can support mechanical defenses, not just creatures with ordinary social AI.
+
+## Spell-System Integration
+
+All important world effects in this AI model should be reachable through the
+spell-casting system. AI coordination must not depend on hidden mechanics that
+spells cannot touch.
+
+### Design Constraint
+
+Signals, alarms, beacons, panic effects, rally markers, territorial warnings,
+and similar world-facing effects should be modeled as ordinary world events or
+world effects that spells can:
+
+- create
+- suppress
+- redirect
+- amplify
+- counterfeit
+- consume
+
+### Consequences
+
+- A silence-like spell should be able to suppress sound-channel communication.
+- An illusion spell should be able to create false disturbances or target marks.
+- Fear or confusion effects should be able to alter panic / retreat signaling.
+- Rune wards or machine hacks should be able to block or hijack beacon-style
+  coordination.
+- If an AI behavior depends on a perceivable effect in the world, that effect
+  should be representable in spell/system terms rather than only inside AI code.
+
+### Architectural Benefit
+
+This keeps the game coherent:
+
+- the AI and the player act on the same world substrate,
+- late-game magic and substrate corruption can meaningfully interfere with group
+  behavior,
+- "communication" stays part of the simulation instead of becoming a special
+  unspellable rules channel.

--- a/xsofy/dag.lg
+++ b/xsofy/dag.lg
@@ -17,7 +17,8 @@
   (:require [xsofy.hash :as hash]
             [xsofy.serialize :as ser]
             [xsofy.world :as world]
-            [xsofy.dispatch :as dispatch]))
+            [xsofy.dispatch :as dispatch]
+            [xsofy.det :as det]))
 
 (def default-budget
   "Retention budget: max commits kept on HEAD's chain before GC advances the
@@ -123,6 +124,82 @@
                                :turn (:turn world')})
         (assoc :head id :world world'))))
 
+(defn- clone-terrain
+  [world]
+  (if-let [t (:terrain world)]
+    (assoc world :terrain (aclone t))
+    world))
+
+(defn- start-replay-action
+  "Mirror dispatch/dispatch's seed+log contract for game-state-only replay
+   actions that can't be resolved at the world layer."
+  [world action]
+  (let [turn (:turn world)
+        fresh (clone-terrain world)
+        salted (det/advance fresh [:action turn (dispatch/action-type action)])]
+    (update salted :action-log conj action)))
+
+(defn- held-item-ids
+  [player]
+  (let [inv (or (:inventory player) [])
+        equip (vals (or (:equipment player) {}))]
+    (vec (distinct (concat inv (filter some? equip))))))
+
+(defn- drop-held-item
+  [player item-id]
+  (let [inv (vec (remove #(= item-id %) (or (:inventory player) [])))
+        equip (reduce (fn [m [slot id]]
+                        (if (= item-id id) (dissoc m slot) (assoc m slot id)))
+                      {}
+                      (seq (or (:equipment player) {})))]
+    (assoc player :inventory inv :equipment equip)))
+
+(defn- current-item-entities
+  [world player]
+  (reduce (fn [m id]
+            (if-let [item (get-in world [:entities id])]
+              (assoc m id (assoc item :pos nil))
+              m))
+          {}
+          (held-item-ids player)))
+
+(defn- rewind-world
+  [current-world target-world cord-id]
+  (let [current-player (drop-held-item (get-in current-world [:entities :player]) cord-id)
+        target-pos (:pos (get-in target-world [:entities :player]))
+        current-items (current-item-entities current-world current-player)
+        remove-ids (conj (set (keys current-items)) :player)
+        entities (reduce dissoc (:entities target-world) remove-ids)
+        entities (assoc entities :player (assoc current-player :pos target-pos))
+        entities (reduce (fn [m [id item]] (assoc m id item)) entities current-items)]
+    (assoc target-world
+           :entities entities
+           :turn (:turn current-world)
+           :seed (:seed current-world)
+           :seed-input (:seed-input current-world)
+           :action-log (:action-log current-world))))
+
+(defn- cast-knot
+  [gs action]
+  (let [base (start-replay-action (:world gs) action)
+        pair (world/give-item base :knotted-cord :player)
+        w' (first pair)
+        cord-id (second pair)]
+    (if cord-id
+      (assoc-in (commit gs action w') [:refs cord-id] (:head gs))
+      gs)))
+
+(defn- use-unwind-cord
+  [gs action cord-id]
+  (if-let [target-id (get-in gs [:refs cord-id])]
+    (if-let [target-world (materialize gs target-id)]
+      (let [base (start-replay-action (:world gs) action)
+            rewound (rewind-world base target-world cord-id)
+            branched (commit (assoc gs :head target-id :world target-world) action rewound)]
+        (update branched :refs dissoc cord-id))
+      gs)
+    gs))
+
 (defn dispatch-gs
   "Game-state-level dispatch. Resolve `action` against HEAD's world via the
    world-level dispatch. Replay (state-mutating) actions append a node and
@@ -132,10 +209,27 @@
    turn: forward play never creates unreachable nodes, and re-walking the chain
    every turn would be O(turns²).)"
   [gs action]
-  (let [w' (dispatch/dispatch (:world gs) action)]
-    (if (dispatch/replay-action? action)
-      (commit gs action w')
-      (assoc gs :world w'))))
+  (let [action-type (dispatch/action-type action)]
+    (cond
+      (= action-type :cast-runes)
+      (if (= [:knot] (:runes action))
+        (cast-knot gs action)
+        (let [w' (dispatch/dispatch (:world gs) action)]
+          (commit gs action w')))
+
+      (= action-type :use-item)
+      (let [item-id (:id action)
+            effect (get-in gs [:world :entities item-id :item :effect])]
+        (if (= :unwind effect)
+          (use-unwind-cord gs action item-id)
+          (let [w' (dispatch/dispatch (:world gs) action)]
+            (commit gs action w'))))
+
+      :else
+      (let [w' (dispatch/dispatch (:world gs) action)]
+        (if (dispatch/replay-action? action)
+          (commit gs action w')
+          (assoc gs :world w'))))))
 
 (defn replay-gs
   "Rebuild a game-state by dispatching `actions` on a fresh deterministic world."

--- a/xsofy/entities.lg
+++ b/xsofy/entities.lg
@@ -94,7 +94,8 @@
 (defn consumable [m]
   {:item {:slot :consumable
           :effect (:effect m)
-          :count (or (:count m) 1)}})
+          :count (or (:count m) 1)
+          :stackable (if (contains? m :stackable) (:stackable m) true)}})
 
 (defn item-name [n]
   {:item-name n})
@@ -268,7 +269,7 @@
     ;; no owner = no pickup (avoid resurrecting a dead entity as {:inventory ...})
     (when owner
       ;; stackable consumables
-      (if (and (= slot :consumable) template)
+      (if (and (= slot :consumable) template (not= false (get-in item [:item :stackable])))
         (if-let [existing (find-stack world owner-id template)]
           ;; stack: add incoming count to existing, remove picked-up entity
           (let [old-count (or (get-in world [:entities existing :item :count]) 1)

--- a/xsofy/items.lg
+++ b/xsofy/items.lg
@@ -155,6 +155,12 @@
   (item-desc "A smooth stone etched with a glowing rune. Touch it to learn its meaning.")
   (consumable {:effect :runestone :count 1}))
 
+(defitem knotted-cord
+  (visual "~" [210 190 120])
+  (item-name "knotted cord")
+  (item-desc "A loop of fate-thread tied to a remembered moment. Use it to jump back.")
+  (consumable {:effect :unwind :count 1 :stackable false}))
+
 ;; --- Arrows ---
 
 (defitem arrow

--- a/xsofy/test/dag_test.lg
+++ b/xsofy/test/dag_test.lg
@@ -6,6 +6,15 @@
 
 (defn- gs0 [] (dag/make-game-state (world/make-world 40 20 7)))
 
+(defn- item-with-slot [w slot]
+  (first (filter #(= slot (get-in w [:entities % :item :slot]))
+                 (get-in w [:entities :player :inventory]))))
+
+(defn- cord-ids [w]
+  (vec
+    (filter #(= :knotted-cord (get-in w [:entities % :template]))
+            (get-in w [:entities :player :inventory]))))
+
 ;; --- commit-id is the rolling :seed hash (O(1), already computed per turn) ---
 
 (deftest commit-id-is-the-seed-hash
@@ -63,6 +72,54 @@
     ;; the world update MUST still propagate so the screen toggles — otherwise
     ;; help/inventory/menu screens would silently never open
     (is (= :help (:screen (dag/head-world g1))) "screen toggled into :world")))
+
+(deftest cast-runes-knot-creates-a-cord-and-pins-head
+  (let [g0      (gs0)
+        root    (:head g0)
+        action  {:type :cast-runes :runes [:knot]}
+        g1      (dag/dispatch-gs g0 action)
+        cords   (cord-ids (dag/head-world g1))
+        cord-id (first cords)]
+    (is (= 1 (count cords)) "exactly one knot cord added to inventory")
+    (is (= 2 (count (:nodes g1))) "casting knot records a new commit")
+    (is (not= root (:head g1)) "HEAD advances to the post-knot commit")
+    (is (= root (get-in g1 [:refs cord-id])) "cord ref pins the pre-cast HEAD")
+    (is (= :knotted-cord (get-in (dag/head-world g1) [:entities cord-id :template])))))
+
+(deftest use-knot-cord-restores-world-but-keeps-current-self
+  (let [g0        (gs0)
+        weapon    (item-with-slot (dag/head-world g0) :weapon)
+        knot-gs   (dag/dispatch-gs g0 {:type :cast-runes :runes [:knot]})
+        cord-id   (first (cord-ids (dag/head-world knot-gs)))
+        knot-head (get-in knot-gs [:refs cord-id])
+        root-pos  (get-in (dag/peek knot-gs knot-head) [:entities :player :pos])
+        moved-gs  (-> knot-gs
+                      (dag/dispatch-gs {:type :unequip :id weapon})
+                      (dag/dispatch-gs :up))
+        before    (dag/head-world moved-gs)
+        turn-now  (:turn before)
+        hp-now    (get-in before [:entities :player :body :hp])
+        g'        (dag/dispatch-gs moved-gs {:type :use-item :id cord-id})
+        after     (dag/head-world g')]
+    (is (not= root-pos (get-in before [:entities :player :pos])) "precondition: player moved away from knot")
+    (is (= root-pos (get-in after [:entities :player :pos])) "player snaps back to the knot position")
+    (is (nil? (get-in after [:entities :player :equipment :weapon])) "current equipment state is preserved")
+    (is (some #{weapon} (get-in after [:entities :player :inventory])) "unequipped weapon stays in inventory")
+    (is (= hp-now (get-in after [:entities :player :body :hp])) "current HP is preserved")
+    (is (= turn-now (:turn after)) "global turn counter does not rewind")
+    (is (empty? (cord-ids after)) "the knot cord is consumed")
+    (is (nil? (get-in g' [:refs cord-id])) "the consumed cord ref is removed")
+    (is (= knot-head (dag/parent-id g' (:head g'))) "the unwind commit branches from the knot")))
+
+(deftest use-knot-cord-with-dangling-ref-fizzles-cleanly
+  (let [g0      (dag/dispatch-gs (gs0) {:type :cast-runes :runes [:knot]})
+        cord-id (first (cord-ids (dag/head-world g0)))
+        broken  (assoc-in g0 [:refs cord-id] 424242)
+        g'      (dag/dispatch-gs broken {:type :use-item :id cord-id})
+        after   (dag/head-world g')]
+    (is (= (:head broken) (:head g')) "HEAD stays put when the knot target is gone")
+    (is (some #{cord-id} (get-in after [:entities :player :inventory])) "cord is not consumed on a fizzle")
+    (is (= 424242 (get-in g' [:refs cord-id])) "broken ref stays intact for now")))
 
 ;; --- materialize / peek: regenerate a past world by replay ---
 

--- a/xsofy/world.lg
+++ b/xsofy/world.lg
@@ -1084,8 +1084,10 @@
   (let [item (get-in world [:entities item-id])
         effect (get-in item [:item :effect])
         iname (or (:item-name item)
-                   (name (or (:template item) (:id item))))]
-    (case effect
+                  (when item (name (or (:template item) (:id item)))))]
+    (if-not item
+      world
+      (case effect
       :heal
       (let [heal-amt 15
             player (get-in world [:entities :player])
@@ -1132,7 +1134,7 @@
               (log-msg "The scroll crumbles. All runes are already known."))))
 
       ;; default
-      (log-msg world (str "You can't use the " iname ".")))))
+      (log-msg world (str "You can't use the " iname "."))))))
 
 ;; --- Enchanting ---
 


### PR DESCRIPTION
## Summary
- add a minimal issue #50 time-travel slice where `:knot` creates a non-stackable `knotted-cord` consumable pinned in DAG `:refs`
- make using a cord rewind the world to its knot while preserving the current player self and current global `:turn`
- add DAG coverage for cord creation, rewind behavior, and dangling-ref fizzle behavior

## Test Plan
- `lg xsofy/test/run.lg 2>&1 | rg "knot|Finished running tests|FAIL|ERROR in test|Tests:"`
