### PR TITLE
[canary · do not merge] Pages deploy sanity check (off #108)

### DIFF
--- a/xsofy/fire.lg
+++ b/xsofy/fire.lg
@@ -19,25 +19,34 @@
 (def fire-default-ttl 5)
 (def protected-tiles #{13 14})  ;; stairs must survive dragon fire and rune fire
 
+;; Fire is light-emitting, so any ignition must invalidate the :lights
+;; cache — step-fire's own terrain-changed gate only sees fires it spreads
+;; or burns out, not ignitions from burning-entities-ignite / dragon /
+;; rune fire, which run in separate phases. Invalidating here (not just in
+;; step-fire) keeps the cache correct for every call site.
 (defn ignite [world x y]
   "Set a tile on fire. Only works on flammable tiles or if forced."
   (let [{:keys [terrain width]} world
         tile (terrain/tget terrain width x y)]
     (if (or (contains? terrain/flammable-tiles tile) (= tile 1))
       (do (terrain/tset! terrain width x y fire-tile)
-          (assoc-in world [:fire-ttl [x y]] fire-default-ttl))
+          (-> world
+              (assoc-in [:fire-ttl [x y]] fire-default-ttl)
+              (assoc :lights nil)))
       world)))
 
 (defn ignite-forced [world x y ttl]
   "Force fire at a position regardless of terrain."
   (let [{:keys [terrain width]} world
-        tile (terrain/tget terrain width x y)]
-    (when (and (not= tile 0) (not= tile 8) (not= tile 7)
-               (not (contains? protected-tiles tile)))  ;; not void, wall, lava, stairs
+        tile (terrain/tget terrain width x y)
+        placed? (and (not= tile 0) (not= tile 8) (not= tile 7)
+                     (not (contains? protected-tiles tile)))]  ;; not void, wall, lava, stairs
+    (when placed?
       (terrain/tset! terrain width x y fire-tile))
     (if (contains? protected-tiles tile)
       world
-      (assoc-in world [:fire-ttl [x y]] ttl))))
+      (let [w (assoc-in world [:fire-ttl [x y]] ttl)]
+        (if placed? (assoc w :lights nil) w)))))
 
 (defn step-fire [world]
   "One tick of fire simulation. Spread, damage, burn out.

--- a/xsofy/fire.lg
+++ b/xsofy/fire.lg
@@ -46,6 +46,11 @@
         fire-ttl (or (:fire-ttl world) {})
         new-fires (atom [])
         new-ttl (atom {})
+        ;; Track whether terrain actually mutated. Used to gate :lights
+        ;; cache invalidation — collect-terrain-lights is O(w*h) and was
+        ;; previously rerun every turn even when no fire ignited or
+        ;; burned out, which is the common case once a floor is settled.
+        terrain-changed (atom false)
         w-ctx (det/with-context world [:fire :step])
         ;; process each fire cell, threading world through spread rolls
         w-after-rolls
@@ -58,6 +63,7 @@
                   (do
                     ;; burn out → ash
                     (terrain/tset! terrain width x y ash-tile)
+                    (reset! terrain-changed true)
                     w)
                   (do
                     ;; keep burning
@@ -87,6 +93,7 @@
                         (if (not= t fire-tile)
                           (do (terrain/tset! (:terrain w) (:width w) x y fire-tile)
                               (swap! new-ttl assoc [x y] fire-default-ttl)
+                              (reset! terrain-changed true)
                               w)
                           w)))
                     w-after-rolls @new-fires)]
@@ -106,8 +113,14 @@
                                         w)))
                                   w targets)))
                       w @new-ttl)]
-        ;; update fire ttl, recompute lights since fire changed
-        (assoc w :fire-ttl @new-ttl :lights nil)))))
+        ;; update fire ttl. Invalidate :lights cache only when terrain
+        ;; actually mutated (a fire ignited or burned out to ash) — those
+        ;; are the only state changes that affect which tiles emit light.
+        ;; Skipping the invalidation on settled turns avoids an O(w*h)
+        ;; terrain scan in collect-terrain-lights on the next update-fov.
+        (if @terrain-changed
+          (assoc w :fire-ttl @new-ttl :lights nil)
+          (assoc w :fire-ttl @new-ttl))))))
 
 ;; --- Web System ---
 ;; Webs are tile 19. Creatures stepping on them get :webbed status.

--- a/xsofy/test/fire_test.lg
+++ b/xsofy/test/fire_test.lg
@@ -1,0 +1,37 @@
+(ns xsofy.test.fire-test
+  (:require [test :refer [deftest is testing]]
+            [xsofy.terrain :as terrain]
+            [xsofy.fire :as fire]))
+
+(defn- room-world []
+  (let [w 12 h 8
+        t (terrain/make-terrain w h)]
+    (terrain/carve-room! t w 1 1 (- w 2) (- h 2))
+    {:terrain t :width w :height h :fire-ttl {}}))
+
+;; Regression for the :lights cache gate (perf: only invalidate on real
+;; terrain mutation). step-fire's terrain-changed gate only sees fires it
+;; spreads or burns out — ignitions from burning-entities-ignite / dragon /
+;; rune fire run in separate phases, so the ignite helpers must invalidate
+;; :lights themselves or a new fire emits no light until it spreads.
+(deftest ignite-flammable-invalidates-lights
+  (let [w (assoc (room-world) :lights [])            ;; stale cached lights
+        _ (terrain/tset! (:terrain w) (:width w) 3 3 2)]  ;; grass (flammable)
+    (let [w' (fire/ignite w 3 3)]
+      (is (= fire/fire-tile (terrain/tget (:terrain w') (:width w') 3 3)))
+      (is (nil? (:lights w'))))))
+
+(deftest ignite-forced-invalidates-lights
+  (let [w (assoc (room-world) :lights [])            ;; 3,3 is carved floor
+        w' (fire/ignite-forced w 3 3 5)]
+    (is (= fire/fire-tile (terrain/tget (:terrain w') (:width w') 3 3)))
+    (is (nil? (:lights w')))))
+
+;; Guard the optimization the other way: an ignite that places no fire
+;; (non-flammable tile) must NOT invalidate, else the cache gate buys
+;; nothing.
+(deftest ignite-noop-preserves-lights
+  (let [w (assoc (room-world) :lights [])
+        _ (terrain/tset! (:terrain w) (:width w) 3 3 8)]  ;; wall — not flammable
+    (let [w' (fire/ignite w 3 3)]
+      (is (= [] (:lights w'))))))

--- a/xsofy/test/run.lg
+++ b/xsofy/test/run.lg
@@ -14,6 +14,7 @@
             [xsofy.test.serialize-test]
             [xsofy.test.dag-test]
             [xsofy.test.container-trigger-test]
+            [xsofy.test.fire-test]
             [xsofy.test.seed-test]
             [xsofy.test.mapgen-audit-test]
             [xsofy.test.replay-test]


### PR DESCRIPTION
Throwaway sanity check — **do not merge, will close.** Empty commit on #108's branch (`perf/wander-lights-cache`), whose preview deployed fine on 2026-07-01. Labeling `deploy-preview` to test whether the current Pages deploy failure is environmental (times out the same way) or content-specific to our mobile stack. Expecting it to time out.