### PR TITLE
Publish Homebrew formula to shared tap

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,77 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: read
+
+jobs:
+  homebrew:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Update Homebrew formula
+        env:
+          GH_TOKEN: ${{ secrets.GORELEASER_PAT }}
+          TAG: ${{ github.ref_name }}
+        run: |
+          set -euo pipefail
+
+          version="${TAG#v}"
+          branch="xsofy-${version}"
+          url="https://github.com/nooga/xsofy/archive/refs/tags/${TAG}.tar.gz"
+          sha256="$(curl -fsSL "$url" | sha256sum | awk '{print $1}')"
+
+          git clone "https://x-access-token:${GH_TOKEN}@github.com/nooga/homebrew-tap.git" tap
+          cd tap
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git checkout -B "$branch"
+          mkdir -p Formula
+
+          cat > Formula/xsofy.rb <<RUBY
+          class Xsofy < Formula
+            desc "Roguelike written in let-go where the magic system is Lisp"
+            homepage "https://github.com/nooga/xsofy"
+            url "$url"
+            version "$version"
+            sha256 "$sha256"
+            license "MIT"
+
+            depends_on "let-go"
+
+            def install
+              libexec.install "main.lg", "xsofy"
+              (bin/"xsofy").write <<~EOS
+                #!/bin/sh
+                cd "#{libexec}" || exit 1
+                exec "#{Formula["let-go"].opt_bin}/lg" main.lg "\$@"
+              EOS
+            end
+
+            test do
+              assert_path_exists libexec/"main.lg"
+              assert_path_exists libexec/"xsofy/title.lg"
+            end
+          end
+          RUBY
+
+          git add Formula/xsofy.rb
+          if git diff --cached --quiet; then
+            echo "Formula/xsofy.rb is already current for ${TAG}."
+            exit 0
+          fi
+
+          git commit -m "Update xsofy to ${TAG}"
+          git push --force-with-lease origin "$branch"
+          gh pr create \
+            --repo nooga/homebrew-tap \
+            --head "$branch" \
+            --base main \
+            --title "Update xsofy to ${TAG}" \
+            --body "Updates xsofy formula for ${TAG}."
+          gh pr merge "$branch" --repo nooga/homebrew-tap --squash --admin --delete-branch

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,7 @@ jobs:
             sha256 "$sha256"
             license "MIT"
 
-            depends_on "let-go"
+            depends_on "nooga/tap/let-go"
 
             def install
               libexec.install "main.lg", "xsofy"

--- a/README.md
+++ b/README.md
@@ -18,7 +18,14 @@ Written in [let-go](https://github.com/nooga/let-go) - a Clojure dialect on a Go
 
 If you like how this game looks check out [Brogue](https://sites.google.com/site/broguegame/) - my main inspiration.
 
-## Running
+## Install
+
+```bash
+brew install nooga/tap/xsofy
+xsofy
+```
+
+## Running from source
 
 ```bash
 lg main.lg
@@ -27,6 +34,5 @@ lg main.lg
 Get `lg` from [let-go](https://github.com/nooga/let-go), or:
 
 ```bash
-brew tap nooga/let-go https://github.com/nooga/let-go
-brew install let-go
+brew install nooga/tap/let-go
 ```


### PR DESCRIPTION
## Summary
- add tag release workflow that updates Formula/xsofy.rb in nooga/homebrew-tap
- install xsofy sources with a launcher that runs lg main.lg
- update install docs to use nooga/tap

## Checks
- ruby YAML parse for release workflow
- git diff --check