### PR TITLE
Place stairs on a reachable floor tile

### DIFF
--- a/xsofy/terrain.lg
+++ b/xsofy/terrain.lg
@@ -800,6 +800,24 @@
         (swap! rooms conj [(quot (+ x1 x2) 2) (quot (+ y1 y2) 2)])
         w6))))
 
+(defn stair-tile
+  "First (or last, if reversed?) room center that is a passable floor tile
+   (1/2), so a stair never lands on a lake- or chasm-carved hazard. Stairs are
+   the last mutation and run after the final connectivity repair, so a floor
+   room center is reachable. Falls back to the first/last room if none qualify."
+  [grid w rooms reversed?]
+  (let [v (vec rooms)
+        n (count v)]
+    (loop [k 0]
+      (if (>= k n)
+        (if reversed? (last v) (first v))
+        (let [idx (if reversed? (- n 1 k) k)
+              [x y] (nth v idx)
+              t (tget grid w x y)]
+          (if (or (= t 1) (= t 2))
+            [x y]
+            (recur (inc k))))))))
+
 (defn generate-level
   ([w h] (generate-level w h 1 {:seed 0}))
   ([w h depth] (generate-level w h depth {:seed depth}))
@@ -989,9 +1007,9 @@
                         (recur (inc x) w-x))))]
               (recur (inc y) w-row))))
 
-        ;; === Phase 8: Stairs (no rolls) ===
-        [sx sy] (first @rooms)
-        [ex ey] (last @rooms)
+        ;; === Phase 8: Stairs (no rolls; on a passable, reachable room center) ===
+        [sx sy] (stair-tile grid w @rooms false)
+        [ex ey] (stair-tile grid w @rooms true)
         _ (tset! grid w sx sy 14)
         _ (tset! grid w ex ey 13)]
 

--- a/xsofy/test/fixtures/dungeon-scenarios.edn
+++ b/xsofy/test/fixtures/dungeon-scenarios.edn
@@ -1,0 +1,15 @@
+;; Regression matrix for the dungeon generator's connectivity guarantee.
+;; Consumed by xsofy.test.mapgen-audit-test; metrics defined in tools/mapaudit.lg.
+;;
+;; :expect is the contract:
+;;   :unreach      hard guarantee — every level fully connected (union-find +
+;;                 reachable-stair fixes). A regression here is a real bug.
+;;   :max-floating coarse tripwire, NOT a cleanliness target. Floating doors are
+;;                 a known, unfixed wart (observed 3-42 across this matrix); the
+;;                 ceiling only catches a generator that drowns levels in them.
+{:w 79
+ :h 30
+ :depths [1 3 5 10]
+ :seed-range [42 92]          ; 42..91 inclusive — the connectivity-validated range
+ :expect {:unreach 0
+          :max-floating 60}}

--- a/xsofy/test/mapgen_audit_test.lg
+++ b/xsofy/test/mapgen_audit_test.lg
@@ -1,0 +1,41 @@
+(ns xsofy.test.mapgen-audit-test
+  "Regression lock for the dungeon generator's connectivity guarantee.
+
+   Loads a scenario matrix (test/fixtures/dungeon-scenarios.edn), regenerates
+   each level, and asserts tools.mapaudit metrics:
+
+   - unreach=0 everywhere — the real guarantee from the union-find connectivity
+     and reachable-stair fixes. A failure here means a level has tiles cut off
+     from the rest, which is a genuine generator regression.
+   - floating <= a loose ceiling — a coarse tripwire only. Floating doors are a
+     known, not-yet-fixed wart (3-42 per level across this matrix), so the
+     ceiling guards against a generator that drowns levels in them, not against
+     their existence.
+
+   tools.mapaudit is pure (no load-time side effects); tools.mapgen is the
+   viewer and must NOT be required here."
+  (:require [test :refer [deftest is]]
+            [tools.mapaudit :as audit]
+            [xsofy.terrain :as terrain]))
+
+;; cwd is the repo root (the suite runs as `lg xsofy/test/run.lg` from there),
+;; so the fixture path is relative to that root.
+(def scenario
+  (read-string (slurp "xsofy/test/fixtures/dungeon-scenarios.edn")))
+
+(defn- scenario-seeds [sc]
+  (let [[lo hi] (:seed-range sc)]
+    (range lo hi)))
+
+(deftest dungeon-generator-regression
+  (let [{:keys [w h depths expect]} scenario
+        ceiling (:max-floating expect)]
+    (doseq [depth depths]
+      (doseq [seed (scenario-seeds scenario)]
+        (let [lvl (first (terrain/generate-level w h depth {:seed seed}))
+              a (audit/audit (:grid lvl) w h)]
+          (is (= (:unreach expect) (:unreach a))
+              (str "unreachable tiles at seed=" seed " depth=" depth ": " a))
+          (is (<= (:floating a) ceiling)
+              (str "floating doors " (:floating a) " exceeded ceiling " ceiling
+                   " at seed=" seed " depth=" depth)))))))

--- a/xsofy/test/run.lg
+++ b/xsofy/test/run.lg
@@ -15,6 +15,7 @@
             [xsofy.test.dag-test]
             [xsofy.test.container-trigger-test]
             [xsofy.test.seed-test]
+            [xsofy.test.mapgen-audit-test]
             [xsofy.test.replay-test]
             [xsofy.test.ui-test]
             [xsofy.test.play-test]


### PR DESCRIPTION
Builds on #89 (the connectivity fix): it clears the one `unreach=1` case #89 called out, and is based on that branch so the diff here is just the stair change. If #89 lands first, this retargets to `main`.

## The problem

Stairs are placed at the first and last room centers (`(first @rooms)` / `(last @rooms)`) with no check that the tile is passable. When a lake or chasm floods that center, the stair lands in hazard and is stranded from the rest of the level. On seed 48 the up-stair ends up walled in by chasm, leaving `unreach=1` even after the connectivity fix.

## The fix

Pick the first (or last) room center that is dry floor (tile 1 or 2), falling back to the first/last room if none qualify. Stairs are already the last mutation and run after the final connectivity repair, so a floor room center is reachable.

No RNG is consumed (only the stair tile moves), so this changes stair placement and nothing else downstream.

## Result

`unreach=0` across seeds 42–91 at depth 3 and 42–71 at depth 6. Together with #89, every floor in that range is fully connected, stairs included.

## Verifying

```
for s in $(seq 42 91); do MAPGEN_SEED=$s MAPGEN_DEPTH=3 MAPGEN_COLOR=0 lg tools/mapgen.lg | head -1; done
```

Every seed reports `unreach=0`. `make test` is green.

## Screenshot (seed 48 unreach=0)

without this PR
<img width="1001" height="673" alt="image" src="https://github.com/user-attachments/assets/ae9534fd-b7cd-4edd-b489-a66dc66298f6" />

with this PR
<img width="1000" height="674" alt="image" src="https://github.com/user-attachments/assets/3d8410e3-11b1-4af8-b73e-f8855d22cc1d" />
