### PR TITLE
ci: ship the xsofy client shell (rune font + ?font=system), not let-go's generic shell

### DIFF
--- a/.github/actions/build-wasm/action.yml
+++ b/.github/actions/build-wasm/action.yml
@@ -1,0 +1,47 @@
+name: Build xsofy WASM bundle
+description: >
+  Build the xsofy WASM bundle the way it ships: shell-less (-w-shell none),
+  then inject xsofy's own client shell (rune font + ?font=system, tools/xsofy-shell.html)
+  and patch the COI service-worker shim. Single source of truth for the bundle
+  build so the Pages deploy, the test smoke gate, and PR previews can't drift
+  (the drift is what shipped the bare let-go shell to production).
+
+inputs:
+  dist:
+    description: Output directory for the bundle.
+    required: false
+    default: dist
+  letgo-src:
+    description: >
+      Path to a let-go source checkout (sets LETGO_SRC) so `lg -w` compiles the
+      WASM runtime from the pinned release instead of let-go@latest. Omit to let
+      the runtime resolve from the installed let-go (fine for a build smoke).
+    required: false
+    default: ''
+
+runs:
+  using: composite
+  steps:
+    # 1. Shell-less bundle: -w-shell none emits glue-only HTML exposing
+    #    window.LetGoHost, so a project can inject its own client shell (#245).
+    - name: Build WASM (shell-less)
+      shell: bash
+      run: |
+        if [ -n "${{ inputs.letgo-src }}" ]; then export LETGO_SRC="${{ inputs.letgo-src }}"; fi
+        let-go -w "${{ inputs.dist }}" -w-shell none main.lg
+
+    # 2. Inject xsofy's own shell: rune font (Fairfax HD, OFL) + ?font=system.
+    #    Without this the bundle ships let-go's generic shell (no rune face,
+    #    no ?font=system) — the pre-existing production gap this fixes.
+    - name: Inject xsofy client shell
+      shell: bash
+      env:
+        XSOFY_WASM_INDEX: ${{ inputs.dist }}/index.html
+      run: let-go tools/inject_shell.lg
+
+    # 3. COI startup guard (SharedArrayBuffer needs cross-origin isolation).
+    - name: Patch COI startup guard
+      shell: bash
+      env:
+        XSOFY_WASM_INDEX: ${{ inputs.dist }}/index.html
+      run: let-go tools/patch_wasm_coi.lg

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -47,16 +47,15 @@ jobs:
       - name: Install let-go
         run: go install github.com/nooga/let-go@${{ steps.letgo.outputs.version }}
 
-      # LETGO_SRC pins the WASM *runtime* to the same release as the binary above;
-      # without it `lg -w` compiles the runtime from let-go@latest, which can drift
-      # from the binary's worker protocol.
-      - name: Build WASM
-        env:
-          LETGO_SRC: ${{ github.workspace }}/let-go-src
-        run: let-go -w dist main.lg
-
-      - name: Patch COI startup guard
-        run: let-go tools/patch_wasm_coi.lg
+      # Build the bundle the way it ships: shell-less + xsofy's own client shell
+      # (rune font + ?font=system) + COI shim. LETGO_SRC pins the WASM runtime to
+      # the same release as the binary above, so `lg -w` doesn't compile the
+      # runtime from let-go@latest and drift from the binary's worker protocol.
+      - name: Build WASM bundle
+        uses: ./.github/actions/build-wasm
+        with:
+          dist: dist
+          letgo-src: ${{ github.workspace }}/let-go-src
 
       - name: Set up Node (smoke gate)
         uses: actions/setup-node@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -74,5 +74,10 @@ jobs:
       - name: Compile smoke test
         run: let-go -b /tmp/xsofy main.lg
 
+      # Build the real shipping bundle (shell-less + xsofy shell + COI), not a
+      # bare `lg -w`, so the smoke gate catches a broken shell graft before it
+      # reaches the deploy.
       - name: WASM build smoke
-        run: let-go -w /tmp/xsofy-dist main.lg
+        uses: ./.github/actions/build-wasm
+        with:
+          dist: /tmp/xsofy-dist


### PR DESCRIPTION
## What

The Pages deploy builds the WASM bundle with a bare `let-go -w dist main.lg`, which ships **let-go's generic shell**. That shell has no rune face and no `?font=system` handler, so the deployed game falls back to a system font for the Runic block (U+16A0–16FF) and `?font=system` is a no-op. `tools/xsofy-shell.html` — the shell with the inlined Fairfax HD rune face (#95) and `?font=system` (#96) — exists in the repo but no build path injects it.

This wires the three-step build (shell-less → inject xsofy shell → COI patch) into the deploy and the test smoke gate, so the deployed bundle is the real xsofy shell.

## Why a shared action

The bundle build lived inline in `deploy-pages.yml`, and `test.yml` had its own bare `lg -w` smoke. Two copies already drifted — that's how the generic shell reached production. The build now lives once in `.github/actions/build-wasm`, and both workflows call it, so they can't diverge again. A composite action (rather than a reusable workflow) keeps the build output in the calling job, so the deploy still uploads `dist/` and the smoke gate still runs against it with no artifact round-trip. A future previews workflow can call the same action.

## The build

```
let-go -w <dist> -w-shell none main.lg   # shell-less glue (exposes window.LetGoHost)
let-go tools/inject_shell.lg             # graft tools/xsofy-shell.html (rune font + ?font=system)
let-go tools/patch_wasm_coi.lg           # COI service-worker shim
```

`-w-shell none` (#245) and the native `js/url-param` seam (#339) both ship in the pinned let-go (v1.11.1), so `?seed=`/`?replay=` stay runtime-native and the shell graft is supported.

## Changes

- `.github/actions/build-wasm/action.yml` — new composite action owning the three-step build. Inputs: `dist` (output dir), `letgo-src` (optional `LETGO_SRC` to pin the WASM runtime).
- `.github/workflows/deploy-pages.yml` — replaces the inline `Build WASM` + `Patch COI` steps with the action (`dist: dist`, `letgo-src` pinned). Smoke, e2e, upload, and deploy steps are unchanged.
- `.github/workflows/test.yml` — the `WASM build smoke` now builds the shipping bundle via the action instead of a bare `lg -w`, so a broken shell graft fails CI before it reaches the deploy.

## Verification

Ran the three-step build locally with the pinned `lg` (v1.11.1). The bundle contains the shell markers absent from a bare `lg -w` build: the `?font=system` handler (`get('font')`, `sysFont`), the inlined `Fairfax HD` face, the `LetGoHost` seam, and the COI service worker. A browser check confirmed the terminal font-family is `"Fairfax HD", …` by default and drops to the platform mono under `?font=system`, surviving the COI service-worker reload.

## Scope

Build correctness only — no game code, no shell-source changes. It corrects production on its own merit (the deployed game gets the rune font and `?font=system`), independent of any branch-publishing or preview work, which can adopt the same action.
