### PR TITLE
Center the terminal grid (letterbox the fit remainder)

### DIFF
--- a/tools/xsofy-shell.html
+++ b/tools/xsofy-shell.html
@@ -480,7 +480,31 @@
     // Mirrors native SIGWINCH behavior; gated on grid change so per-pixel
     // resize events don't spam the worker.
     function refit() {
+      // Clear the letterbox padding before fitting so fit() measures the full
+      // box, not the previously-padded one (which would ratchet inward).
+      const host = term.element ? term.element.parentElement : null; // #terminal
+      if (host) { host.style.padding = "0px"; }
       try { fit.fit(); } catch (_) {}
+      // Letterbox the sub-cell fit remainder on both axes. The grid is a whole
+      // number of fixed-size cells, so up to ~one cell is left over per axis;
+      // xterm pins the grid top-left, pooling the slack on the right and bottom
+      // edges. Split each axis into equal padding so the grid sits centered —
+      // the geometry is unchanged, only where the slack lives. #terminal's
+      // border-box is fixed by flex (height) and stretch (width), so this
+      // padding stays inside it and never shifts the bar below.
+      const screen = host ? host.querySelector(".xterm-screen") : null;
+      if (host && screen) {
+        const slackX = host.clientWidth - screen.clientWidth;
+        const slackY = host.clientHeight - screen.clientHeight;
+        if (slackX > 1) {
+          const p = Math.floor(slackX / 2) + "px";
+          host.style.paddingLeft = p; host.style.paddingRight = p;
+        }
+        if (slackY > 1) {
+          const p = Math.floor(slackY / 2) + "px";
+          host.style.paddingTop = p; host.style.paddingBottom = p;
+        }
+      }
       if (term.cols !== lastCols || term.rows !== lastRows) {
         lastCols = term.cols; lastRows = term.rows;
         if (boundMode === "worker" && window.LetGoHost) {
@@ -519,6 +543,9 @@
         term.onResize(({ cols, rows }) => window.LetGoHost.setSize(cols, rows));
         term.onData((d) => window.LetGoHost.sendInput(d));
       }
+      // Center the grid on first paint. lastCols/lastRows are already set, so
+      // this only applies the letterbox padding — it won't re-advertise size.
+      refit();
     });
 
     // Ambient viewport changes — drag-resize, rotation, and the mobile URL bar


### PR DESCRIPTION
# Center the terminal grid (letterbox the fit remainder)

Stacked on #114 — it extends the same `refit()`. Part of the #84 shell
ergonomics work; review this diff as the top commit.

## Why

xterm renders a fixed-cell grid, and the FitAddon floors to a whole number of
columns and rows. A container is almost never an exact multiple of the cell
size, so up to ~one cell is left over on each axis — and xterm pins the grid to
the top-left, pooling that slack on the right and bottom edges. At most viewport
sizes the grid sits visibly hard against the top-left with a ragged gap on the
right and below.

## What

In `refit()`, split the remainder on each axis into equal padding on `#terminal`
so the grid sits centered. The padding is cleared before `fit()` (so it measures
the full box, not the previously-padded one) and re-applied after. `onReady` now
calls `refit()` once so the centering also lands on first paint, not only after
a resize.

`#terminal`'s border-box is fixed by flex (height) and the default column-flex stretch
(width), so the padding stays inside it and never shifts the bar below it. The
grid geometry is untouched — same columns, same rows, same cell metrics. Only
the offset changes, so xterm's selection and mouse mapping stay aligned: they
read the screen element's own rect, which moves with the padding.

## Validation

Browser, measured grid offset (px):

- Landscape 1440×760: was 0/19 right, 0/11 bottom → **9/10** left/right, **5/6**
  top/bottom. Grid stays inside `#terminal`; the bar below is unmoved.
- Portrait 390×780: **8/8** and **7/8**; the `55vh` terminal height is
  preserved, so the grid centers within it and the touch panel below is
  untouched.
- Re-splits on resize (e.g. 1607 wide → 9/9).

The ≤1px asymmetry is the odd-pixel remainder of an odd slack.

