### PR TITLE
fix(play): repaint on idle terminal resize, not just on keypress

### DIFF
--- a/xsofy/play.lg
+++ b/xsofy/play.lg
@@ -96,7 +96,13 @@
 (defn play-step
   "The play loop's scan. [:action] dispatches an explicit key (cancelling any
    auto-mode first); [:tick] advances ambient :ui and, if auto-moving, dispatches
-   one auto-step. Both route through play-advance / the deterministic dispatch."
+   one auto-step. Both route through play-advance / the deterministic dispatch.
+
+   An idle [:tick] also repaints when the terminal resized or a :redraw? request
+   is pending. The size poll otherwise lives only in play-advance, which idle
+   ticks skip — so without this a resize stays invisible until the next keypress.
+   The repaint is off the dispatch path (no seed/action-log mutation), so it's
+   replay-safe; :redraw? is the extension point for future force-repaint triggers."
   [state ev]
   (let [[tag payload] ev
         world (:world state)]
@@ -105,8 +111,14 @@
                             (dissoc world :resting :running-dir :autoexploring :auto-target)
                             payload)
       :tick (let [st (update-in state [:ui :frame] (fn [f] (inc (or f 0))))
-                  ak (auto-key-for world)]
-              (if ak (play-advance st world ak) st))
+                  ak (auto-key-for world)
+                  sz (term/size)]
+              (cond
+                ak (play-advance st world ak)
+                (or (:redraw? st) (and sz (not= sz (:size st))))
+                (do (render/render-full world)
+                    (assoc st :size sz :redraw? false))
+                :else st))
       state)))
 
 (defn run-play-loop


### PR DESCRIPTION
Resizing the terminal didn't repaint the play screen — the new layout only showed up on the next keypress. The play loop is poll-based but renders only on input, so a resize sat unhandled until something woke the loop. This makes an idle resize repaint on its own.

## Why it waited for a keypress

The loop runs on a `clock-source` ticking ~30 ms, but the only render path is inside `play-advance`, and an idle `:tick` calls it solely when auto-moving (autoexplore/rest). The terminal-size poll lives in `play-advance` too. So with no input the loop spun every tick doing nothing: a `setSize` from the shell updated `term/size`, but nothing read it until a key arrived and ran `play-advance`, which saw the new size and did a full render. The death screen already polls size per `:tick`; the play loop never did.

## The fix

An idle `:tick` now compares `term/size` to the last size and calls `render-full` when it changed (or when a `:redraw?` flag is set). It runs off the dispatch path — no `dispatch`, no seed advance, no action-log entry — so replay determinism holds (`dispatch.lg` spells out why a resize must not touch the seed). `:redraw?` is there for future force-repaint triggers (theme, font) without re-deriving the size-change check.

## Validation

Counting the bytes the worker renders, so xterm reflow can't mask the result, against the deploy-pinned let-go `8087f99`: from a settled-idle state the worker emits 0 bytes; a resize with no keypress then produces a full ~77 KB frame, repeatably; `origin/main` emits 0 on the same resize. Full suite: 278 tests, no new failures (same 4 pre-existing errors).
