### PR TITLE
build(wasm): client-owned shell via lg -w -w-shell none

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,8 +18,14 @@ test: ## Run the let-go test suite
 smoke-lg: ## Layer-1 headless runtime smoke (frozen-title guard + render-survives-turns)
 	LG=$(LG) python3 xsofy/test/check_smoke.py
 
-wasm: ## Build the WASM web app into $(DIST) and apply COI + ?seed= patches
-	$(LG) -w $(DIST) main.lg
+wasm: ## Build the WASM web app into $(DIST): client-owned shell + COI/?seed= bridges
+	# Build glue-only (no let-go xterm shell), then inject xsofy's own shell.
+	# Requires a let-go with -w-shell (mparrett/let-go feat/shell-extraction).
+	$(LG) -w $(DIST) -w-shell none main.lg
+	XSOFY_WASM_INDEX=$(DIST)/index.html $(LG) tools/inject_shell.lg
+	# COI bounded-retry and the ?seed=/?replay= env bridge still patch the core
+	# glue: they touch the COI lifecycle and the worker VM env, which the shell
+	# contract (window.LetGoHost) does not cover. Tracked as follow-up seams.
 	XSOFY_WASM_INDEX=$(DIST)/index.html $(LG) tools/patch_wasm_coi.lg
 	XSOFY_WASM_INDEX=$(DIST)/index.html $(LG) tools/patch_wasm_seed.lg
 

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ smoke-lg: ## Layer-1 headless runtime smoke (frozen-title guard + render-survive
 
 wasm: ## Build the WASM web app into $(DIST): client-owned shell + COI/?seed= bridges
 	# Build glue-only (no let-go xterm shell), then inject xsofy's own shell.
-	# Requires a let-go with -w-shell (mparrett/let-go feat/shell-extraction).
+	# Requires a let-go with -w-shell none (nooga/let-go, merged in #245).
 	$(LG) -w $(DIST) -w-shell none main.lg
 	XSOFY_WASM_INDEX=$(DIST)/index.html $(LG) tools/inject_shell.lg
 	# COI bounded-retry and the ?seed=/?replay= env bridge still patch the core

--- a/tools/inject_shell.lg
+++ b/tools/inject_shell.lg
@@ -1,0 +1,42 @@
+(ns tools.inject-shell
+  "Inject xsofy's own shell (tools/xsofy-shell.html) into the lg -w -w-shell none
+   bundle, just before </body>. Replaces patching let-go's xterm shell: instead
+   of reaching into let-go's generated artifact, we append our shell against the
+   public window.LetGoHost contract. Idempotent and fail-closed, like the
+   patch_wasm_* tools."
+  (:require [string :as str]
+            [os]))
+
+(def index-path
+  (let [path (os/getenv "XSOFY_WASM_INDEX")]
+    (if (and path (> (count path) 0)) path "dist/index.html")))
+
+(def shell-path "tools/xsofy-shell.html")
+
+;; Marker that proves our shell is already present (idempotent re-run guard).
+(def shell-marker "xsofy's own client shell")
+
+(defn abort! [m] (println m) (os/exit 1))
+
+(let [html (slurp index-path)]
+  (cond
+    ;; Already injected — nothing to do.
+    (str/includes? html shell-marker)
+    (println (str "shell already injected in " index-path))
+
+    ;; The shell-less bundle must expose LetGoHost and a </body> to inject into.
+    (not (str/includes? html "window.LetGoHost"))
+    (abort! (str "no window.LetGoHost in " index-path
+                 " — build with `lg -w -w-shell none` first"))
+
+    (not (str/includes? html "</body>"))
+    (abort! (str "no </body> in " index-path))
+
+    :else
+    (let [shell (slurp shell-path)
+          parts (vec (str/split html "</body>"))]
+      (when (not= 2 (count parts))
+        (abort! "expected exactly one </body>"))
+      (spit index-path
+            (str (nth parts 0) shell "\n</body>" (nth parts 1)))
+      (println (str "injected " shell-path " into " index-path)))))

--- a/tools/xsofy-shell.html
+++ b/tools/xsofy-shell.html
@@ -2,26 +2,16 @@
      tools/inject_shell.lg. Binds to the let-go runtime only through the public
      window.LetGoHost surface (onReady / onOutput / sendInput / setSize) — no
      patching of let-go's generated glue. xsofy owns the terminal, theme, and
-     font here; in particular the Runic-block glyphs (U+16A0-16FF) get a bundled
-     monospace face instead of the platform's proportional fallback. -->
+     font. (Runic-block glyphs (U+16A0-16FF) fall back to the platform face here;
+     a dedicated rune font is a follow-up PR stacked on this one.) -->
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@xterm/xterm@5.5.0/css/xterm.min.css">
 <script src="https://cdn.jsdelivr.net/npm/@xterm/xterm@5.5.0/lib/xterm.min.js"></script>
 <script src="https://cdn.jsdelivr.net/npm/@xterm/addon-fit@0.10.0/lib/addon-fit.min.js"></script>
-<style>
-  /* The held rune font (Fairfax HD, OFL). Ship fonts/FairfaxHD.woff2 alongside
-     the bundle; under COEP require-corp it must be same-origin (it is). Falls
-     back to a system monospace until the woff2 is added. */
-  @font-face {
-    font-family: "Fairfax HD";
-    src: url("fonts/FairfaxHD.woff2") format("woff2");
-    font-display: swap;
-  }
-</style>
 <script>
 (function () {
   const termEl = document.getElementById('terminal');
   const term = new Terminal({
-    fontFamily: '"Fairfax HD", "DejaVu Sans Mono", "Menlo", monospace',
+    fontFamily: '"DejaVu Sans Mono", "Menlo", monospace',
     fontSize: 16,
     theme: { background: '#0a0e14', foreground: '#d4c5a0', cursor: '#ff6b35' },
     allowProposedApi: true,

--- a/tools/xsofy-shell.html
+++ b/tools/xsofy-shell.html
@@ -1,0 +1,46 @@
+<!-- xsofy's own client shell, injected into the lg -w -w-shell none bundle by
+     tools/inject_shell.lg. Binds to the let-go runtime only through the public
+     window.LetGoHost surface (onReady / onOutput / sendInput / setSize) — no
+     patching of let-go's generated glue. xsofy owns the terminal, theme, and
+     font here; in particular the Runic-block glyphs (U+16A0-16FF) get a bundled
+     monospace face instead of the platform's proportional fallback. -->
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@xterm/xterm@5.5.0/css/xterm.min.css">
+<script src="https://cdn.jsdelivr.net/npm/@xterm/xterm@5.5.0/lib/xterm.min.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/@xterm/addon-fit@0.10.0/lib/addon-fit.min.js"></script>
+<style>
+  /* The held rune font (Fairfax HD, OFL). Ship fonts/FairfaxHD.woff2 alongside
+     the bundle; under COEP require-corp it must be same-origin (it is). Falls
+     back to a system monospace until the woff2 is added. */
+  @font-face {
+    font-family: "Fairfax HD";
+    src: url("fonts/FairfaxHD.woff2") format("woff2");
+    font-display: swap;
+  }
+</style>
+<script>
+(function () {
+  const termEl = document.getElementById('terminal');
+  const term = new Terminal({
+    fontFamily: '"Fairfax HD", "DejaVu Sans Mono", "Menlo", monospace',
+    fontSize: 16,
+    theme: { background: '#0a0e14', foreground: '#d4c5a0', cursor: '#ff6b35' },
+    allowProposedApi: true,
+    convertEol: true,
+  });
+  const fit = new FitAddon.FitAddon();
+  term.loadAddon(fit);
+
+  window.LetGoHost.onReady((mode) => {
+    const s = document.getElementById('status'); if (s) s.style.display = 'none';
+    termEl.style.display = 'block';
+    term.open(termEl); fit.fit(); term.focus();
+    window.LetGoHost.onOutput((x) => term.write(x));
+    if (mode === 'worker') {
+      window.LetGoHost.setSize(term.cols, term.rows);
+      term.onResize(({cols, rows}) => window.LetGoHost.setSize(cols, rows));
+      term.onData((d) => window.LetGoHost.sendInput(d));
+    }
+  });
+  window.addEventListener('resize', () => fit.fit());
+})();
+</script>


### PR DESCRIPTION
## What

Build the WASM bundle glue-only (`lg -w -w-shell none`) and inject xsofy's **own** shell, instead of patching let-go's generated artifact. The shell binds to the runtime through the public `window.LetGoHost` surface (`onReady` / `onOutput` / `sendInput` / `setSize`) — no reaching into let-go's internals. xsofy owns the terminal, theme, and font, ~including~ (deferred; see #79) a bundled monospace face for the Runic-block glyphs (U+16A0–16FF) that previously had no clean home.

- `tools/xsofy-shell.html` — xsofy's xterm shell + `@font-face` hook + `onReady` binding
- `tools/inject_shell.lg` — append the shell before `</body>` (idempotent, fail-closed, same shape as the `patch_wasm_*` tools)
- `Makefile` — `-w-shell none` + the inject step

## Why this is the win

Custom presentation was the motivating case for shell extraction: anything beyond let-go's default shell — embedding fonts, wiring an audio hook, rendering graphics next to the terminal — meant patching the generated artifact. With the client owning the shell, that's all just xsofy's own code now: no patch, and nothing let-go needs to know about.

Validated interactively on **iOS Safari** over a header-capable HTTPS serve: the game renders and takes input in xsofy's own shell, bound only through `LetGoHost.onReady`.

## Scope — honest about what this does NOT remove

This replaces **shell/presentation** patching. Two patches stay, because they touch concerns the shell contract doesn't cover:

- `patch_wasm_coi.lg` — COI bounded-retry for header-less hosts (GitHub Pages). Touches the COI lifecycle; core owns service-worker registration.
- `patch_wasm_seed.lg` — `?seed=`/`?replay=` → worker `go.env`. xsofy reads the seed via `os/getenv` in the **worker** VM; passing env there isn't in the `LetGoHost` surface.

Both now patch let-go's *core glue* (stable markers) rather than its shell. They motivate follow-up seams — an env/config surface and a COI option — tracked on the let-go side, not blocking this.

## Companion

let-go side: [nooga/let-go#245](https://github.com/nooga/let-go/pull/245) (merged) — `feat(wasm): client-owned shell — split lg-host.js, add -w-shell none`. This PR is the client that proves that contract.
