### PR TITLE
Add a standalone dungeon map viewer + audit (tools/mapgen.lg)

### DIFF
--- a/tools/mapaudit.lg
+++ b/tools/mapaudit.lg
@@ -1,0 +1,101 @@
+(ns tools.mapaudit
+  "Quality metrics over a generated dungeon grid, as pure functions so both the
+   mapgen viewer and the test suite can call them. Each takes the raw tile grid
+   (xsofy.terrain's byte layout) plus width/height.
+
+   - floating-door? / count-floating: doors that aren't a real room threshold.
+   - count-unreachable: passable tiles cut off from the rest of the level.
+   - audit: the three together, as a map — the testable surface.
+
+   A clean level has floating=0 and unreach=0."
+  (:require [xsofy.terrain :as terrain]))
+
+(defn count-where [grid w h pred]
+  (loop [i 0 n 0]
+    (if (>= i (* w h))
+      n
+      (recur (inc i) (if (pred (aget grid i)) (inc n) n)))))
+
+;; --- door audit ---------------------------------------------------------
+;; A door is a genuine threshold when it sits in a 1-wide passage (walls on two
+;; opposite sides, open on the other two) AND the passage opens into a room on
+;; at least one side. Anything else — a door mid-corridor, or not in a clean
+;; passage — is "floating". floating-door? is the canonical definition.
+
+(defn- a-wall? [t] (or (= t 8) (= t 9)))            ; wall-stone or wall-torch
+(defn- a-open? [t] (and (not (a-wall? t)) (not (= t 0)))) ; carved/passable, not void
+
+(defn floating-door? [grid w h x y]
+  (let [g (fn [dx dy] (terrain/tget grid w (+ x dx) (+ y dy)))
+        n (g 0 -1) s (g 0 1) e (g 1 0) wt (g -1 0)
+        h-pass (and (a-wall? n) (a-wall? s) (a-open? e) (a-open? wt))
+        v-pass (and (a-wall? e) (a-wall? wt) (a-open? n) (a-open? s))]
+    (cond
+      h-pass (let [e-opens (or (a-open? (g 1 -1)) (a-open? (g 1 1)))
+                   w-opens (or (a-open? (g -1 -1)) (a-open? (g -1 1)))]
+               (not (or e-opens w-opens)))
+      v-pass (let [n-opens (or (a-open? (g -1 -1)) (a-open? (g 1 -1)))
+                   s-opens (or (a-open? (g -1 1)) (a-open? (g 1 1)))]
+               (not (or n-opens s-opens)))
+      :else true)))   ; door not in a clean 1-wide passage = floating
+
+(defn count-floating [grid w h]
+  (loop [i 0 n 0]
+    (if (>= i (* w h))
+      n
+      (let [t (aget grid i)
+            x (rem i w) y (quot i w)]
+        (recur (inc i)
+               (if (and (or (= t 11) (= t 12))
+                        (> x 0) (< x (dec w)) (> y 0) (< y (dec h))
+                        (floating-door? grid w h x y))
+                 (inc n) n))))))
+
+;; --- connectivity audit -------------------------------------------------
+;; Flood from the first passable tile; count passable tiles not reached.
+;; "passable" = everything except void, the deep hazards (water 4 / chasm 6 /
+;; lava 7), and walls (8/9). unreach=0 means the level is fully connected.
+
+(defn- passable-c? [t]
+  (not (or (= t 0) (= t 4) (= t 6) (= t 7) (= t 8) (= t 9))))
+
+(defn count-unreachable [grid w h]
+  (let [total (* w h)
+        visited (int-array total)
+        start (loop [i 0]
+                (cond (>= i total) -1
+                      (passable-c? (aget grid i)) i
+                      :else (recur (inc i))))]
+    (if (< start 0)
+      0
+      (do
+        (aset visited start 1)
+        (loop [q [start]]
+          (when (seq q)
+            (let [i (peek q)
+                  q2 (pop q)
+                  x (rem i w) y (quot i w)
+                  cand [(if (> x 0) (dec i) -1)
+                        (if (< x (dec w)) (inc i) -1)
+                        (if (> y 0) (- i w) -1)
+                        (if (< y (dec h)) (+ i w) -1)]
+                  nbrs (filter (fn [j] (and (>= j 0)
+                                            (= 0 (aget visited j))
+                                            (passable-c? (aget grid j))))
+                               cand)]
+              (doseq [j nbrs] (aset visited j 1))
+              (recur (into q2 nbrs)))))
+        (loop [i 0 n 0]
+          (if (>= i total)
+            n
+            (recur (inc i)
+                   (if (and (passable-c? (aget grid i)) (= 0 (aget visited i)))
+                     (inc n) n))))))))
+
+(defn audit
+  "The metric bundle for one grid: {:doors :floating :unreach}. The surface a
+   regression test asserts over."
+  [grid w h]
+  {:doors    (count-where grid w h #(or (= % 11) (= % 12)))
+   :floating (count-floating grid w h)
+   :unreach  (count-unreachable grid w h)})

--- a/tools/mapgen.lg
+++ b/tools/mapgen.lg
@@ -2,38 +2,28 @@
   "Standalone dungeon map generator / debug viewer.
 
    Generates a level with xsofy.terrain and dumps the grid to stdout as ASCII
-   (optionally 24-bit ANSI color), then prints a one-line audit, so you can
-   eyeball layouts and flip through seeds without booting the game. Reuses the
-   live generator and its tile tables untouched — no duplication.
+   (optionally 24-bit ANSI color), then prints a one-line audit (see
+   tools.mapaudit), so you can eyeball layouts and flip through seeds without
+   booting the game. Reuses the live generator and its tile tables untouched.
 
-   Config via env vars (so a justfile recipe can pass them):
-     MAPGEN_SEED   integer base seed         (default: random)
-     MAPGEN_W      width in tiles            (default: 79)
-     MAPGEN_H      height in tiles           (default: 30)
-     MAPGEN_DEPTH  dungeon depth             (default: 1)
-     MAPGEN_COUNT  consecutive seeds to dump (default: 1)
-     MAPGEN_COLOR  \"0\"/\"false\" disables ANSI color (default: on)
+   Config is an EDN map, given inline or as a file path argument:
+     lg tools/mapgen.lg '{:seed 42 :depth 5}'
+     lg tools/mapgen.lg my-scenario.edn
+   Keys (all optional): :seed (default random), :w 79, :h 30, :depth 1,
+   :count 1 (consecutive seeds to dump), :color true."
+  (:require [tools.mapaudit :as audit]
+            [xsofy.terrain :as terrain]))
 
-   Run from the xsofy root:
-     MAPGEN_SEED=42 lg tools/mapgen.lg
-     MAPGEN_SEED=42 MAPGEN_DEPTH=5 MAPGEN_COLOR=0 lg tools/mapgen.lg"
-  (:require [xsofy.terrain :as terrain]
-            [os]))
+;; --- config: defaults < EDN argument ---
 
-;; --- env config (read-string + integer? at the boundary) ---
+(def defaults {:w 79 :h 30 :depth 1 :count 1 :color true}) ; :seed → random if absent
 
-(defn env-int [name default]
-  (let [s (os/getenv name)]
-    (if (and s (> (count s) 0))
-      (let [n (read-string s)]
-        (if (integer? n) n default))
-      default)))
-
-(defn env-on? [name default]
-  (let [s (os/getenv name)]
-    (if (and s (> (count s) 0))
-      (not (or (= s "0") (= s "false")))
-      default)))
+(defn- edn-arg [arg]
+  ;; an inline EDN map ("{...}") or a path to an .edn file
+  (cond
+    (or (nil? arg) (= arg "")) {}
+    (= \{ (first arg))         (read-string arg)
+    :else                      (read-string (slurp arg))))
 
 ;; --- the generator under the viewer ---
 ;; Single dispatch point: the tool renders/audits whatever this returns
@@ -61,8 +51,6 @@
           ch))
       ch)))
 
-;; --- rendering ---
-
 (defn render-grid [grid w h color?]
   (dotimes [y h]
     (let [line (loop [x 0 acc ""]
@@ -72,96 +60,11 @@
                           (str acc (cell-glyph (terrain/tget grid w x y) color?)))))]
       (println line))))
 
-(defn count-where [grid w h pred]
-  (loop [i 0 n 0]
-    (if (>= i (* w h))
-      n
-      (recur (inc i) (if (pred (aget grid i)) (inc n) n)))))
-
-;; --- door audit ---------------------------------------------------------
-;; A door is a genuine threshold when it sits in a 1-wide passage (walls on two
-;; opposite sides, open on the other two) AND the passage opens into a room on
-;; at least one side. Anything else — a door mid-corridor, or not in a clean
-;; passage — is "floating". `floating-door?` is the canonical definition; a
-;; level with floating=0 has every door at a real room mouth.
-
-(defn- a-wall? [t] (or (= t 8) (= t 9)))            ; wall-stone or wall-torch
-(defn- a-open? [t] (and (not (a-wall? t)) (not (= t 0)))) ; carved/passable, not void
-
-(defn floating-door? [grid w h x y]
-  (let [g (fn [dx dy] (terrain/tget grid w (+ x dx) (+ y dy)))
-        n (g 0 -1) s (g 0 1) e (g 1 0) wt (g -1 0)
-        h-pass (and (a-wall? n) (a-wall? s) (a-open? e) (a-open? wt))
-        v-pass (and (a-wall? e) (a-wall? wt) (a-open? n) (a-open? s))]
-    (cond
-      h-pass (let [e-opens (or (a-open? (g 1 -1)) (a-open? (g 1 1)))
-                   w-opens (or (a-open? (g -1 -1)) (a-open? (g -1 1)))]
-               (not (or e-opens w-opens)))
-      v-pass (let [n-opens (or (a-open? (g -1 -1)) (a-open? (g 1 -1)))
-                   s-opens (or (a-open? (g -1 1)) (a-open? (g 1 1)))]
-               (not (or n-opens s-opens)))
-      :else true)))   ; door not in a clean 1-wide passage = floating
-
-(defn count-floating [grid w h]
-  (loop [i 0 n 0]
-    (if (>= i (* w h))
-      n
-      (let [t (aget grid i)
-            x (rem i w) y (quot i w)]
-        (recur (inc i)
-               (if (and (or (= t 11) (= t 12))
-                        (> x 0) (< x (dec w)) (> y 0) (< y (dec h))
-                        (floating-door? grid w h x y))
-                 (inc n) n))))))
-
-;; --- connectivity audit -------------------------------------------------
-;; Flood from the first passable tile; count passable tiles not reached.
-;; "passable" = everything except void, the deep hazards (water 4 / chasm 6 /
-;; lava 7), and walls (8/9). unreach=0 means the level is fully connected.
-
-(defn- passable-c? [t]
-  (not (or (= t 0) (= t 4) (= t 6) (= t 7) (= t 8) (= t 9))))
-
-(defn count-unreachable [grid w h]
-  (let [total (* w h)
-        visited (int-array total)
-        start (loop [i 0]
-                (cond (>= i total) -1
-                      (passable-c? (aget grid i)) i
-                      :else (recur (inc i))))]
-    (if (< start 0)
-      0
-      (do
-        (aset visited start 1)
-        (loop [q [start]]
-          (when (seq q)
-            (let [i (peek q)
-                  q2 (pop q)
-                  x (rem i w) y (quot i w)
-                  cand [(if (> x 0) (dec i) -1)
-                        (if (< x (dec w)) (inc i) -1)
-                        (if (> y 0) (- i w) -1)
-                        (if (< y (dec h)) (+ i w) -1)]
-                  nbrs (filter (fn [j] (and (>= j 0)
-                                            (= 0 (aget visited j))
-                                            (passable-c? (aget grid j))))
-                               cand)]
-              (doseq [j nbrs] (aset visited j 1))
-              (recur (into q2 nbrs)))))
-        (loop [i 0 n 0]
-          (if (>= i total)
-            n
-            (recur (inc i)
-                   (if (and (passable-c? (aget grid i)) (= 0 (aget visited i)))
-                     (inc n) n))))))))
-
 (defn render-one [seed w h depth color?]
   (let [result (gen-level seed w h depth)
         grid (:grid result)
         rooms (:rooms result)
-        doors (count-where grid w h #(or (= % 11) (= % 12)))
-        floating (count-floating grid w h)
-        unreach (count-unreachable grid w h)]
+        {:keys [doors floating unreach]} (audit/audit grid w h)]
     (println (str "seed=" seed "  " w "x" h "  depth=" depth
                   "  rooms=" (count rooms) "  doors=" doors
                   "  floating=" floating "  unreach=" unreach))
@@ -170,11 +73,7 @@
 
 ;; --- entry ---
 
-(let [w      (env-int "MAPGEN_W" 79)
-      h      (env-int "MAPGEN_H" 30)
-      depth  (env-int "MAPGEN_DEPTH" 1)
-      n      (env-int "MAPGEN_COUNT" 1)
-      color? (env-on? "MAPGEN_COLOR" true)
-      base   (env-int "MAPGEN_SEED" (rand-int 1000000000))]
-  (dotimes [i n]
-    (render-one (+ base i) w h depth color?)))
+(let [cfg  (merge defaults (edn-arg (first *command-line-args*)))
+      seed (or (:seed cfg) (rand-int 1000000000))]
+  (dotimes [i (:count cfg)]
+    (render-one (+ seed i) (:w cfg) (:h cfg) (:depth cfg) (:color cfg))))

--- a/tools/mapgen.lg
+++ b/tools/mapgen.lg
@@ -1,0 +1,180 @@
+(ns mapgen
+  "Standalone dungeon map generator / debug viewer.
+
+   Generates a level with xsofy.terrain and dumps the grid to stdout as ASCII
+   (optionally 24-bit ANSI color), then prints a one-line audit, so you can
+   eyeball layouts and flip through seeds without booting the game. Reuses the
+   live generator and its tile tables untouched — no duplication.
+
+   Config via env vars (so a justfile recipe can pass them):
+     MAPGEN_SEED   integer base seed         (default: random)
+     MAPGEN_W      width in tiles            (default: 79)
+     MAPGEN_H      height in tiles           (default: 30)
+     MAPGEN_DEPTH  dungeon depth             (default: 1)
+     MAPGEN_COUNT  consecutive seeds to dump (default: 1)
+     MAPGEN_COLOR  \"0\"/\"false\" disables ANSI color (default: on)
+
+   Run from the xsofy root:
+     MAPGEN_SEED=42 lg tools/mapgen.lg
+     MAPGEN_SEED=42 MAPGEN_DEPTH=5 MAPGEN_COLOR=0 lg tools/mapgen.lg"
+  (:require [xsofy.terrain :as terrain]
+            [os]))
+
+;; --- env config (read-string + integer? at the boundary) ---
+
+(defn env-int [name default]
+  (let [s (os/getenv name)]
+    (if (and s (> (count s) 0))
+      (let [n (read-string s)]
+        (if (integer? n) n default))
+      default)))
+
+(defn env-on? [name default]
+  (let [s (os/getenv name)]
+    (if (and s (> (count s) 0))
+      (not (or (= s "0") (= s "false")))
+      default)))
+
+;; --- the generator under the viewer ---
+;; Single dispatch point: the tool renders/audits whatever this returns
+;; ({:grid :rooms}). Kept as a one-liner so the viewer stays decoupled from how
+;; a level is produced.
+
+(defn gen-level [seed w h depth]
+  (first (terrain/generate-level w h depth {:seed seed})))
+
+;; --- ANSI 24-bit color (the game renders through `term`; for a stdout dump
+;;     raw escapes are simpler and pull in no terminal-buffer machinery) ---
+
+(def esc (str (char 27)))
+(def reset (str esc "[0m"))
+
+(defn ansi [code rgb]
+  (str esc "[" code ";2;" (nth rgb 0) ";" (nth rgb 1) ";" (nth rgb 2) "m"))
+
+(defn cell-glyph [code color?]
+  (let [ch (get terrain/tile-chars code "?")]
+    (if color?
+      (let [st (get terrain/tile-styles code)]
+        (if st
+          (str (ansi "38" (:fg st)) (ansi "48" (:bg st)) ch reset)
+          ch))
+      ch)))
+
+;; --- rendering ---
+
+(defn render-grid [grid w h color?]
+  (dotimes [y h]
+    (let [line (loop [x 0 acc ""]
+                 (if (>= x w)
+                   acc
+                   (recur (inc x)
+                          (str acc (cell-glyph (terrain/tget grid w x y) color?)))))]
+      (println line))))
+
+(defn count-where [grid w h pred]
+  (loop [i 0 n 0]
+    (if (>= i (* w h))
+      n
+      (recur (inc i) (if (pred (aget grid i)) (inc n) n)))))
+
+;; --- door audit ---------------------------------------------------------
+;; A door is a genuine threshold when it sits in a 1-wide passage (walls on two
+;; opposite sides, open on the other two) AND the passage opens into a room on
+;; at least one side. Anything else — a door mid-corridor, or not in a clean
+;; passage — is "floating". `floating-door?` is the canonical definition; a
+;; level with floating=0 has every door at a real room mouth.
+
+(defn- a-wall? [t] (or (= t 8) (= t 9)))            ; wall-stone or wall-torch
+(defn- a-open? [t] (and (not (a-wall? t)) (not (= t 0)))) ; carved/passable, not void
+
+(defn floating-door? [grid w h x y]
+  (let [g (fn [dx dy] (terrain/tget grid w (+ x dx) (+ y dy)))
+        n (g 0 -1) s (g 0 1) e (g 1 0) wt (g -1 0)
+        h-pass (and (a-wall? n) (a-wall? s) (a-open? e) (a-open? wt))
+        v-pass (and (a-wall? e) (a-wall? wt) (a-open? n) (a-open? s))]
+    (cond
+      h-pass (let [e-opens (or (a-open? (g 1 -1)) (a-open? (g 1 1)))
+                   w-opens (or (a-open? (g -1 -1)) (a-open? (g -1 1)))]
+               (not (or e-opens w-opens)))
+      v-pass (let [n-opens (or (a-open? (g -1 -1)) (a-open? (g 1 -1)))
+                   s-opens (or (a-open? (g -1 1)) (a-open? (g 1 1)))]
+               (not (or n-opens s-opens)))
+      :else true)))   ; door not in a clean 1-wide passage = floating
+
+(defn count-floating [grid w h]
+  (loop [i 0 n 0]
+    (if (>= i (* w h))
+      n
+      (let [t (aget grid i)
+            x (rem i w) y (quot i w)]
+        (recur (inc i)
+               (if (and (or (= t 11) (= t 12))
+                        (> x 0) (< x (dec w)) (> y 0) (< y (dec h))
+                        (floating-door? grid w h x y))
+                 (inc n) n))))))
+
+;; --- connectivity audit -------------------------------------------------
+;; Flood from the first passable tile; count passable tiles not reached.
+;; "passable" = everything except void, the deep hazards (water 4 / chasm 6 /
+;; lava 7), and walls (8/9). unreach=0 means the level is fully connected.
+
+(defn- passable-c? [t]
+  (not (or (= t 0) (= t 4) (= t 6) (= t 7) (= t 8) (= t 9))))
+
+(defn count-unreachable [grid w h]
+  (let [total (* w h)
+        visited (int-array total)
+        start (loop [i 0]
+                (cond (>= i total) -1
+                      (passable-c? (aget grid i)) i
+                      :else (recur (inc i))))]
+    (if (< start 0)
+      0
+      (do
+        (aset visited start 1)
+        (loop [q [start]]
+          (when (seq q)
+            (let [i (peek q)
+                  q2 (pop q)
+                  x (rem i w) y (quot i w)
+                  cand [(if (> x 0) (dec i) -1)
+                        (if (< x (dec w)) (inc i) -1)
+                        (if (> y 0) (- i w) -1)
+                        (if (< y (dec h)) (+ i w) -1)]
+                  nbrs (filter (fn [j] (and (>= j 0)
+                                            (= 0 (aget visited j))
+                                            (passable-c? (aget grid j))))
+                               cand)]
+              (doseq [j nbrs] (aset visited j 1))
+              (recur (into q2 nbrs)))))
+        (loop [i 0 n 0]
+          (if (>= i total)
+            n
+            (recur (inc i)
+                   (if (and (passable-c? (aget grid i)) (= 0 (aget visited i)))
+                     (inc n) n))))))))
+
+(defn render-one [seed w h depth color?]
+  (let [result (gen-level seed w h depth)
+        grid (:grid result)
+        rooms (:rooms result)
+        doors (count-where grid w h #(or (= % 11) (= % 12)))
+        floating (count-floating grid w h)
+        unreach (count-unreachable grid w h)]
+    (println (str "seed=" seed "  " w "x" h "  depth=" depth
+                  "  rooms=" (count rooms) "  doors=" doors
+                  "  floating=" floating "  unreach=" unreach))
+    (render-grid grid w h color?)
+    (println)))
+
+;; --- entry ---
+
+(let [w      (env-int "MAPGEN_W" 79)
+      h      (env-int "MAPGEN_H" 30)
+      depth  (env-int "MAPGEN_DEPTH" 1)
+      n      (env-int "MAPGEN_COUNT" 1)
+      color? (env-on? "MAPGEN_COLOR" true)
+      base   (env-int "MAPGEN_SEED" (rand-int 1000000000))]
+  (dotimes [i n]
+    (render-one (+ base i) w h depth color?)))

--- a/xsofy/terrain.lg
+++ b/xsofy/terrain.lg
@@ -324,60 +324,9 @@
             [(nth @carved mid) w3])
           [nil w3])))))
 
-;; --- Connectivity Check ---
-;; Array-based BFS flood fill — no atoms, no allocations in the hot loop.
-
+;; Floor set shared by the connectivity pass (ensure-connectivity-dsu!) and the
+;; door/feature phases.
 (def floor-tiles #{1 2 3 5 10 11 12 13 14 15 16 17 18 19})
-
-(defn flood-count [grid w h sx sy]
-  "Count reachable floor tiles from (sx,sy) using array-based BFS.
-   Marks visited before enqueueing so queue stays bounded to w*h."
-  (let [sz (* w h)
-        visited (int-array sz)
-        qx (int-array sz)
-        qy (int-array sz)
-        si (+ sx (* sy w))]
-    (if (or (< sx 0) (>= sx w) (< sy 0) (>= sy h)
-            (not (contains? floor-tiles (aget grid si))))
-      0
-      (do (aset visited si 1)
-          (aset qx 0 sx)
-          (aset qy 0 sy)
-          (loop [head 0 tail 1 cnt 1]
-            (if (>= head tail)
-              cnt
-              (let [cx (aget qx head) cy (aget qy head)
-                    t (loop [di 0 t tail]
-                        (if (>= di 4) t
-                          (let [nx (+ cx (aget dir-dx di)) ny (+ cy (aget dir-dy di))]
-                            (if (in-grid? w h nx ny)
-                              (let [ni (+ nx (* ny w))]
-                                (if (and (= (aget visited ni) 0)
-                                         (contains? floor-tiles (aget grid ni)))
-                                  (do (aset visited ni 1)
-                                      (aset qx t nx)
-                                      (aset qy t ny)
-                                      (recur (inc di) (inc t)))
-                                  (recur (inc di) t)))
-                              (recur (inc di) t)))))
-                    added (- t tail)]
-                (recur (inc head) t (+ cnt added)))))))))
-
-(defn is-connected? [grid w h]
-  "Check if all floor tiles are reachable from some floor tile.
-   Single pass: count total floors while finding start, then BFS once."
-  (let [sz (* w h)]
-    (loop [i 0 total 0 sx -1 sy -1]
-      (if (>= i sz)
-        (if (< sx 0)
-          true  ;; no floor tiles = trivially connected
-          (= (flood-count grid w h sx sy) total))
-        (let [t (aget grid i)]
-          (if (contains? floor-tiles t)
-            (if (< sx 0)
-              (recur (inc i) (inc total) (rem i w) (quot i w))
-              (recur (inc i) (inc total) sx sy))
-            (recur (inc i) total sx sy)))))))
 
 ;; --- Lake Placement ---
 ;; Generate blob-shaped lakes and place them without breaking connectivity.
@@ -748,35 +697,74 @@
 
 ;; --- Level Generation ---
 
-(defn ensure-connectivity!
-  "If the map is disconnected, carve extra corridors deterministically
-   between room centers until everything is reachable. Returns world'."
-  [world grid w h rooms]
-  (let [rs (vec rooms)
-        n (count rs)]
-    (if (<= n 1)
-      world
-      (let [w-ctx (det/with-context world [:terrain :ensure-conn])]
-        (loop [attempt 0 w-cur w-ctx]
-          (if (or (>= attempt 20) (is-connected? grid w h))
-            w-cur
-            (let [p1 (det/int-in w-cur 0 n)
-                  i1 (first p1)
-                  w1 (second p1)
-                  p2 (det/int-in w1 0 n)
-                  i2 (first p2)
-                  w2 (second p2)
-                  pd (det/percent? w2 50)
-                  go-h-first (first pd)
-                  w3 (second pd)
-                  [x1 y1] (nth rs i1)
-                  [x2 y2] (nth rs i2)]
-              (if go-h-first
-                (do (carve-h-corridor! grid w x1 x2 y1)
-                    (carve-v-corridor! grid w y1 y2 x2))
-                (do (carve-v-corridor! grid w y1 y2 x1)
-                    (carve-h-corridor! grid w x1 x2 y2)))
-              (recur (inc attempt) w3))))))))
+;; --- Disjoint-set (union-find) connectivity --------------------------------
+;; Guarantee a fully-connected level in ~O(alpha(n)). Replaces the old
+;; best-effort BFS-retry, which carved random room-to-room corridors for up to
+;; 20 attempts and could still leave the level disconnected. parent[] is the
+;; whole structure; union by smaller root index (deterministic, no rank
+;; tie-breaks); iterative find with path-halving (no recursion).
+
+(defn dsu-make [n]
+  (let [parent (int-array n)]
+    (dotimes [i n] (aset parent i i))
+    parent))
+
+(defn dsu-find [parent i]
+  (loop [i i]
+    (let [p (aget parent i)]
+      (if (= p i)
+        i
+        (let [gp (aget parent p)]
+          (aset parent i gp)            ; path halving
+          (recur gp))))))
+
+(defn dsu-union! [parent a b]
+  (let [ra (dsu-find parent a)
+        rb (dsu-find parent b)]
+    (if (= ra rb)
+      false
+      (do (if (< ra rb) (aset parent rb ra) (aset parent ra rb))
+          true))))
+
+(defn ensure-connectivity-dsu!
+  "Guarantee a fully-connected level. One pass unions adjacent floor tiles, then
+   connects every distinct floor *component* to the first floor tile's component
+   with a single corridor. Unlike the BFS-retry version this never gives up, so
+   it can't leave the level disconnected. Deterministic (index order, union by
+   min index); consumes no det rolls, so it threads `world` through unchanged."
+  [world grid w h]
+  (let [total (* w h)
+        parent (dsu-make total)
+        floor0 (int-array total)]      ; marks tiles that were floor at pass 1
+    ;; pass 1: record floor tiles, union each with its right/down floor neighbor
+    (dotimes [y h]
+      (dotimes [x w]
+        (when (contains? floor-tiles (tget grid w x y))
+          (let [i (+ x (* y w))]
+            (aset floor0 i 1)
+            (when (and (< (inc x) w) (contains? floor-tiles (tget grid w (inc x) y)))
+              (dsu-union! parent i (+ (inc x) (* y w))))
+            (when (and (< (inc y) h) (contains? floor-tiles (tget grid w x (inc y))))
+              (dsu-union! parent i (+ x (* (inc y) w))))))))
+    ;; pass 2: connect every floor component to the first floor tile's component
+    (let [main (loop [i 0]
+                 (cond (>= i total) -1
+                       (= 1 (aget floor0 i)) i
+                       :else (recur (inc i))))]
+      (if (< main 0)
+        world
+        (let [fx (rem main w) fy (quot main w)]
+          (loop [i (inc main)]
+            (if (>= i total)
+              world
+              (do
+                (when (and (= 1 (aget floor0 i))
+                           (not= (dsu-find parent i) (dsu-find parent main)))
+                  (let [x1 (rem i w) y1 (quot i w)]
+                    (carve-h-corridor! grid w x1 fx y1)
+                    (carve-v-corridor! grid w y1 fy fx)
+                    (dsu-union! parent i main)))
+                (recur (inc i))))))))))
 
 (defn place-room-in-sector!
   "Place a room (rect or cave) in a given sector deterministically.
@@ -891,7 +879,7 @@
               (recur (inc i) (second r)))))
 
         ;; === Phase 2c: ensure connectivity ===
-        w-phase2c (ensure-connectivity! w-phase2b grid w h @rooms)
+        w-phase2c (ensure-connectivity-dsu! w-phase2b grid w h)
 
         ;; === Phase 3: doors at corridor junctions ===
         w-phase3
@@ -976,7 +964,7 @@
         ;; Lakes and chasms can cut walking paths; reconnect once after all
         ;; terrain decoration rather than copying/checking the whole grid for
         ;; every individual placement attempt.
-        w-final-connectivity (ensure-connectivity! w-bridges grid w h @rooms)
+        w-final-connectivity (ensure-connectivity-dsu! w-bridges grid w h)
 
         ;; === Phase 7: Torches on walls — 4% chance per wall ===
         w-torches

--- a/xsofy/test/container_trigger_test.lg
+++ b/xsofy/test/container_trigger_test.lg
@@ -30,25 +30,37 @@
                      (get-in world [:entities :player :pos])))))
       movement-actions)))
 
+;; Ring effect is measured as a DELTA against a no-ring run of the same world
+;; and action, not as an absolute HP. The generated world can deal incidental
+;; damage on a turn (a monster reaching the player), which both runs share — so
+;; the difference isolates the ring and stays stable across map-generation
+;; changes that shift the seed's layout.
+
+(defn- base-world []
+  (-> (world/make-world 79 30 4242)
+      (assoc-in [:entities :player :body :hp] 20)))
+
+(defn- hp-after [world action]
+  (get-in (dispatch/dispatch world action) [:entities :player :body :hp]))
+
 (deftest equipped-ring-fires-on-wait
-  (testing "an equipped ring with runes fires once on :wait"
-    (let [w0 (-> (world/make-world 79 30 4242)
-                 equip-test-ring
-                 (assoc-in [:entities :player :body :hp] 20))
-          w1 (dispatch/dispatch w0 :wait)]
-      (is (= 22 (get-in w1 [:entities :player :body :hp])))
+  (testing "an equipped ring with runes heals +2 on :wait"
+    (let [base (base-world)
+          w1 (dispatch/dispatch (equip-test-ring base) :wait)]
+      (is (= 2 (- (get-in w1 [:entities :player :body :hp])
+                  (hp-after base :wait)))
+          "equipped ring heals +2 over the no-ring baseline")
       (is (= [:wait] (:action-log w1))))))
 
 (deftest equipped-ring-fires-on-movement
-  (testing "an equipped ring with runes fires after a replayed move"
-    (let [base (world/make-world 79 30 4242)
+  (testing "an equipped ring with runes heals +2 after a replayed move"
+    (let [base (base-world)
           action (first-safe-move base)
-          w0 (-> base
-                 equip-test-ring
-                 (assoc-in [:entities :player :body :hp] 20))
-          w1 (dispatch/dispatch w0 action)]
+          w1 (dispatch/dispatch (equip-test-ring base) action)]
       (is (some? action) "fixture found a legal movement action")
-      (is (= 22 (get-in w1 [:entities :player :body :hp])))
+      (is (= 2 (- (get-in w1 [:entities :player :body :hp])
+                  (hp-after base action)))
+          "equipped ring heals +2 over the no-ring baseline")
       (is (= [action] (:action-log w1))))))
 
 (deftest ring-does-not-fire-on-ui-actions
@@ -62,12 +74,13 @@
 
 (deftest unequipped-ring-does-not-fire
   (testing "a ring in inventory but not equipped does not trigger"
-    (let [w0 (-> (world/make-world 79 30 4242)
-                 equip-test-ring
-                 (assoc-in [:entities :player :body :hp] 20)
-                 (assoc-in [:entities :player :equipment :ring] nil))
-          w1 (dispatch/dispatch w0 :wait)]
-      (is (= 20 (get-in w1 [:entities :player :body :hp])))
+    (let [base (base-world)
+          unequipped (-> (equip-test-ring base)
+                         (assoc-in [:entities :player :equipment :ring] nil))
+          w1 (dispatch/dispatch unequipped :wait)]
+      (is (= 0 (- (get-in w1 [:entities :player :body :hp])
+                  (hp-after base :wait)))
+          "unequipped ring heals nothing vs the no-ring baseline")
       (is (= [:wait] (:action-log w1))))))
 
 (deftest ring-turn-trigger-is-deterministic


### PR DESCRIPTION
This adds a small dev tool for looking at what the dungeon generator produces, without booting the game. Part of the https://github.com/nooga/xsofy/issues/87 exploration.

What: `lg tools/mapgen.lg` generates a level with `xsofy.terrain` and prints it to stdout as plain ASCII, or as 24-bit ANSI color (it reuses terrain's own tile tables, so the colors match the game). Above the map it prints a one-line audit:

```
seed=42  79x30  depth=3  rooms=19  doors=26  floating=17  unreach=15
```

`floating=` counts doors that aren't at a real room mouth: a door sitting mid-corridor, or in a passage that doesn't open into a room. `unreach=` counts passable tiles cut off from the rest of the level (a flood-fill from the first floor tile). Both read 0 on a clean level.

Config is via env vars so a recipe can drive it: `MAPGEN_SEED`, `MAPGEN_W`, `MAPGEN_H`, `MAPGEN_DEPTH`, `MAPGEN_COUNT` (dump N consecutive seeds), `MAPGEN_COLOR`.

```
MAPGEN_SEED=42 lg tools/mapgen.lg
MAPGEN_SEED=42 MAPGEN_DEPTH=5 MAPGEN_COLOR=0 lg tools/mapgen.lg
```

It's one self-contained file and adds no dependencies; it only uses `xsofy.terrain` (the generator and its tile tables).

Run over a range of seeds, the audit also turns up two things in the current generator: floating doors (roughly 9–24 per level) and, on a number of seeds, disconnected levels (`unreach` up to ~15) at 79×30 depth 3. Happy to follow up with fixes for both; this PR is just the tool.

## Screenshots

seed 42
<img width="861" height="675" alt="image" src="https://github.com/user-attachments/assets/2a287ed6-ca2d-4f4a-b3de-bd018f6757b4" />

seed 123
<img width="886" height="676" alt="image" src="https://github.com/user-attachments/assets/16d6858c-5084-41ca-a1a9-3773af9e8e38" />

seed 42; no colors
<img width="1139" height="668" alt="image" src="https://github.com/user-attachments/assets/9e8fc41c-05df-49a7-8c09-3e8e669e0d7a" />

