### PR TITLE
fix(ui): de-overlap death screen — drop on-screen replay code

### DIFF
--- a/main.lg
+++ b/main.lg
@@ -4,6 +4,7 @@
 (ns xsofy.main
   (:require [term]
             [os]
+            [io :refer [write! flush! *err*]]
             [string]
             [xsofy.world :as world]
             [xsofy.entities :as ent]
@@ -427,12 +428,18 @@
          :death
          (let [[tw th] (term/size)
                runes (render/death-runes tw th)  ;; scatter ONCE — stable across frames
-               ;; compute ONCE — encode is O(n) per call. encode-run-safe yields
-               ;; nil for runs whose log has map actions (item use/equip/etc via
-               ;; dispatch); the death screen then shows the seed alone, instead
-               ;; of crashing the game on encode-run's keyword-only guard.
-               replay-code (replay/encode-run-safe world)
                _ (sfx/clear-screen tw th)  ;; clear ONCE, not per-frame — was the flicker source
+               ;; Dev repro capture: XSOFY_DUMP_REPLAY=1 dumps this organic run's
+               ;; replay code to stderr (redirect 2>file to capture past the TUI).
+               ;; Gated on the env var so players never see it; the WASM worker
+               ;; doesn't bridge the var, so it's effectively native-only.
+               _ (when (seq (or (os/getenv "XSOFY_DUMP_REPLAY") ""))
+                   (let [code (replay/encode-run-safe world)]
+                     (write! *err*
+                             (str "replay-code: "
+                                  (or code "(unavailable: run has parameterized actions)")
+                                  "\n"))
+                     (flush! *err*)))
                ;; Animate the death screen via the poll-based event loop: a
                ;; cosmetic clock pulses the runes each tick while we wait for a
                ;; key, instead of freezing on a blocking read (see xsofy.ui /
@@ -455,7 +462,7 @@
                         {:sources  [(ui/input-source ui/raw-key->event) (ui/clock-source 0)]
                          :state    {:frame 0 :scroll 0}
                          :step     step
-                         :render   (fn [st] (render/render-death-screen world runes (:scroll st) (:frame st) replay-code))
+                         :render   (fn [st] (render/render-death-screen world runes (:scroll st) (:frame st)))
                          :frame-ms 120})]
            (cond
              (= result :new-game)

--- a/xsofy/render.lg
+++ b/xsofy/render.lg
@@ -883,7 +883,7 @@
   [tw th]
   (sfx/scatter-runes tw th 30 [200 50 30]))  ;; crimson runes
 
-(defn render-death-screen [world runes scroll-offset frame replay-code]
+(defn render-death-screen [world runes scroll-offset frame]
   (let [[tw th] (term-dims)
         cx (quot tw 2)
         cy (quot th 2)
@@ -991,25 +991,7 @@
             (term/move-cursor (max 1 (- cx (quot (count sline) 2))) sy)
             (term/set-fg 110 105 90)
             (term/set-bg 10 10 10)
-            (term/write sline)
-            ;; replay code — wrapped across the lower rows. The full code replays
-            ;; the exact run via ?replay=; long codes may overflow (share the seed).
-            (when (and replay-code (> (count replay-code) 0))
-              (let [cw (max 24 (- tw 4))
-                    lines (loop [s replay-code acc []]
-                            (if (<= (count s) cw)
-                              (conj acc s)
-                              (recur (subs s cw) (conj acc (subs s 0 cw)))))
-                    ly0 (min (- th 2) (+ sy 2))]
-                (term/move-cursor 2 ly0)
-                (term/set-fg 70 85 75) (term/set-bg 10 10 10)
-                (term/write "replay code (paste into ?replay=):")
-                (loop [i 0 ls lines]
-                  (when (and (seq ls) (< (+ ly0 1 i) th))
-                    (term/move-cursor 2 (+ ly0 1 i))
-                    (term/set-fg 110 125 105) (term/set-bg 10 10 10)
-                    (term/write (first ls))
-                    (recur (inc i) (rest ls))))))))))
+            (term/write sline)))))
     ;; message log — scrollable
     (let [log (or (:log world) [])
           log-count (count log)


### PR DESCRIPTION
On death, `render-death-screen` drew the full base64 `?replay=` code wrapped across the lower rows. For a long run the code overflows its budgeted rows and bleeds into the scrollable message log: a garbled green wall under the tombstone, made worse by the 30 pulsing background runes showing through the gaps.

`?replay=` is a repro/e2e determinism tool. Its only consumer is `tests/e2e/regression.spec.js`, which generates codes via `lg -e`, not off this screen, and a multi-line base64 with no clipboard was never practically copyable. So this drops the on-screen dump. The player-facing `?seed=` share line is untouched.

This is already live on the deployed Pages build, which was built from a commit predating the fix.

Tests: 279 / 2725 green.

Relates to #99 (the env-gated `XSOFY_DUMP_REPLAY` dev dump is the same code at a later life stage; see the issue for details).