### PR TITLE
fix(shell): debounced re-fit on rotate + visualViewport, not just resize

### DIFF
--- a/tools/xsofy-shell.html
+++ b/tools/xsofy-shell.html
@@ -31,6 +31,16 @@
       term.onData((d) => window.LetGoHost.sendInput(d));
     }
   });
-  window.addEventListener('resize', () => fit.fit());
+  // Debounced so a drag/rotate burst settles on the final size, not an
+  // intermediate one. visualViewport catches the mobile URL-bar show/hide,
+  // which a window 'resize' can miss. Guarded: a resize can fire pre-onReady.
+  let refitPending;
+  function refit() {
+    clearTimeout(refitPending);
+    refitPending = setTimeout(() => { try { fit.fit(); } catch (_) {} }, 100);
+  }
+  window.addEventListener('resize', refit);
+  window.addEventListener('orientationchange', refit);
+  if (window.visualViewport) window.visualViewport.addEventListener('resize', refit);
 })();
 </script>


### PR DESCRIPTION
The shell only re-fit the terminal on a window `resize`. On a phone that's the wrong set of events: rotation and the URL bar sliding in/out don't reliably fire one, and an un-debounced `fit()` thrashes mid-gesture. This adds the events it misses and debounces the fit.

## What `resize` alone misses

`window.addEventListener('resize', () => fit.fit())` — one event, no debounce. The cases that matter on a phone:
- **URL bar show/hide** fires a `visualViewport` resize, which doesn't reliably surface as a window `resize`.
- **Rotation** lands as an `orientationchange`.
- **Drag/pinch** fires a burst of `resize` events; an immediate `fit()` on each thrashes and can settle on an intermediate size.

## The debounced refit

One debounced `refit` (100 ms) on `resize`, `orientationchange`, and `visualViewport` resize. Guarded — a `resize` can fire before `onReady` opens the terminal, where an unguarded `fit()` throws.

## Validation

Headless: shrinking then growing the viewport re-fits the grid (43 → 22 → 47 rows), and the game receives each new size through `term.onResize`; `orientationchange` and `visualViewport` dispatch with no throw; the bundle boots to the title with no console errors.

## Scope

The shell half — it hands the runtime new dimensions via `setSize`. The idle game loop *noticing* them is #85; independent, either lands first.
