### PR TITLE
docs: add CHANGELOG + release-notes config (v0.0.2)

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,18 @@
+# Config for GitHub's auto-generated release notes (gh release create --generate-notes).
+# Categorizes merged PRs by label; unlabeled PRs fall into "Other changes".
+changelog:
+  exclude:
+    labels:
+      - ignore-for-release
+      - deploy-preview
+  categories:
+    - title: Features
+      labels: [feature, feat, enhancement]
+    - title: Fixes
+      labels: [bug, fix]
+    - title: CI / build
+      labels: [ci, build, infrastructure]
+    - title: Docs
+      labels: [documentation, docs]
+    - title: Other changes
+      labels: ['*']

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,13 +18,15 @@ applies to both builds.
 - Balance pass: tamed slimes, throttled ranged fire rate, softened spider webs
   (#71).
 - `Ctrl-C` as a confirm-quit alias for `Esc` (#76).
+- Death screen: dropped a redundant death line and cleaned up the scroll residue
+  in the message log (#109).
 
 ### Internal (not player-facing)
 
 - Pages deploys from `v*` tags, gated by a browser smoke + seeded-determinism e2e
   (#59, #60).
 - Branch-based Pages publishing + per-PR previews (#106).
-- Client-owned WASM shell; built against published let-go v1.11.x (#78, #94).
+- Client-owned WASM shell; built against published let-go v1.11.1 (#78, #94).
 - Dungeon map viewer and terrain workbench dev tools (#88, #93).
 
 [v0.0.2]: https://github.com/nooga/xsofy/releases/tag/v0.0.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,39 +1,30 @@
 # Changelog
 
-Notable changes to xsofy. Each version is a `v*` git tag that deploys the web build.
+Notable changes to xsofy. Each version is a `v*` git tag that releases both the
+web build (Pages) and the native build (Homebrew). Entries are the net change a
+player sees from the previous release; intra-cycle churn (introduced and fixed
+between tags) is omitted. Web-only items are marked `(web)`; everything else
+applies to both builds.
 
 ## v0.0.2
 
-### Highlights
+- Runes render in the browser terminal — v0.0.1 showed tofu/overflow, because the
+  web build shipped let-go's generic shell. It now ships xsofy's own shell with
+  the Fairfax HD rune face (#102). `(web)`
+- New `?font=system` — render the terminal in the platform monospace font instead
+  of the bundled rune face (#96). `(web)`
+- Reproducible, shareable runs: `?seed=<n>` reproduces a run, `?replay=<code>`
+  plays back a recording, and the seed is shown in-game (#62, #66, #69). `(web)`
+- Balance pass: tamed slimes, throttled ranged fire rate, softened spider webs
+  (#71).
+- `Ctrl-C` as a confirm-quit alias for `Esc` (#76).
 
-- **Runes render in the web build.** The browser terminal now ships the Fairfax HD rune face, so Runic-block glyphs display instead of tofu/overflow.
-- **`?font=system`** — a URL option to render the terminal in the platform monospace font instead of the bundled rune face.
-- **Cleaner death screen** — the raw replay code no longer overlays the tombstone.
+### Internal (not player-facing)
 
-### Added
-
-- `?font=system` to render the terminal in the platform mono (#96)
-- Knot rewind cords (#74)
-- Per-turn ring container triggers (#75)
-- `Ctrl-C` as a confirm-quit alias for `Esc` (#76)
-
-### Fixed
-
-- Death screen no longer overlays the on-screen replay code (#101)
-- Web-font measurement race that twitched the terminal (#95)
-- WASM-safe title input poll (a deploy regression) (#61)
-- Dev replay dump now routes off-terminal on web (#104)
-
-### Changed
-
-- The web build ships xsofy's own client shell (rune font + `?font=system`) instead of let-go's generic shell (#78, #102)
-- Balance: tamed slimes, throttled ranged fire rate, softened spider webs (#71)
-- Built against published let-go v1.11.0/v1.11.1; the `?seed=` / `?replay=` URL bridge is now native (#94)
-
-### Infrastructure
-
-- Pages deploys from `v*` tags, gated by a browser smoke + seeded-determinism e2e (#59, #60)
-- Branch-based Pages publishing + per-PR previews (#106)
-- Dungeon map viewer and terrain workbench dev tools (#88, #93)
+- Pages deploys from `v*` tags, gated by a browser smoke + seeded-determinism e2e
+  (#59, #60).
+- Branch-based Pages publishing + per-PR previews (#106).
+- Client-owned WASM shell; built against published let-go v1.11.x (#78, #94).
+- Dungeon map viewer and terrain workbench dev tools (#88, #93).
 
 [v0.0.2]: https://github.com/nooga/xsofy/releases/tag/v0.0.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,39 @@
+# Changelog
+
+Notable changes to xsofy. Each version is a `v*` git tag that deploys the web build.
+
+## v0.0.2
+
+### Highlights
+
+- **Runes render in the web build.** The browser terminal now ships the Fairfax HD rune face, so Runic-block glyphs display instead of tofu/overflow.
+- **`?font=system`** — a URL option to render the terminal in the platform monospace font instead of the bundled rune face.
+- **Cleaner death screen** — the raw replay code no longer overlays the tombstone.
+
+### Added
+
+- `?font=system` to render the terminal in the platform mono (#96)
+- Knot rewind cords (#74)
+- Per-turn ring container triggers (#75)
+- `Ctrl-C` as a confirm-quit alias for `Esc` (#76)
+
+### Fixed
+
+- Death screen no longer overlays the on-screen replay code (#101)
+- Web-font measurement race that twitched the terminal (#95)
+- WASM-safe title input poll (a deploy regression) (#61)
+- Dev replay dump now routes off-terminal on web (#104)
+
+### Changed
+
+- The web build ships xsofy's own client shell (rune font + `?font=system`) instead of let-go's generic shell (#78, #102)
+- Balance: tamed slimes, throttled ranged fire rate, softened spider webs (#71)
+- Built against published let-go v1.11.0/v1.11.1; the `?seed=` / `?replay=` URL bridge is now native (#94)
+
+### Infrastructure
+
+- Pages deploys from `v*` tags, gated by a browser smoke + seeded-determinism e2e (#59, #60)
+- Branch-based Pages publishing + per-PR previews (#106)
+- Dungeon map viewer and terrain workbench dev tools (#88, #93)
+
+[v0.0.2]: https://github.com/nooga/xsofy/releases/tag/v0.0.2


### PR DESCRIPTION
First curated changelog (v0.0.1 shipped with no release notes) plus `.github/release.yml` so `gh release create --generate-notes` categorizes PRs by label.

Single running `CHANGELOG.md` (Keep a Changelog style); v0.0.2 section covers everything since v0.0.1. Merge before tagging v0.0.2 so the tag includes it.