### PR TITLE
Guarantee level connectivity with union-find

### DIFF
--- a/xsofy/terrain.lg
+++ b/xsofy/terrain.lg
@@ -324,60 +324,9 @@
             [(nth @carved mid) w3])
           [nil w3])))))
 
-;; --- Connectivity Check ---
-;; Array-based BFS flood fill — no atoms, no allocations in the hot loop.
-
+;; Floor set shared by the connectivity pass (ensure-connectivity-dsu!) and the
+;; door/feature phases.
 (def floor-tiles #{1 2 3 5 10 11 12 13 14 15 16 17 18 19})
-
-(defn flood-count [grid w h sx sy]
-  "Count reachable floor tiles from (sx,sy) using array-based BFS.
-   Marks visited before enqueueing so queue stays bounded to w*h."
-  (let [sz (* w h)
-        visited (int-array sz)
-        qx (int-array sz)
-        qy (int-array sz)
-        si (+ sx (* sy w))]
-    (if (or (< sx 0) (>= sx w) (< sy 0) (>= sy h)
-            (not (contains? floor-tiles (aget grid si))))
-      0
-      (do (aset visited si 1)
-          (aset qx 0 sx)
-          (aset qy 0 sy)
-          (loop [head 0 tail 1 cnt 1]
-            (if (>= head tail)
-              cnt
-              (let [cx (aget qx head) cy (aget qy head)
-                    t (loop [di 0 t tail]
-                        (if (>= di 4) t
-                          (let [nx (+ cx (aget dir-dx di)) ny (+ cy (aget dir-dy di))]
-                            (if (in-grid? w h nx ny)
-                              (let [ni (+ nx (* ny w))]
-                                (if (and (= (aget visited ni) 0)
-                                         (contains? floor-tiles (aget grid ni)))
-                                  (do (aset visited ni 1)
-                                      (aset qx t nx)
-                                      (aset qy t ny)
-                                      (recur (inc di) (inc t)))
-                                  (recur (inc di) t)))
-                              (recur (inc di) t)))))
-                    added (- t tail)]
-                (recur (inc head) t (+ cnt added)))))))))
-
-(defn is-connected? [grid w h]
-  "Check if all floor tiles are reachable from some floor tile.
-   Single pass: count total floors while finding start, then BFS once."
-  (let [sz (* w h)]
-    (loop [i 0 total 0 sx -1 sy -1]
-      (if (>= i sz)
-        (if (< sx 0)
-          true  ;; no floor tiles = trivially connected
-          (= (flood-count grid w h sx sy) total))
-        (let [t (aget grid i)]
-          (if (contains? floor-tiles t)
-            (if (< sx 0)
-              (recur (inc i) (inc total) (rem i w) (quot i w))
-              (recur (inc i) (inc total) sx sy))
-            (recur (inc i) total sx sy)))))))
 
 ;; --- Lake Placement ---
 ;; Generate blob-shaped lakes and place them without breaking connectivity.
@@ -748,35 +697,74 @@
 
 ;; --- Level Generation ---
 
-(defn ensure-connectivity!
-  "If the map is disconnected, carve extra corridors deterministically
-   between room centers until everything is reachable. Returns world'."
-  [world grid w h rooms]
-  (let [rs (vec rooms)
-        n (count rs)]
-    (if (<= n 1)
-      world
-      (let [w-ctx (det/with-context world [:terrain :ensure-conn])]
-        (loop [attempt 0 w-cur w-ctx]
-          (if (or (>= attempt 20) (is-connected? grid w h))
-            w-cur
-            (let [p1 (det/int-in w-cur 0 n)
-                  i1 (first p1)
-                  w1 (second p1)
-                  p2 (det/int-in w1 0 n)
-                  i2 (first p2)
-                  w2 (second p2)
-                  pd (det/percent? w2 50)
-                  go-h-first (first pd)
-                  w3 (second pd)
-                  [x1 y1] (nth rs i1)
-                  [x2 y2] (nth rs i2)]
-              (if go-h-first
-                (do (carve-h-corridor! grid w x1 x2 y1)
-                    (carve-v-corridor! grid w y1 y2 x2))
-                (do (carve-v-corridor! grid w y1 y2 x1)
-                    (carve-h-corridor! grid w x1 x2 y2)))
-              (recur (inc attempt) w3))))))))
+;; --- Disjoint-set (union-find) connectivity --------------------------------
+;; Guarantee a fully-connected level in ~O(alpha(n)). Replaces the old
+;; best-effort BFS-retry, which carved random room-to-room corridors for up to
+;; 20 attempts and could still leave the level disconnected. parent[] is the
+;; whole structure; union by smaller root index (deterministic, no rank
+;; tie-breaks); iterative find with path-halving (no recursion).
+
+(defn dsu-make [n]
+  (let [parent (int-array n)]
+    (dotimes [i n] (aset parent i i))
+    parent))
+
+(defn dsu-find [parent i]
+  (loop [i i]
+    (let [p (aget parent i)]
+      (if (= p i)
+        i
+        (let [gp (aget parent p)]
+          (aset parent i gp)            ; path halving
+          (recur gp))))))
+
+(defn dsu-union! [parent a b]
+  (let [ra (dsu-find parent a)
+        rb (dsu-find parent b)]
+    (if (= ra rb)
+      false
+      (do (if (< ra rb) (aset parent rb ra) (aset parent ra rb))
+          true))))
+
+(defn ensure-connectivity-dsu!
+  "Guarantee a fully-connected level. One pass unions adjacent floor tiles, then
+   connects every distinct floor *component* to the first floor tile's component
+   with a single corridor. Unlike the BFS-retry version this never gives up, so
+   it can't leave the level disconnected. Deterministic (index order, union by
+   min index); consumes no det rolls, so it threads `world` through unchanged."
+  [world grid w h]
+  (let [total (* w h)
+        parent (dsu-make total)
+        floor0 (int-array total)]      ; marks tiles that were floor at pass 1
+    ;; pass 1: record floor tiles, union each with its right/down floor neighbor
+    (dotimes [y h]
+      (dotimes [x w]
+        (when (contains? floor-tiles (tget grid w x y))
+          (let [i (+ x (* y w))]
+            (aset floor0 i 1)
+            (when (and (< (inc x) w) (contains? floor-tiles (tget grid w (inc x) y)))
+              (dsu-union! parent i (+ (inc x) (* y w))))
+            (when (and (< (inc y) h) (contains? floor-tiles (tget grid w x (inc y))))
+              (dsu-union! parent i (+ x (* (inc y) w))))))))
+    ;; pass 2: connect every floor component to the first floor tile's component
+    (let [main (loop [i 0]
+                 (cond (>= i total) -1
+                       (= 1 (aget floor0 i)) i
+                       :else (recur (inc i))))]
+      (if (< main 0)
+        world
+        (let [fx (rem main w) fy (quot main w)]
+          (loop [i (inc main)]
+            (if (>= i total)
+              world
+              (do
+                (when (and (= 1 (aget floor0 i))
+                           (not= (dsu-find parent i) (dsu-find parent main)))
+                  (let [x1 (rem i w) y1 (quot i w)]
+                    (carve-h-corridor! grid w x1 fx y1)
+                    (carve-v-corridor! grid w y1 fy fx)
+                    (dsu-union! parent i main)))
+                (recur (inc i))))))))))
 
 (defn place-room-in-sector!
   "Place a room (rect or cave) in a given sector deterministically.
@@ -891,7 +879,7 @@
               (recur (inc i) (second r)))))
 
         ;; === Phase 2c: ensure connectivity ===
-        w-phase2c (ensure-connectivity! w-phase2b grid w h @rooms)
+        w-phase2c (ensure-connectivity-dsu! w-phase2b grid w h)
 
         ;; === Phase 3: doors at corridor junctions ===
         w-phase3
@@ -976,7 +964,7 @@
         ;; Lakes and chasms can cut walking paths; reconnect once after all
         ;; terrain decoration rather than copying/checking the whole grid for
         ;; every individual placement attempt.
-        w-final-connectivity (ensure-connectivity! w-bridges grid w h @rooms)
+        w-final-connectivity (ensure-connectivity-dsu! w-bridges grid w h)
 
         ;; === Phase 7: Torches on walls — 4% chance per wall ===
         w-torches

--- a/xsofy/test/container_trigger_test.lg
+++ b/xsofy/test/container_trigger_test.lg
@@ -30,25 +30,37 @@
                      (get-in world [:entities :player :pos])))))
       movement-actions)))
 
+;; Ring effect is measured as a DELTA against a no-ring run of the same world
+;; and action, not as an absolute HP. The generated world can deal incidental
+;; damage on a turn (a monster reaching the player), which both runs share — so
+;; the difference isolates the ring and stays stable across map-generation
+;; changes that shift the seed's layout.
+
+(defn- base-world []
+  (-> (world/make-world 79 30 4242)
+      (assoc-in [:entities :player :body :hp] 20)))
+
+(defn- hp-after [world action]
+  (get-in (dispatch/dispatch world action) [:entities :player :body :hp]))
+
 (deftest equipped-ring-fires-on-wait
-  (testing "an equipped ring with runes fires once on :wait"
-    (let [w0 (-> (world/make-world 79 30 4242)
-                 equip-test-ring
-                 (assoc-in [:entities :player :body :hp] 20))
-          w1 (dispatch/dispatch w0 :wait)]
-      (is (= 22 (get-in w1 [:entities :player :body :hp])))
+  (testing "an equipped ring with runes heals +2 on :wait"
+    (let [base (base-world)
+          w1 (dispatch/dispatch (equip-test-ring base) :wait)]
+      (is (= 2 (- (get-in w1 [:entities :player :body :hp])
+                  (hp-after base :wait)))
+          "equipped ring heals +2 over the no-ring baseline")
       (is (= [:wait] (:action-log w1))))))
 
 (deftest equipped-ring-fires-on-movement
-  (testing "an equipped ring with runes fires after a replayed move"
-    (let [base (world/make-world 79 30 4242)
+  (testing "an equipped ring with runes heals +2 after a replayed move"
+    (let [base (base-world)
           action (first-safe-move base)
-          w0 (-> base
-                 equip-test-ring
-                 (assoc-in [:entities :player :body :hp] 20))
-          w1 (dispatch/dispatch w0 action)]
+          w1 (dispatch/dispatch (equip-test-ring base) action)]
       (is (some? action) "fixture found a legal movement action")
-      (is (= 22 (get-in w1 [:entities :player :body :hp])))
+      (is (= 2 (- (get-in w1 [:entities :player :body :hp])
+                  (hp-after base action)))
+          "equipped ring heals +2 over the no-ring baseline")
       (is (= [action] (:action-log w1))))))
 
 (deftest ring-does-not-fire-on-ui-actions
@@ -62,12 +74,13 @@
 
 (deftest unequipped-ring-does-not-fire
   (testing "a ring in inventory but not equipped does not trigger"
-    (let [w0 (-> (world/make-world 79 30 4242)
-                 equip-test-ring
-                 (assoc-in [:entities :player :body :hp] 20)
-                 (assoc-in [:entities :player :equipment :ring] nil))
-          w1 (dispatch/dispatch w0 :wait)]
-      (is (= 20 (get-in w1 [:entities :player :body :hp])))
+    (let [base (base-world)
+          unequipped (-> (equip-test-ring base)
+                         (assoc-in [:entities :player :equipment :ring] nil))
+          w1 (dispatch/dispatch unequipped :wait)]
+      (is (= 0 (- (get-in w1 [:entities :player :body :hp])
+                  (hp-after base :wait)))
+          "unequipped ring heals nothing vs the no-ring baseline")
       (is (= [:wait] (:action-log w1))))))
 
 (deftest ring-turn-trigger-is-deterministic


### PR DESCRIPTION
Builds on #88 (the mapgen viewer + audit tool) — its `unreach=` metric is how this is measured, and the PR is based on that branch so the diff here is just the connectivity change. If #88 lands first, this retargets to `main`.

## The problem

`ensure-connectivity!` is best-effort. It loops up to 20 times; each iteration runs a full-grid BFS connectivity check (`is-connected?`) and, if the level is still disconnected, carves a corridor between two random room centers. After 20 attempts it gives up and returns whatever it has, connected or not.

In practice it often doesn't connect. Across seeds 42–91 at 79×30 depth 3, only 17 of 50 levels were fully connected; the rest had stranded floor (one seed left 37 tiles unreachable). Those are regions the player can see but can't walk to.

## The fix

Replace the retry loop with a disjoint-set (union-find) pass:

1. One O(W·H) sweep unions each floor tile with its right and down floor neighbor, labeling the connected components.
2. A second sweep carves one corridor from each distinct component to the first, unioning as it goes.

It never gives up, so the level is provably connected.

Complexity, for `n = W·H` (α is the inverse Ackermann function, ≤ 4 for any real grid):

- Before: up to 20 retries, each a full O(W·H) BFS → O(20·W·H) worst case per call, and still best-effort. Two call sites (after corridor carving, and after lakes/bridges) means up to ~40 full-grid floods per level.
- After: a single near-linear pass → O(W·H·α(n)) ≈ O(W·H), guaranteed.

After the change, 49 of those 50 seeds are fully connected.

## The one residual

Seed 48 still reports `unreach=1`, and it's a separate bug, not a connectivity miss. The floor is fully connected; the stranded tile is the up-stair, placed on a room center that a chasm floods, leaving the stair itself boxed in. Stairs are placed without a reachability check — a separate fix. I note it here because the audit catches it.

## Determinism and the test change

Still deterministic by seed. The new pass consumes no RNG and no longer threads through `det/with-context`, so a given seed's downstream layout differs from the old output. That shifted two ring tests in `container_trigger_test.lg` that pinned a seed's absolute player HP. They now assert the ring's effect as a delta against a no-ring run of the same world and action, which isolates the ring and holds across generator changes. The change also drops the now-dead `is-connected?` / `flood-count` BFS helpers.

## Verifying

```
for s in $(seq 42 91); do MAPGEN_SEED=$s MAPGEN_DEPTH=3 MAPGEN_COLOR=0 lg tools/mapgen.lg | head -1; done
```

Human-verified, `unreach=0` on every seed but 48 (the stair). `make test` is green.

## Captures
<img width="1005" height="675" alt="image" src="https://github.com/user-attachments/assets/238c4e9d-10dd-48ee-a8bb-d640cb45afe0" />

<img width="996" height="672" alt="image" src="https://github.com/user-attachments/assets/41ccb124-6a92-4a86-aa83-f8eda864437b" />

<img width="1007" height="672" alt="image" src="https://github.com/user-attachments/assets/138bebf6-0805-446c-b1af-5f0e5bf54ca3" />

