### PR TITLE
fix(terrain): remove floating doors via post-connectivity cleanup

### DIFF
--- a/xsofy/terrain.lg
+++ b/xsofy/terrain.lg
@@ -818,6 +818,37 @@
             [x y]
             (recur (inc k))))))))
 
+;; --- Floating-door cleanup -------------------------------------------------
+;; Phase 3 places doors at clean room thresholds, but a LATER phase — the
+;; post-bridge connectivity repair especially, plus lakes flooding a door's
+;; flanks — can break that 1-wide passage, leaving a floating door at a junction
+;; or mid-water. Revert any such door to plain floor after all terrain settles.
+;; Mirrors the mapgen auditor's floating-door? predicate. Purely subtractive
+;; (door→floor, both passable), so it can neither disconnect the level nor
+;; create a new floating door.
+
+(defn- a-wall? [t] (or (= t 8) (= t 9)))
+(defn- a-open? [t] (and (not (a-wall? t)) (not (= t 0))))
+
+(defn door-floating? [grid w h x y]
+  (let [g (fn [dx dy] (tget grid w (+ x dx) (+ y dy)))
+        n (g 0 -1) s (g 0 1) e (g 1 0) wt (g -1 0)
+        h-pass (and (a-wall? n) (a-wall? s) (a-open? e) (a-open? wt))
+        v-pass (and (a-wall? e) (a-wall? wt) (a-open? n) (a-open? s))]
+    (cond
+      h-pass (not (or (a-open? (g 1 -1)) (a-open? (g 1 1))
+                      (a-open? (g -1 -1)) (a-open? (g -1 1))))
+      v-pass (not (or (a-open? (g -1 -1)) (a-open? (g 1 -1))
+                      (a-open? (g -1 1)) (a-open? (g 1 1))))
+      :else true)))   ; door not in a clean 1-wide passage = floating
+
+(defn cleanup-floating-doors! [grid w h]
+  (doseq [y (range 1 (dec h))]
+    (doseq [x (range 1 (dec w))]
+      (let [t (tget grid w x y)]
+        (when (and (or (= t 11) (= t 12)) (door-floating? grid w h x y))
+          (tset! grid w x y 1))))))
+
 (defn generate-level
   ([w h] (generate-level w h 1 {:seed 0}))
   ([w h depth] (generate-level w h depth {:seed depth}))
@@ -983,6 +1014,9 @@
         ;; terrain decoration rather than copying/checking the whole grid for
         ;; every individual placement attempt.
         w-final-connectivity (ensure-connectivity-dsu! w-bridges grid w h)
+        ;; later carving (esp. the repair above) and lake flooding can break a
+        ;; door's 1-wide passage → floating door; revert those to floor.
+        _ (cleanup-floating-doors! grid w h)
 
         ;; === Phase 7: Torches on walls — 4% chance per wall ===
         w-torches

--- a/xsofy/test/fixtures/dungeon-scenarios.edn
+++ b/xsofy/test/fixtures/dungeon-scenarios.edn
@@ -4,12 +4,14 @@
 ;; :expect is the contract:
 ;;   :unreach      hard guarantee — every level fully connected (union-find +
 ;;                 reachable-stair fixes). A regression here is a real bug.
-;;   :max-floating coarse tripwire, NOT a cleanliness target. Floating doors are
-;;                 a known, unfixed wart (observed 3-42 across this matrix); the
-;;                 ceiling only catches a generator that drowns levels in them.
+;;   :max-floating hard guarantee — the post-connectivity cleanup pass reverts
+;;                 every floating door to floor (door-floating? mirrors the
+;;                 auditor), so a clean level has zero. Was a loose tripwire
+;;                 (60) while floating doors were an open wart (3-42); the
+;;                 cleanup closed it, so the contract is now exactly 0.
 {:w 79
  :h 30
  :depths [1 3 5 10]
  :seed-range [42 92]          ; 42..91 inclusive — the connectivity-validated range
  :expect {:unreach 0
-          :max-floating 60}}
+          :max-floating 0}}


### PR DESCRIPTION

Doors are placed at clean room thresholds in Phase 3, but later phases break some of them: the post-bridge connectivity repair carves through a door's wall, and lakes flood a door's flanks, leaving the door floating at a junction or mid-water. On current `main` that's 3 to 42 floating doors per level across a 200-level matrix (seeds 42–91 × depths 1/3/5/10).

`cleanup-floating-doors!` runs once after the final connectivity repair and reverts any door that's no longer a clean 1-wide threshold back to floor. It's purely subtractive — door → floor, both passable — so it can't disconnect the level or create a new floating door. Its `door-floating?` predicate mirrors the auditor's, so what the cleanup removes is exactly what the regression test counts. With it the matrix is clean: floating=0 everywhere.

The second commit tightens the floating assertion in the regression matrix (added with the reachable-stair fix this stacks on) from a loose ceiling to 0, since the cleanup makes zero a guarantee rather than a hope.

Stacks on #91 (reachable stairs + the connectivity regression test).

| before | after |
|---|---|
| <img width="359" height="327" alt="image" src="https://github.com/user-attachments/assets/0d23c53c-f284-402b-9db1-ed2583df1244" /> | <img width="356" height="323" alt="image" src="https://github.com/user-attachments/assets/63a49edd-278b-4f9b-8ced-801d207d4152" /> |
