### PR TITLE
fix(tools): reactivate WASM patch scripts against current let-go glue

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -23,15 +23,31 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # Pinned to a let-go commit, not a tag: the client-shell WASM glue these
+      # patch scripts target (markers, worker init protocol) landed after #245
+      # and is not in any release yet (v1.10.0 predates it). Bump to a tagged
+      # release once one ships with it.
+      - name: Check out let-go (pinned)
+        uses: actions/checkout@v4
+        with:
+          repository: nooga/let-go
+          ref: 8087f9979f511a9dc89266c9d84a41af00d98287
+          path: let-go-src
+
       - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.24'
+          go-version: '1.26'
 
       - name: Install let-go
-        run: go install github.com/nooga/let-go@v1.9.0
+        run: go install github.com/nooga/let-go@8087f9979f511a9dc89266c9d84a41af00d98287
 
+      # LETGO_SRC pins the WASM *runtime* to the same commit as the binary above;
+      # without it `lg -w` compiles the runtime from let-go@latest (the old
+      # v1.10.0 glue), which mismatches the binary's worker protocol.
       - name: Build WASM
+        env:
+          LETGO_SRC: ${{ github.workspace }}/let-go-src
         run: let-go -w dist main.lg
 
       - name: Patch COI startup guard

--- a/tools/patch_wasm_coi.lg
+++ b/tools/patch_wasm_coi.lg
@@ -3,7 +3,7 @@
             [os]))
 
 (def index-path
-  (let [path (getenv "XSOFY_WASM_INDEX")]
+  (let [path (os/getenv "XSOFY_WASM_INDEX")]
     (if (and path (> (count path) 0))
       path
       "dist/index.html")))
@@ -12,7 +12,7 @@
   "// --- Cross-origin isolation: prefer server headers, fall back to SW ---")
 
 (def wasm-marker
-  "// --- Inline wasm_exec.js and WASM data ---")
+  "// --- wasm_exec.js + WASM payload ---")
 
 (def wasm-const-marker
   "const WASM_EXEC_JS")

--- a/tools/patch_wasm_seed.lg
+++ b/tools/patch_wasm_seed.lg
@@ -6,7 +6,7 @@
             [os]))
 
 (def index-path
-  (let [path (getenv "XSOFY_WASM_INDEX")]
+  (let [path (os/getenv "XSOFY_WASM_INDEX")]
     (if (and path (> (count path) 0)) path "dist/index.html")))
 
 (defn abort! [m] (println m) (os/exit 1))
@@ -22,22 +22,23 @@
 
 ;; 1) Main thread: read ?seed= / ?replay= and include them in the worker init.
 (def post-before
-  "worker.postMessage({ t: 'init', sab, wasmGzB64: WASM_GZ_B64, wasmExecJS: WASM_EXEC_JS });")
+  "const initMsg = { t: 'init', sab, mode: WASM_MODE, wasmExecJS: WASM_EXEC_JS };")
 (def post-after
   (str "const __lgParams = new URLSearchParams(location.search);\n"
        "  const __lgSeed = __lgParams.get('seed');\n"
        "  const __lgReplay = __lgParams.get('replay');\n"
-       "  worker.postMessage({ t: 'init', sab, wasmGzB64: WASM_GZ_B64, wasmExecJS: WASM_EXEC_JS, seed: __lgSeed, replay: __lgReplay });"))
+       "  const initMsg = { t: 'init', sab, mode: WASM_MODE, wasmExecJS: WASM_EXEC_JS, seed: __lgSeed, replay: __lgReplay };"))
 
 ;; 2) Worker: destructure seed + replay out of the init message.
-(def destr-before "const { sab, wasmGzB64, wasmExecJS } = e.data;")
-(def destr-after  "const { sab, wasmGzB64, wasmExecJS, seed, replay } = e.data;")
+(def destr-before "const { sab, mode, wasmModule, wasmGzB64, wasmExecJS } = e.data;")
+(def destr-after  "const { sab, mode, wasmModule, wasmGzB64, wasmExecJS, seed, replay } = e.data;")
 
-;; 3) Worker: set go.env from seed/replay before running. Anchored on the unique
-;;    "// Run Go WASM" comment so it can't match the main-thread new Go().
-(def go-before  "// Run Go WASM\n      const go = new Go();")
+;; 3) Worker: set go.env from seed/replay before running. Anchored on the worker's
+;;    lowercase eval(wasmExecJS) (the main thread uses eval(WASM_EXEC_JS)), so it
+;;    can't match the main-thread new Go().
+(def go-before  "eval(wasmExecJS);\n      const go = new Go();")
 (def go-after
-  (str "// Run Go WASM\n      const go = new Go();\n"
+  (str "eval(wasmExecJS);\n      const go = new Go();\n"
        "      { const __lgEnv = Object.assign({}, go.env);\n"
        "        if (seed != null && seed !== '') __lgEnv.XSOFY_SEED = String(seed);\n"
        "        if (replay != null && replay !== '') __lgEnv.XSOFY_REPLAY = String(replay);\n"


### PR DESCRIPTION
Follow-up to #78. The post-injection patch scripts it shipped (`patch_wasm_coi.lg`, `patch_wasm_seed.lg`) broke as let-go's generated WASM glue evolved, so `make wasm` aborts right after `inject_shell` on a current-let-go build. This re-couples them.

## What drifted

- **Bare `getenv`.** Both scripts read `(getenv "XSOFY_WASM_INDEX")`; current let-go exposes it as `os/getenv` (`inject_shell.lg`, which still works, already uses that form). First failure point on both.
- **COI splice end-marker.** `patch_wasm_coi.lg` splices its bounded-retry block between two marker comments. The end marker `// --- Inline wasm_exec.js and WASM data ---` is now emitted as `// --- wasm_exec.js + WASM payload ---`.
- **Seed bridge anchors (×3).** `patch_wasm_seed.lg` injects the `?seed=`/`?replay=` → `go.env` bridge at three points that all moved with the new worker init protocol:
  - the init message is now `const initMsg = { ... mode: WASM_MODE ... }` then `worker.postMessage(initMsg)`, not an inline `worker.postMessage({ ... wasmGzB64 ... })`;
  - the worker's destructuring of `e.data` gained `mode` and `wasmModule`;
  - the `// Run Go WASM` comment that uniquely marked the worker's `new Go()` is gone. Re-anchored on the worker's lowercase `eval(wasmExecJS)` — the main thread uses `eval(WASM_EXEC_JS)`, so the two stay distinct.

## Deploy pin

The Pages deploy (`deploy-pages.yml`) installed `let-go@v1.9.0` and built with `let-go -w dist main.lg`, which emits the *old* glue markers — so the reactivated scripts would fail a tag deploy at the COI splice. The marker set the scripts target only exists on let-go `main` (post-#245); no release carries it (v1.10.0 predates it). So the deploy is pinned to commit `8087f99`:

- both the binary (`go install …@<sha>`) and the WASM runtime (`LETGO_SRC`) — without the latter, `lg -w` compiles the runtime from `let-go@latest` (= the old v1.10.0 glue) and mismatches the binary's worker protocol;
- `setup-go` bumped to `1.26` (let-go's `go.mod`).

A commit rather than a tag is a deliberate stopgap until let-go ships a release with the client-shell glue. The deploy still builds the default-xterm bundle — switching it to the client shell + font (#79) is a separate migration. The patch scripts apply to either bundle (they target the shared core glue), confirmed against both.

## Verification

Built against let-go tip with `make wasm`:

- Runs clean through `inject_shell` → `patch_wasm_coi` → `patch_wasm_seed`.
- COI establishes: the terminal fits the viewport (measured 34×127 on a 1280-wide window) instead of the default 80×24 it falls back to when isolation never comes up.
- `?seed=12345` reaches the game — the title screen reports `seed 12345` rather than a random one.

No behavior change to the patched output beyond matching the current glue; the injected COI and seed/replay logic is unchanged.
