### PR TITLE
feat(input): add Ctrl-C as a confirm-quit alias for Esc

### DIFF
--- a/xsofy/input.lg
+++ b/xsofy/input.lg
@@ -28,7 +28,7 @@
    {:action :rune-codex  :category :information :label "Open rune codex"  :keys ["r"] :help-keys ["r"]}
    {:action :messages    :category :information :label "Open message log" :keys ["m"] :help-keys ["m"]}
    {:action :help        :category :information :label "Open keybindings" :keys ["?"] :help-keys ["?"]}
-   {:action :quit        :category :system     :label "Quit"              :keys ["\u001b"] :help-keys ["Esc"]}])
+   {:action :quit        :category :system     :label "Quit"              :keys ["\u001b" (str (char 3))] :help-keys ["Esc" "Ctrl-C"]}])
 
 (defn key-matches? [k binding]
   (some (fn [key] (= k key)) (:keys binding)))

--- a/xsofy/test/input_test.lg
+++ b/xsofy/test/input_test.lg
@@ -1,0 +1,15 @@
+(ns xsofy.test.input-test
+  "Tests for xsofy.input — key→action resolution and help-key labels."
+  (:require [test :refer [deftest is testing]]
+            [xsofy.input :as input]))
+
+(deftest quit-binds-esc-and-ctrl-c
+  (testing "both Esc (0x1b) and Ctrl-C (0x03) resolve to :quit"
+    (is (= :quit (input/parse-key (str (char 27)))))
+    (is (= :quit (input/parse-key (str (char 3))))))
+  (testing "the keybindings screen advertises both, Esc first"
+    (is (= "Esc, Ctrl-C" (input/action-key-labels :quit)))))
+
+(deftest unbound-keys-resolve-to-unknown
+  (testing "a nearby unbound key is :unknown, not a stray action"
+    (is (= :unknown (input/parse-key "Q")))))

--- a/xsofy/test/run.lg
+++ b/xsofy/test/run.lg
@@ -17,6 +17,7 @@
             [xsofy.test.replay-test]
             [xsofy.test.ui-test]
             [xsofy.test.play-test]
-            [xsofy.test.menu-dispatch-test]))
+            [xsofy.test.menu-dispatch-test]
+            [xsofy.test.input-test]))
 
 (run-tests)


### PR DESCRIPTION
## What

Binds **Ctrl-C** to the existing `:quit` action, so it opens the same `y/n`
`:confirm-quit` prompt that `Esc` does. `Esc` is unchanged. Ctrl-C does **not**
quit immediately.

*(This started life as a bare-`q` PR, then an immediate-Ctrl-C experiment. Both
are dropped; see the thread. This is the safe version.)*

## Why this shape

- Quitting a permadeath roguelike should stay deliberate. `Esc` + `y/n` is already
  on the light end for the genre (NetHack confirms, Brogue menus, DCSS makes you
  type), so the default needs no loosening. This only adds a second, familiar key
  into the same safe path.
- `Ctrl-C → "really quit?"` is the NetHack convention, so it matches what genre
  players already reach for.
- Deliberately **not** an immediate/unconfirmed exit. That would reintroduce the
  accidental-run-loss problem that retired bare `q` after the HN launch, just
  behind a different key.

## How it works (the non-obvious bit)

`term/raw-mode!` (golang.org/x/term `MakeRaw`) disables `ISIG`, so Ctrl-C is not a
`SIGINT`. It arrives as the byte `0x03` from `term/read-key`, where it was
previously parsed to `:unknown` and dropped. Binding it is just adding the key to
the map.

The change is one line: `(str (char 3))` joins the `:quit` binding's `:keys`, and
`"Ctrl-C"` joins `:help-keys`. `(str (char 3))` keeps the raw control byte out of
the source. The keybindings screen (`?`) derives labels from `:help-keys`, so it
now shows `Esc, Ctrl-C` for free.

## Tests

`input_test.lg` asserts both `Esc` (`0x1b`) and `Ctrl-C` (`0x03`) resolve to
`:quit`, and that the help label reads `Esc, Ctrl-C`.

## Deferred: configurable keybinds

Per @nnunley, user-remappable keys are the real long-term answer (and @nooga is
right that the binding *data model* is already a plain map). What's missing is a
persistence layer (file native, localStorage in WASM) and a rebind UI. Tracked
separately rather than blocking this.
