### PR TITLE
ci(pages): branch-based publishing + per-PR previews

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -5,29 +5,25 @@ on:
     tags: ['v*']
   workflow_dispatch:
 
+# Branch publishing only needs write to contents (push to gh-pages). The old
+# pages:/id-token: perms + github-pages environment belonged to the
+# Actions-deployment model we moved off of — which also sidesteps the
+# environment protection rule that blocked tag deploys.
 permissions:
-  contents: read
-  pages: write
-  id-token: write
+  contents: write
 
+# Serialize every gh-pages write (root deploys + PR previews share the branch).
 concurrency:
-  group: pages
-  cancel-in-progress: true
+  group: gh-pages-publish
+  cancel-in-progress: false
 
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - uses: actions/checkout@v4
 
-      # Single-source the let-go version from .let-go-version (the repo's
-      # declared pin), so the deploy and the test floor can't drift apart.
-      # The pinned release ships the client-shell WASM glue (-w-shell none, #245)
-      # and the js/url-param host seam (#339) the bundle needs, so the
-      # ?seed=/?replay= bridge is native — no glue patch.
+      # Single-source the let-go version from .let-go-version (the repo's pin).
       - name: Resolve let-go version
         id: letgo
         run: echo "version=$(grep -v '^#' .let-go-version | grep . | head -1 | tr -d '[:space:]')" >> "$GITHUB_OUTPUT"
@@ -47,10 +43,8 @@ jobs:
       - name: Install let-go
         run: go install github.com/nooga/let-go@${{ steps.letgo.outputs.version }}
 
-      # Build the bundle the way it ships: shell-less + xsofy's own client shell
-      # (rune font + ?font=system) + COI shim. LETGO_SRC pins the WASM runtime to
-      # the same release as the binary above, so `lg -w` doesn't compile the
-      # runtime from let-go@latest and drift from the binary's worker protocol.
+      # The shared build: shell-less + xsofy's own client shell (rune font +
+      # ?font=system) + COI shim. dist/ stays in this job (no artifact round-trip).
       - name: Build WASM bundle
         uses: ./.github/actions/build-wasm
         with:
@@ -72,10 +66,6 @@ jobs:
         working-directory: tests/browser
         run: node smoke.mjs --dir ../../dist
 
-      # Seeded determinism regression: boots /?seed=12345 and asserts the
-      # seed-derived title — proving the ?seed= bridge AND wasm==native xxh3.
-      # (The title-animation gate is the separate `smoke.mjs` step above /
-      # the fixme test, pending nooga/xsofy#61.)
       - name: E2E seeded regression (@playwright/test)
         working-directory: tests/e2e
         run: |
@@ -91,11 +81,11 @@ jobs:
           path: tests/browser/smoke-failure.png
           if-no-files-found: ignore
 
-      - name: Upload Pages artifact
-        uses: actions/upload-pages-artifact@v3
+      - name: Publish to gh-pages root
+        uses: peaceiris/actions-gh-pages@v4
         with:
-          path: dist
-
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: dist
+          # keep_files so a root deploy doesn't wipe live /pr-N/ previews
+          # (or pinned /vX.Y.Z/ version dirs).
+          keep_files: true

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -1,0 +1,97 @@
+name: PR Preview
+
+# Publishes a self-contained WASM build of a PR to gh-pages/pr-<N>/, served at
+#   https://<owner>.github.io/xsofy/pr-preview/pr-<N>/
+# and removes it when the PR closes. Same composite build as the tag deploy, so
+# a preview is byte-for-byte what a release would ship.
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened, labeled, closed]
+
+# One run per PR; a newer event (label after open, or a new push) cancels the
+# in-flight one, so opened+labeled don't double-fire.
+concurrency:
+  group: pr-preview-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+# pull_request_target runs in the BASE-repo context with a write token, which is
+# what lets it publish previews for fork PRs. To keep that token away from
+# untrusted PR code, the build/publish only runs once a maintainer applies the
+# 'deploy-preview' label (the if: gate). Removal on close runs regardless.
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  deploy:
+    if: >
+      github.event.action != 'closed' &&
+      contains(github.event.pull_request.labels.*.name, 'deploy-preview')
+    runs-on: ubuntu-latest
+    concurrency:
+      group: gh-pages-publish      # serialize gh-pages writes with the tag deploy
+      cancel-in-progress: false
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Resolve let-go version
+        id: letgo
+        run: echo "version=$(grep -v '^#' .let-go-version | grep . | head -1 | tr -d '[:space:]')" >> "$GITHUB_OUTPUT"
+
+      - name: Check out let-go (pinned)
+        uses: actions/checkout@v4
+        with:
+          repository: nooga/let-go
+          ref: ${{ steps.letgo.outputs.version }}
+          path: let-go-src
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.26'
+
+      - name: Install let-go
+        run: go install github.com/nooga/let-go@${{ steps.letgo.outputs.version }}
+
+      - name: Build WASM bundle
+        uses: ./.github/actions/build-wasm
+        with:
+          dist: dist
+          letgo-src: ${{ github.workspace }}/let-go-src
+
+      - name: Set up Node (smoke gate)
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install smoke dependencies
+        working-directory: tests/browser
+        run: |
+          npm ci --no-audit --no-fund
+          npx playwright install --with-deps chromium
+
+      - name: Browser smoke (must boot to title screen)
+        working-directory: tests/browser
+        run: node smoke.mjs --dir ../../dist
+
+      - name: Deploy preview
+        uses: rossjrw/pr-preview-action@v1
+        with:
+          source-dir: dist
+          action: deploy
+
+  remove:
+    if: github.event.action == 'closed'
+    runs-on: ubuntu-latest
+    concurrency:
+      group: gh-pages-publish
+      cancel-in-progress: false
+    steps:
+      - uses: actions/checkout@v4
+      - name: Remove preview
+        uses: rossjrw/pr-preview-action@v1
+        with:
+          action: remove


### PR DESCRIPTION
## What this does

Moves Pages publishing off the GitHub Actions deployment model onto a `gh-pages` branch. The tag deploy publishes to the branch root; a labeled PR publishes a self-contained WASM build to `gh-pages/pr-<N>/` and removes it when the PR closes.

Reuses the `.github/actions/build-wasm` composite action from #102 (merged), so previews and the tag deploy ship the same bundle.

## Why

- **Per-PR previews.** Reviewers can play a PR's build at a stable URL before merge, instead of building locally or trusting a screenshot.
- **Multiple versions side by side, later.** Once the site is branch-served, hosting `/`, `/pr-N/`, and pinned `/vX.Y.Z/` from one branch is more directories: the substrate for a version switcher.
- **Drops the `github-pages` environment.** Branch publishing doesn't use it, which also clears the environment protection rule that blocked tag deploys.

## The change

Two workflow files; no game source touched. Both reuse the `.github/actions/build-wasm` composite action from #102, so previews and the tag deploy build the same shipping bundle (rune font + `?font=system`) and the build output stays in the job — no artifact round-trip.

- **`deploy-pages.yml`** — the `v*` tag deploy now publishes `dist/` to `gh-pages` root (peaceiris, `keep_files: true` so a deploy doesn't wipe live previews) instead of `upload-pages-artifact` + `deploy-pages`. Permissions drop to `contents: write`.
- **`pr-preview.yml`** — a `deploy-preview` label publishes a preview to `gh-pages/pr-<N>/` via `pr-preview-action` and removes it on close. It runs on `pull_request_target` so it can preview fork PRs, gated behind a maintainer applying the label so untrusted code never runs with the write token unprompted. Per-PR `concurrency` collapses the `opened` + `labeled` double-fire to one run.

## Cutover

One-time, for the maintainer, after merge. Merging this is safe on its own: until the Pages source is flipped, the site keeps serving the last Actions deployment. The steps are ordered — seed the branch before flipping the source, or the live site 404s in the gap:

1. **Merge this PR.** No user-facing change yet.
2. **Seed `gh-pages` root** — push a `v*` tag (or run the deploy via `workflow_dispatch`). This builds and creates `gh-pages` with the current site at root.
3. **Flip the Pages source** — Settings → Pages → Build and deployment → Source: Deploy from a branch → `gh-pages` / `(root)`. The live site is now served from the root seeded in step 2.
4. **Verify** the live URL serves the game.
5. Previews now work: label any PR `deploy-preview`.

Reversible: if anything looks wrong after the flip, switch the Pages source back to "GitHub Actions" and re-run the tag deploy on the previous workflow, and the old path is restored.

## Validation

Proven end to end on a fork before this PR: tag/seed deploy to `gh-pages` root, a labeled PR publishing a live preview, and cleanup removing it on close, with the root site untouched throughout.

## Follow-ups

Separate PRs, not included here:

- **COI service-worker fix.** The `patch_wasm_coi.lg` cleanup unregisters the service worker once isolated, but on Pages the SW *is* the isolation source, so that forces a re-register and reload on every visit (and, with multiple deployments on one origin, tears down siblings' SWs). A one-line `!controller` guard keeps the SW when isolation came from it. This one stands alone — it also fixes the every-visit double-load on the current single-site deploy.
- **Cache-bust on preview links.** Preview URLs are stable across pushes, so a re-deployed preview can serve a CDN-cached older build. Appending `?v=<sha>` to the link in the PR comment forces the fresh build.
