### PR TITLE
Debounced resize / orientation / visualViewport re-fit (#83)

### DIFF
--- a/tools/xsofy-shell.html
+++ b/tools/xsofy-shell.html
@@ -521,7 +521,34 @@
       }
     });
 
-    window.addEventListener("resize", refit);
+    // Ambient viewport changes — drag-resize, rotation, and the mobile URL bar
+    // showing/hiding — arrive as a burst of events over the gesture. Debounce
+    // to the trailing edge and coalesce the fit into one rAF so it runs once
+    // per settle, never mid-gesture or on an intermediate size. Discrete user
+    // actions (font cycle, touch-control toggle) call refit() directly below —
+    // they're single events and don't need settling.
+    let refitTimer = null, refitRaf = null;
+    function scheduleRefit() {
+      if (refitTimer) clearTimeout(refitTimer);
+      refitTimer = setTimeout(() => {
+        refitTimer = null;
+        if (refitRaf) cancelAnimationFrame(refitRaf);
+        refitRaf = requestAnimationFrame(() => { refitRaf = null; refit(); });
+      }, 120);
+    }
+
+    window.addEventListener("resize", scheduleRefit);
+    // Rotation settles over several resize events; the trailing-edge debounce
+    // waits them out, so no extra orientation-specific delay is needed.
+    window.addEventListener("orientationchange", scheduleRefit);
+    // The URL bar collapsing/expanding reclaims height without always firing a
+    // window resize; it does fire visualViewport resize (and scroll on some
+    // engines). refit() is grid-change-gated, so scroll spam costs nothing when
+    // the row count is unchanged.
+    if (window.visualViewport) {
+      window.visualViewport.addEventListener("resize", scheduleRefit);
+      window.visualViewport.addEventListener("scroll", scheduleRefit);
+    }
 
     // Shell-owned font sizing — replaces the fork's host-side _lgSetFontSize.
     // Safe before term.open (sets the option; the fit() is caught); the


### PR DESCRIPTION
# Debounced resize / orientation / visualViewport re-fit

Addresses #83. Stacked on #113 (the touch shell) — the re-fit function and the
explicit toggle/font-cycle calls this builds on land there; review this diff as
the top commit.

## Why

The shell re-fits off a single `window` `resize` listener. On a phone that
misses the cases that matter:

- The URL bar showing or hiding reclaims height but doesn't always fire a
  `window` resize — it fires a `visualViewport` resize. The grid never re-fits
  to the reclaimed rows.
- Rotation settles over a burst of events; a fit on each can land on an
  intermediate size.
- An un-debounced fit thrashes mid-gesture during a drag or rotate.

The viewport-meta and `dvh` work fixed the height; the re-fit *trigger* was
still the weak link.

## What

Route the ambient triggers (`resize`, `orientationchange`, and `visualViewport`
resize/scroll) through a trailing-edge debounce that coalesces into a single
`requestAnimationFrame` fit per settle. `refit()` is already gated on an actual
character-grid change, so no-op events (a `visualViewport` scroll that doesn't
change the row count) cost nothing. Discrete user actions (the font-size cycle
and the touch-control toggle) keep calling `refit()` directly; they're single
events and don't need settling.

## Validation

Browser, mobile viewport (390 wide):

- Grow height 700 → 980: grid re-fits 16 → 23 rows. Shrink to 500: → 11 rows.
- A burst of five rapid resizes coalesces to two fits (not five), and the final
  grid matches the final viewport — debounced, no thrash.
- `crossOriginIsolated` holds, terminal boots, no new console errors.

Desktop resize still fits (same `resize` path, now debounced); native is
unaffected — none of these events exist there.
