### PR TITLE
fix(ui): death-screen log — drop redundant death line + pad scroll residue

### DIFF
--- a/xsofy/render.lg
+++ b/xsofy/render.lg
@@ -1005,7 +1005,7 @@
       (term/move-cursor 2 log-top)
       (term/set-fg 90 80 65)
       (term/set-bg 10 10 10)
-      (term/write (str "─── Messages " (if (> max-offset 0) (str "(" (- log-count offset) "/" log-count ") ") "") "───"))
+      (term/write (u/right-pad (str "─── Messages " (if (> max-offset 0) (str "(" (- log-count offset) "/" log-count ") ") "") "───") (- tw 4)))
       ;; messages
       (dotimes [i (count visible)]
         (let [msg (format-log-entry (nth visible i))
@@ -1014,9 +1014,11 @@
           (term/move-cursor 3 (+ log-top 1 i))
           (term/set-fg bright (max 40 (- bright 25)) (max 30 (- bright 50)))
           (term/set-bg 10 10 10)
-          (term/write (if (> (count msg) (- tw 4))
-                        (subs msg 0 (- tw 4))
-                        msg)))))
+          ;; pad to the panel width so a shorter line erases the residue of a
+          ;; longer one when scrolling — the death screen never clear-rects per
+          ;; frame, so each line must clear its own trailing cells.
+          (let [w (- tw 4)]
+            (term/write (u/right-pad (if (> (count msg) w) (subs msg 0 w) msg) w))))))
     ;; prompt
     (let [prompt (if *in-wasm*
                    "[n/enter] new game    [esc] confirm restart    [j/k] scroll"

--- a/xsofy/world.lg
+++ b/xsofy/world.lg
@@ -19,6 +19,7 @@
             [xsofy.title :as title]
             [xsofy.opcontext :as opctx]
             [xsofy.util :as u]
+            [string :as str]
             [math]))
 
 ;; --- World invariants ---
@@ -1886,7 +1887,14 @@
       (if (or (nil? (get-in w [:entities :player]))
               (nil? (get-in w [:entities :player :body :hp]))
               (<= (get-in w [:entities :player :body :hp] 0) 0))
-        (-> w
-            (log-msg "You die...")
-            (assoc :screen :death))
+        ;; Skip the generic "You die..." when a specific kill line ("The X
+        ;; kills you!") was just logged — it's redundant. Non-combat deaths
+        ;; (poison/burning) keep it as their death marker (balance.lg relies
+        ;; on it too).
+        (let [last-msg (let [e (peek (or (:log w) []))]
+                         (if (map? e) (:msg e) e))
+              kill-line? (and (string? last-msg) (str/includes? last-msg "kills you"))]
+          (-> w
+              (cond-> (not kill-line?) (log-msg "You die..."))
+              (assoc :screen :death)))
         w))))


### PR DESCRIPTION
Two death-screen message-log fixes that are on the daily branch but not on `main`.

**Redundant "You die…" line (`world.lg`)** — when death follows a kill, combat already logs "The X kills you!", and the death branch then also logs "You die…", so the log shows both. Drops the redundant "You die…" when a cause-of-death line was already logged that turn.

**Message-log scroll residue (`render.lg`)** — the death-screen log rows were written without right-padding, so scrolling up left tails of longer earlier lines behind shorter ones. Pads each rendered row to width.

Both touch only the death-screen log. xsofy suite 279/2725 green; native compile clean.

Companion to the `d3ac676` re-clear-on-resize fix, which needs a manual rebase over the merged #101 render-death-screen change and will follow in a separate death-screen-polish PR.