### PR TITLE
Fix the web-font measurement race that twitches the terminal

### DIFF
--- a/tools/xsofy-shell.html
+++ b/tools/xsofy-shell.html
@@ -44,19 +44,28 @@
   const fit = new FitAddon.FitAddon();
   term.loadAddon(fit);
 
-  window.LetGoHost.onReady((mode) => {
+  window.LetGoHost.onReady(async (mode) => {
     const s = document.getElementById('status'); if (s) s.style.display = 'none';
     termEl.style.display = 'block';
+    // Capture output before we open, so nothing emitted during the font wait
+    // below is lost; flush it once the terminal is live.
+    let opened = false, pending = '';
+    window.LetGoHost.onOutput((x) => { if (opened) term.write(x); else pending += x; });
+    // The terminal font is an inlined @font-face. Present-at-parse is not
+    // loaded: the browser defers rasterizing it until first use, but xterm
+    // measures the glyph cell synchronously in term.open(). Measuring before
+    // Fairfax HD loads locks in a fallback's (full-width) cell; the half-width
+    // glyphs then sit off-grid and jitter on every repaint. Load the face
+    // first so the cell is measured against the real metrics.
+    try { await document.fonts.load('16px "Fairfax HD"'); } catch (e) {}
     term.open(termEl); fit.fit(); term.focus();
-    window.LetGoHost.onOutput((x) => term.write(x));
+    opened = true;
+    if (pending) { term.write(pending); pending = ''; }
     if (mode === 'worker') {
       window.LetGoHost.setSize(term.cols, term.rows);
       term.onResize(({cols, rows}) => window.LetGoHost.setSize(cols, rows));
       term.onData((d) => window.LetGoHost.sendInput(d));
     }
-    // Rune font is inlined (present at parse), so this re-fit is just a cheap
-    // safety net to re-measure glyph cells with Fairfax HD once fonts settle.
-    document.fonts.ready.then(() => { try { fit.fit(); } catch (e) {} });
   });
   // Debounced so a drag/rotate burst settles on the final size, not an
   // intermediate one. visualViewport catches the mobile URL-bar show/hide,


### PR DESCRIPTION
**Fixing a regression introduced with the Fairfax rune font.**

The title screen jitters horizontally during the rune animation. The cause is a font-load race, not the font, so this keeps the bundled rune face and fixes the twitch in the shell. This was fixed locally but missed in the original PR.

## Why

xterm measures the glyph cell synchronously inside `term.open()`. The terminal font is an inlined `@font-face` (Fairfax HD). It's present in the CSS at parse, but the browser defers rasterizing it until first use. So `term.open()` measures a fallback's full-width cell; Fairfax then loads at its half-width metrics, the glyphs sit off the measured grid, and every repaint jitters.

The existing `document.fonts.ready` re-fit couldn't fix this: `FitAddon.fit()` recomputes rows/cols from the cached cell size; it never re-measures the glyph cell, so the wrong cell width survives.

## What

- Await `document.fonts.load('16px "Fairfax HD"')` before `term.open()`, so the cell is measured against Fairfax's real metrics.
- Buffer output across that wait so nothing emitted before the terminal opens is lost.
- Drop the now-redundant `document.fonts.ready` re-fit.

This is the synchronous-measurement race `@xterm/addon-web-fonts` exists for; the `document.fonts.load` await is the minimal form of its `loadFonts()` guard. Adopting the addon is the heavier alternative; one await covers our single inlined face.

## Evidence

Same seed, only the load timing differs:

- **Before** — Fairfax measured before load: twitches.
- **After** — font awaited before `open()`: steady, runes intact.

Coverage isn't the cause: a full 25k-glyph Fairfax build twitches identically before the fix, and a no-Fairfax build is steady only because it has no web font to race.

## Verification

- In-browser, seed-locked: the title animation renders steady after the fix,
  versus the twitch before.
- Runes (U+16A0–16FF) still render from the bundled Fairfax face, so no
  system-font tofu.
- `make browser-smoke` and `make e2e` (4/4 — boot, title animation, seed 12345,
  `?replay=`) pass on the fixed build. The output buffering across the font-await
  loses nothing, and the seed/replay paths still verify.