### PR TITLE
Add ?font=system to render the terminal in the platform mono

### DIFF
--- a/tools/xsofy-shell.html
+++ b/tools/xsofy-shell.html
@@ -34,8 +34,13 @@
 <script>
 (function () {
   const termEl = document.getElementById('terminal');
+  // ?font=system bypasses the bundled rune face and renders in the platform
+  // mono — a debug/preference escape hatch. Runes (U+16A0–16FF) then fall back
+  // to the viewer's system fonts, which may tofu where none cover them.
+  const MONO = '"DejaVu Sans Mono", "Menlo", monospace';
+  const sysFont = new URLSearchParams(location.search).get('font') === 'system';
   const term = new Terminal({
-    fontFamily: '"Fairfax HD", "DejaVu Sans Mono", "Menlo", monospace',
+    fontFamily: sysFont ? MONO : '"Fairfax HD", ' + MONO,
     fontSize: 16,
     theme: { background: '#0a0e14', foreground: '#d4c5a0', cursor: '#ff6b35' },
     allowProposedApi: true,
@@ -57,7 +62,8 @@
     // Fairfax HD loads locks in a fallback's (full-width) cell; the half-width
     // glyphs then sit off-grid and jitter on every repaint. Load the face
     // first so the cell is measured against the real metrics.
-    try { await document.fonts.load('16px "Fairfax HD"'); } catch (e) {}
+    // Only the bundled face needs the pre-open load; ?font=system has none.
+    if (!sysFont) { try { await document.fonts.load('16px "Fairfax HD"'); } catch (e) {} }
     term.open(termEl); fit.fit(); term.focus();
     opened = true;
     if (pending) { term.write(pending); pending = ''; }


### PR DESCRIPTION
A host-side escape hatch: `?font=system` drops the bundled Fairfax HD face and renders the terminal in the platform mono. Useful for a quick A/B, or as a bail-out if a font issue ever surfaces, or if the player prefers to not use the bundled font.

## What

The shell reads `?font=` from `location.search` on the main thread, independent of the game's `js/url-param` `?seed=`/`?replay=` bridge (which runs in the worker). When `font=system`:

- `fontFamily` drops `"Fairfax HD"` and uses the mono stack (`DejaVu Sans Mono,  Menlo, monospace`).
- It skips the pre-open `document.fonts.load` await — no web font to wait for.

Default behavior is unchanged.

## Tradeoff

With the bundled face gone, runes (U+16A0–16FF) fall back to the viewer's system fonts: they render on macOS, but a device without a Runic system face shows tofu. That's why it's an opt-in knob, not the default.

## Verification

Headless, same build:

- default → `fontFamily` resolves `"Fairfax HD", …`, and Fairfax is loaded.
- `?font=system` → `fontFamily` resolves the mono stack, and Fairfax is never
  loaded.

## Stacking

Stacked on #95 (the web-font measure-race fix): the `?font=system` path skips that fix's pre-open await, so the two compose. Retarget to `main` once #95 merges.