### PR TITLE
ci(pages): recreate the root CNAME if it's ever dropped

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -89,3 +89,9 @@ jobs:
           # keep_files so a root deploy doesn't wipe live /pr-N/ previews
           # (or pinned /vX.Y.Z/ version dirs).
           keep_files: true
+          # Recreate the root CNAME if it's ever missing — e.g. keep_files
+          # gets flipped off (which git-rm's the branch) or gh-pages is
+          # re-derived. peaceiris skips this when a CNAME is already present,
+          # so it won't stomp a domain set via the Pages UI; it's a
+          # restore-if-dropped safety net, not a per-deploy overwrite.
+          cname: xsofy.quest


### PR DESCRIPTION
## What

Add `cname: xsofy.quest` to the `peaceiris/actions-gh-pages` step in `deploy-pages.yml`.

## Why

The tag deploy relies on `keep_files: true` to preserve the root `CNAME` the owner added when setting up the custom domain (`xsofy.quest`). That preservation is *passive*: it holds only as long as `keep_files` stays on and nothing re-derives the `gh-pages` branch. If `keep_files` is ever flipped off (which git-rm's the branch) or the branch is re-derived, the `CNAME` drops silently and the custom domain breaks — with no signal until users hit the bare `github.io` URL.

## What the `cname` input actually does

peaceiris writes the `CNAME` only when the file is **absent** from the publish target — it logs `CNAME already exists, skip adding CNAME` and no-ops when one is already present (see [`utils.ts` `addCNAME`](https://github.com/peaceiris/actions-gh-pages/blob/v4/src/utils.ts)). So this is **create-if-missing**, not a per-deploy overwrite:

- Normal deploy (`keep_files` on, CNAME present) → skipped, no change.
- `keep_files` flipped off → `git rm -r *` wipes the branch CNAME → peaceiris recreates it.
- branch re-derived / orphaned → fresh tree, no CNAME → peaceiris recreates it.

That's exactly the self-healing we want, and it's the *right* behavior: because it never overwrites an existing CNAME, it won't stomp a domain deliberately changed through the repo's Pages settings UI (which writes its own CNAME to `gh-pages` root). It's a restore-if-dropped safety net, not an enforce-this-value hammer.

## Scope / safety

- One line (plus a comment). No behavior change while `CNAME` is present today — it just closes the drop-and-stay-dropped failure mode.
- The PR-preview workflow is unaffected: `rossjrw/pr-preview-action` only writes under `pr-preview/pr-<N>/` and never touches root, so it needs no equivalent.

## Not this PR

This does **not** address the current Pages *activation* stall (deploys hanging/cancelling since 2026-07-02 ~15:27 UTC). That's a separate, domain-state issue on the Pages environment side; the `CNAME` file itself has been intact and unchanged throughout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)