### PR TITLE
docs: align let-go version comments to v1.11.1 (single-sourced)

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -25,9 +25,9 @@ jobs:
 
       # Single-source the let-go version from .let-go-version (the repo's
       # declared pin), so the deploy and the test floor can't drift apart.
-      # v1.11.0 ships the client-shell WASM glue (-w-shell none, #245) and the
-      # js/url-param host seam (#339) the bundle needs, so the ?seed=/?replay=
-      # bridge is native — no glue patch.
+      # The pinned release ships the client-shell WASM glue (-w-shell none, #245)
+      # and the js/url-param host seam (#339) the bundle needs, so the
+      # ?seed=/?replay= bridge is native — no glue patch.
       - name: Resolve let-go version
         id: letgo
         run: echo "version=$(grep -v '^#' .let-go-version | grep . | head -1 | tr -d '[:space:]')" >> "$GITHUB_OUTPUT"

--- a/.let-go-version
+++ b/.let-go-version
@@ -1,9 +1,8 @@
-# Minimum let-go version for building xsofy.
+# let-go version for building xsofy — single source of truth.
+# deploy-pages.yml and the test.yml floor lane both resolve the version from here.
 #
-# The WASM web build needs let-go >= v1.11.0:
+# v1.11.1 ships what the WASM web build needs:
 #   - `lg -w -w-shell none` client-owned shell (nooga/let-go#245)
 #   - the js/url-param host seam (nooga/let-go#339) that carries ?seed=/?replay=
 #     into the worker, so the URL bridge is native (no glue patch)
-#
-# The Pages deploy workflow pins this same tag — bump both together.
 v1.11.1

--- a/Makefile
+++ b/Makefile
@@ -25,8 +25,9 @@ rune-font: ## Regenerate the inlined terminal font in tools/xsofy-shell.html fro
 
 wasm: ## Build the WASM web app into $(DIST): client-owned shell + COI bridge
 	# Build glue-only (no let-go xterm shell), then inject xsofy's own shell.
-	# Requires let-go >= v1.11.0: -w-shell none (#245) and the js/url-param host
-	# seam (#339) that carries ?seed=/?replay= into the worker natively.
+	# Requires the let-go release pinned in .let-go-version: -w-shell none (#245)
+	# and the js/url-param host seam (#339) that carries ?seed=/?replay= into the
+	# worker natively.
 	$(LG) -w $(DIST) -w-shell none main.lg
 	XSOFY_WASM_INDEX=$(DIST)/index.html $(LG) tools/inject_shell.lg
 	# COI bounded-retry still patches the core glue: it drives the crossOriginIsolated


### PR DESCRIPTION
The `.let-go-version` value is `v1.11.1` (merged in #94), but the explanatory comments in `.let-go-version`, the `Makefile`, and `deploy-pages.yml` still read `v1.11.0`.

This points the Makefile/workflow comments at `.let-go-version` (the single source #94 introduced) rather than hardcoding a version, and states `v1.11.1` in the source file itself — so the number lives in exactly one place and can't go stale again. Comments only; no build or CI behavior change.