### PR TITLE
Drop redundant HP/depth from the browser chrome

### DIFF
--- a/tools/xsofy-shell.html
+++ b/tools/xsofy-shell.html
@@ -376,8 +376,11 @@
     <span class="quest play-only" id="xs-quest"></span>
     <span class="build debug-only" id="xs-build" title="Build provenance — written by local-scripts/deploy.sh"></span>
     <span class="stats">
-      <span class="play-only"><span class="k">d</span> <span id="xs-depth">·</span></span>
-      <span class="play-only"><span class="k">hp</span> <span id="xs-hp">·</span>/<span id="xs-max">·</span></span>
+      <!-- HP and depth used to live here (play-only), but the in-grid top bar
+           (sidebar when wide, top bar when narrow) now carries both, so the
+           browser chrome no longer duplicates them. title + quest stay — the
+           grid has no home for those. The bridge still emits hp/depth; they're
+           just not displayed here. -->
       <span class="debug-only"><span class="k">t</span><span id="xs-turn">·</span></span>
       <span class="debug-only" id="xs-perf-turn-wrap"><span class="k">@t</span><span id="xs-perf-turn">·</span></span>
       <span class="debug-only"><span class="k">u</span><span id="xs-update">·</span><span class="k">ms</span></span>
@@ -528,9 +531,6 @@
     const $ = (id) => document.getElementById(id);
     const titleEl = $("xs-title");
     const questEl = $("xs-quest");
-    const depthEl = $("xs-depth");
-    const hpEl = $("xs-hp");
-    const maxEl = $("xs-max");
     const turnEl = $("xs-turn");
 
     // Capitalize a quest-item name for the bar. Keep it terse.
@@ -563,10 +563,7 @@
       const d = e.detail || {};
       titleEl.textContent = d.title || "—";
       questEl.textContent = nameOf(d.quest);
-      // Reset stats on new run — they'll fill in after the first tick.
-      hpEl.textContent = "·";
-      maxEl.textContent = "·";
-      depthEl.textContent = "1";
+      // Reset the turn counter on a new run — it fills in after the first tick.
       turnEl.textContent = "0";
     });
 
@@ -589,9 +586,8 @@
 
     window.addEventListener("xsofy/stats", (e) => {
       const d = e.detail || {};
-      if (d.hp != null) hpEl.textContent = d.hp;
-      if (d["max-hp"] != null) maxEl.textContent = d["max-hp"];
-      if (d.depth != null) depthEl.textContent = d.depth;
+      // hp / max-hp / depth are still emitted but no longer shown in the chrome
+      // (the in-grid HUD carries them); only the debug turn counter reads here.
       if (d.turn != null) {
         turnEl.textContent = d.turn;
         lastTurn = d.turn;


### PR DESCRIPTION
Builds on #120 (dev-gating) and is based on that branch — it's the tip of the
shell line. **Depends on #119** (the narrow-width top bar): the removal is only
safe where the top bar is present, so this should merge after #119. See the
sequencing note below.

## The problem

The browser info bar duplicates HP and depth that the game already renders in
the grid. That duplication is a leftover: before the top bar, the chrome was the
only place HP showed once the sidebar folded on a narrow viewport. With #119, HP
and depth have an in-grid home at every width — the sidebar when wide, the top
bar when the sidebar folds — so the chrome copies are redundant.

## The change

Remove the `hp` / `max-hp` / `depth` spans from the chrome info bar and the JS
that updates them. Title and quest stay — the grid has no home for those.

The ui-bridge still emits `hp` / `max-hp` / `depth` (the same stats event also
carries the debug turn counter), so the bridge contract is unchanged; the values
are no longer displayed. Shell-only, no `.lg` change.

## Sequencing — depends on #119

The top bar (#119) is on the #112 game line; this chrome lives on the #113 shell
line. They're parallel, and the removal is only safe when both are in the build:
a build of the shell line alone, without the top bar, would show no HP on a
narrow viewport.

Verified on an integration build carrying both #119 and this cut: HP renders in
the grid at narrow (top bar, `HP 30/30 … D1`) and wide (sidebar, `HP 30/30`),
the chrome HP element is gone, and title/quest remain. Review this via the #116
integration preview, which has the top bar; this slice's own build (the shell
line, no top bar) is not a faithful mobile preview on its own.
