### PR TITLE
Native engine benchmark + shared xsofy.perf core

### DIFF
--- a/bench/native.lg
+++ b/bench/native.lg
@@ -1,0 +1,47 @@
+;; bench/native.lg — native engine benchmark (Tier 1).
+;;
+;; Drives xsofy.perf's shared core against the same lg binary that runs the
+;; game, headlessly: no render, no bridge, no xterm. Measures the engine's
+;; per-turn cost in isolation so later overheads (WASM/JS bridge/xterm canvas)
+;; can be attributed by delta. The in-bundle WASM harness (xsofy/bench.lg)
+;; drives the same core + fixtures so the two numbers diff directly.
+;;
+;; Run:  lg bench/native.lg
+;;
+;; Seed strategy: seed = trial index, so each trial samples a distinct world;
+;; averaging across the spread also smooths timing noise (GC, scheduling).
+;; rand-int is cosmetic-only and never touches gameplay state.
+;;
+;; No (ns ...) form: lg evaluates a namespaced file twice (script + namespace
+;; load), which would double-run the bench. tests/run.lg uses the same trick;
+;; the bare-symbol require + separate alias below is the non-ns idiom.
+
+(require 'xsofy.perf)
+(alias 'perf 'xsofy.perf)
+
+(def fixtures
+  [;; baseline: entity AI + floor effects tick, player idle — "what does an
+   ;; empty turn cost?"
+   [:wait    (fn [_] ".") 60]
+   ;; autoexplore: BFS pathfinder + render-full cadence as the camera shifts.
+   [:autoex  (fn [n] (if (zero? n) "x" ".")) 60]
+   ;; descend-then-wait: reach deeper floors (more entities/lighting/fire).
+   [:descend (fn [n] (if (zero? n) ">" ".")) 60]
+   ;; busy-explore: long autoexplore across varied terrain — allocator attribution.
+   [:busy    (fn [n] (if (zero? n) "x" ".")) 300]])
+
+(def TRIALS 5)
+(def seeds  (vec (range TRIALS)))   ; distinct seed per trial
+
+(defn -main []
+  (println "=== xsofy native engine benchmark ===")
+  (println (format "trials per fixture: %d (each a distinct seed); turns vary — see n" TRIALS))
+  (println)
+  (println (format "%-12s %6s %6s %6s %6s %6s" "fixture" "n" "avg" "p50" "p95" "max"))
+  (println (format "%-12s %6s %6s %6s %6s %6s" "--------" "------" "------" "------" "------" "------"))
+  (doseq [f fixtures]
+    (let [s (perf/run-fixture f seeds 1)]   ; :per-seed ignored here
+      (println (format "%-12s %6d %5dms %5dms %5dms %5dms"
+                       (str (:name s)) (:n s) (:avg s) (:p50 s) (:p95 s) (:max s))))))
+
+(-main)

--- a/bench/native.lg
+++ b/bench/native.lg
@@ -10,7 +10,6 @@
 ;;
 ;; Seed strategy: seed = trial index, so each trial samples a distinct world;
 ;; averaging across the spread also smooths timing noise (GC, scheduling).
-;; rand-int is cosmetic-only and never touches gameplay state.
 ;;
 ;; No (ns ...) form: lg evaluates a namespaced file twice (script + namespace
 ;; load), which would double-run the bench. tests/run.lg uses the same trick;

--- a/xsofy/perf.lg
+++ b/xsofy/perf.lg
@@ -1,0 +1,81 @@
+(ns xsofy.perf
+  (:require [xsofy.world :as world]
+            [xsofy.input :as input]))
+
+;; Shared benchmark core — the UI-agnostic engine-timing primitives that both
+;; the native harness (bench/native.lg) and the in-bundle WASM harness
+;; (xsofy/bench.lg) drive. World+input only: no render, no bridge, no xterm,
+;; no println, no profiling — those belong to the drivers. Keeping this core
+;; dependency-free is what lets the native harness stand alone.
+;;
+;; A fixture is [name keystroke-fn turn-count]. keystroke-fn takes the 0-based
+;; turn index and returns the *string* form of a key; the driver owns the list.
+;;
+;; Determinism: make-world threads `seed` through the world's det state (RNG +
+;; :next-id), so a given seed replays bit-identically run-to-run. Drivers choose
+;; their seed strategy (spread of worlds vs a pinned world) via run-fixture args.
+
+(defn time-turn
+  "Run one turn; return [new-world ms]."
+  [w key-str]
+  (let [k  (input/parse-key key-str)
+        t0 (System/currentTimeMillis)
+        w' (world/update-world w k)
+        dt (- (System/currentTimeMillis) t0)]
+    [w' dt]))
+
+(defn run-trial
+  "One trial: fresh world at `seed`, up to n turns (stops early on player
+   death). Returns a vector of per-turn ms."
+  [keystroke-fn n seed]
+  (loop [w (world/make-world 79 30 seed)
+         i 0
+         samples (transient [])]
+    (cond
+      (= i n)                               (persistent! samples)
+      (nil? (get-in w [:entities :player])) (persistent! samples)
+      :else
+      (let [[w' dt] (time-turn w (keystroke-fn i))]
+        (recur w' (inc i) (conj! samples dt))))))
+
+(defn percentile [sorted p]
+  (let [n (count sorted)
+        idx (min (dec n) (int (* (dec n) p)))]
+    (nth sorted idx)))
+
+(defn summarize [samples]
+  ;; Short-circuit the empty case: percentile calls (nth sorted -1) on an empty
+  ;; vector otherwise. run-fixture can hand us no samples (empty seeds, zero
+  ;; trials, or a zero-turn fixture).
+  (let [n (count samples)]
+    (if (zero? n)
+      {:n 0 :avg 0 :p50 0 :p95 0 :max 0}
+      (let [sorted (vec (sort samples))
+            sum (reduce + samples)]
+        {:n   n
+         :avg (quot sum n)
+         :p50 (percentile sorted 0.50)
+         :p95 (percentile sorted 0.95)
+         :max (last sorted)}))))
+
+(defn run-fixture
+  "Run `fixture` once per seed in `seeds`, `trials` times per seed. Returns
+   {:name kw, <aggregate summarize keys>, :per-seed [{:seed n ...} ...]}.
+   Aggregate spans all samples; :per-seed surfaces seed-specific variance.
+     - spread-of-worlds: (run-fixture f (vec (range TRIALS)) 1)
+     - pinned world:     (run-fixture f [42] TRIALS)"
+  [[name keystroke-fn turn-count] seeds trials]
+  (let [per (mapv (fn [seed]
+                    {:seed seed
+                     :samples (loop [i 0 acc []]
+                                (if (= i trials)
+                                  acc
+                                  (recur (inc i)
+                                         (into acc (run-trial keystroke-fn turn-count seed)))))})
+                  seeds)
+        all (vec (mapcat :samples per))]
+    (merge (summarize all)
+           {:name     name
+            :per-seed (mapv (fn [{:keys [seed samples]}]
+                              (assoc (summarize samples) :seed seed))
+                            per)})))


### PR DESCRIPTION
# Native engine benchmark + shared `xsofy.perf` core

## Why

We have no way to measure the engine's per-turn cost on its own. Every timing
number today is entangled with the browser: WASM, the JS bridge, and the xterm
canvas all sit between a turn and the clock. That makes "is the game slow?" and
"is the *shell* slow?" the same unanswerable question.

This adds a native, headless baseline — Tier 1. It runs the same `lg` binary
that runs the game, headless: no render, no bridge, no terminal. It times
`update-world` directly. Once the in-bundle WASM harness lands and drives the
same fixtures, the browser overhead falls out as a straight delta instead of a
guess.

## What

- `xsofy/perf.lg` — a UI-agnostic timing core: `time-turn`, `run-trial`,
  `percentile`, `summarize`, `run-fixture`. World and input only.
- `bench/native.lg` — a native CLI driver (`lg bench/native.lg`) that defines
  the fixtures and prints the table.

Four fixtures, chosen to exercise distinct cost centers: `:wait` (idle turn —
AI + floor effects with the player still), `:autoex` (BFS pathfinder + full
render cadence), `:descend` (one descent then idle — the floor-gen + entity/lighting/fire spike), and
`:busy` (long autoexplore for allocator behavior).

```
fixture           n    avg    p50    p95    max
--------     ------ ------ ------ ------ ------
:wait           300    10ms    10ms    18ms    23ms
:autoex         300    11ms    11ms    15ms    18ms
:descend        300    11ms    11ms    17ms    56ms
:busy          1002     9ms    10ms    13ms    17ms
```

## Design notes

- **The core is deliberately dependency-free** (no render/bridge/xterm/println).
  That is what lets the native harness stand alone, and what lets the future
  WASM harness drive the *same* core and fixtures so the two numbers compare
  directly. The drivers own presentation and seed policy; the core owns timing.
- **Seed = trial index.** Each trial samples a distinct world, so averaging
  across the spread also smooths timing noise (GC, scheduling). Determinism
  comes from `make-world` threading the seed through the world's RNG and
  `:next-id`, so a given seed replays bit-identically. `run-fixture` takes
  `(seeds, trials)` explicitly, so a caller can instead pin one world and repeat
  it — the one real policy difference between drivers is now an argument, not a
  fork.
- **No `(ns …)` form in `bench/native.lg`.** `lg` evaluates a namespaced file
  twice (script eval + namespace load), which would run the bench twice. The
  bare `require` + `alias` is the same idiom `tests/run.lg` uses.

This is purely additive: `main` has no bench today.

