### PR TITLE
fix(replay): route the dev replay dump off-terminal on web (#99 follow-up)

### DIFF
--- a/main.lg
+++ b/main.lg
@@ -4,6 +4,7 @@
 (ns xsofy.main
   (:require [term]
             [os]
+            [js]
             [io :refer [write! flush! *err*]]
             [string]
             [xsofy.world :as world]
@@ -429,17 +430,22 @@
          (let [[tw th] (term/size)
                runes (render/death-runes tw th)  ;; scatter ONCE — stable across frames
                _ (sfx/clear-screen tw th)  ;; clear ONCE, not per-frame — was the flicker source
-               ;; Dev repro capture: XSOFY_DUMP_REPLAY=1 dumps this organic run's
-               ;; replay code to stderr (redirect 2>file to capture past the TUI).
-               ;; Gated on the env var so players never see it; the WASM worker
-               ;; doesn't bridge the var, so it's effectively native-only.
-               _ (when (seq (or (os/getenv "XSOFY_DUMP_REPLAY") ""))
-                   (let [code (replay/encode-run-safe world)]
-                     (write! *err*
-                             (str "replay-code: "
-                                  (or code "(unavailable: run has parameterized actions)")
-                                  "\n"))
-                     (flush! *err*)))
+               ;; Dev repro capture of this organic run's replay code. Trigger is
+               ;; per-platform: ?dump-replay= URL param on web (js/url-param),
+               ;; XSOFY_DUMP_REPLAY env var natively. Gated so players never see it.
+               ;; Sink differs because *err* aliases *out* in WASM (one host writer
+               ;; for both — let-go rendermain), so writing *err* there paints the
+               ;; game screen. On web route the dump off-terminal via a js/emit host
+               ;; event; natively keep stderr (redirect 2>file to capture past the TUI).
+               _ (when-let [trig (or (js/url-param "dump-replay")
+                                     (os/getenv "XSOFY_DUMP_REPLAY"))]
+                   (when (> (count trig) 0)
+                     (let [code (replay/encode-run-safe world)
+                           payload (or code "(unavailable: run has parameterized actions)")]
+                       (if (= (os/os-name) "js")
+                         (js/emit "xsofy/replay-dump" {:code payload})
+                         (do (write! *err* (str "replay-code: " payload "\n"))
+                             (flush! *err*))))))
                ;; Animate the death screen via the poll-based event loop: a
                ;; cosmetic clock pulses the runes each tick while we wait for a
                ;; key, instead of freezing on a blocking read (see xsofy.ui /


### PR DESCRIPTION
Stacked on #101 (base branch `fix/death-screen-replay-overlap`).

Follow-up to #99. #101 removed the on-screen replay display; this fixes the dev dump it relocated to, which was broken on web two ways:

- **Sink:** the dump wrote `*err*`, but in WASM `*err*` and `*out*` share one host writer (`_lgOutput` → `onOutput` → the terminal), so it painted the game screen.
- **Trigger:** it gated on the `XSOFY_DUMP_REPLAY` env var, which is unreachable in the browser (`wasm_exec` inits `go.env = {}`), so capture never worked on web at all.

Fix, per platform:
- **Trigger** — `?dump-replay=` URL param on web (`js/url-param`) or `XSOFY_DUMP_REPLAY` env var natively (the same dual-source shape `xsofy.seed` uses for `?seed=`).
- **Sink** — on web, `(js/emit "xsofy/replay-dump" {:code …})` rides the `*emit*` → `onEmit` host channel, off the terminal; natively, keep `*err*` so `2>file` still works.

Verified in a headless WASM bundle: with the emit path the code arrives via `LetGoHost.onEmit` and never reaches `onOutput`. Native compile + WASM build clean; xsofy suite 279/2725 green.