### PR TITLE
Reflow title and death screens on resize / font change

### DIFF
--- a/main.lg
+++ b/main.lg
@@ -454,8 +454,7 @@
 
          :death
          (let [[tw th] (term/size)
-               runes (render/death-runes tw th)  ;; scatter ONCE — stable across frames
-               _ (sfx/clear-screen tw th)  ;; clear ONCE, not per-frame — was the flicker source
+               _ (sfx/clear-screen tw th)  ;; initial clear; the loop re-clears + re-scatters on resize
                ;; Dev repro capture of this organic run's replay code. Trigger is
                ;; per-platform: ?dump-replay= URL param on web (js/url-param),
                ;; XSOFY_DUMP_REPLAY env var natively. Gated so players never see it.
@@ -479,7 +478,14 @@
                step (fn [st ev]
                       (let [[tag payload] ev]
                         (case tag
-                          :tick (assoc st :frame payload)
+                          :tick (let [cur (or (term/size) (:size st))]
+                                  (if (= cur (:size st))
+                                    (assoc st :frame payload)
+                                    ;; resized: re-scatter + clear for the new size
+                                    (let [[nw nh] cur]
+                                      (sfx/clear-screen nw nh)
+                                      (assoc st :frame payload :size cur
+                                             :runes (render/death-runes nw nh)))))
                           :action
                           (let [k payload]
                             (cond
@@ -492,9 +498,9 @@
                           st)))
                result (ui/run-loop
                         {:sources  [(ui/input-source ui/raw-key->event) (ui/clock-source 0)]
-                         :state    {:frame 0 :scroll 0}
+                         :state    {:frame 0 :scroll 0 :size [tw th] :runes (render/death-runes tw th)}
                          :step     step
-                         :render   (fn [st] (render/render-death-screen world runes (:scroll st) (:frame st)))
+                         :render   (fn [st] (render/render-death-screen world (:runes st) (:scroll st) (:frame st)))
                          :frame-ms 120})]
            (cond
              (= result :new-game)

--- a/xsofy/title.lg
+++ b/xsofy/title.lg
@@ -153,19 +153,29 @@
         [tw th] (or (term/size) [100 36])
         [title rng]  (generate-title rng)
         subtitle "Press any key"
-        [scheme rng] (pick-scheme rng)
-        runes (sfx/scatter-runes tw th 40 scheme)]
+        [scheme rng] (pick-scheme rng)]
     (sfx/clear-screen tw th)
     ;; Animate via the poll-based event loop: a cosmetic clock advances the
     ;; particle frame each tick; any key ends the screen. Never blocks while
     ;; idle, so it stays responsive in native + wasm (see xsofy.ui / #56).
+    ;; :size and :runes live in state so a resize / font-size change mid-title
+    ;; re-scatters for the new dims and repaints. Without it the screen stays
+    ;; frozen at the size it opened at — play.lg already re-reads size per
+    ;; tick; the animated wait screens didn't.
     (ui/run-loop
       {:sources  [(ui/input-source ui/raw-key->event) (ui/clock-source 0)]
-       :state    {:frame 0}
+       :state    {:frame 0 :size [tw th] :runes (sfx/scatter-runes tw th 40 scheme)}
        :step     (fn [st ev]
                    (let [[tag payload] ev]
                      (case tag
-                       :tick   (assoc st :frame payload)
+                       :tick   (let [cur (or (term/size) (:size st))]
+                                 (if (= cur (:size st))
+                                   (assoc st :frame payload)
+                                   ;; resized: re-scatter + clear for the new size
+                                   (let [[nw nh] cur]
+                                     (sfx/clear-screen nw nh)
+                                     (assoc st :frame payload :size cur
+                                            :runes (sfx/scatter-runes nw nh 40 scheme)))))
                        ;; Any key ends the title — except the shell's resize
                        ;; nudge (a lone BEL, 0x07), which wakes read-key on a
                        ;; browser resize but is not a user keypress. Without this
@@ -174,7 +184,9 @@
                        ;; :unknown and must still start the game.
                        :action (if (= payload (str (char 7))) st (reduced st))
                        st)))
-       :render   (fn [st] (draw-frame runes title subtitle tw th (:frame st) seed))
+       :render   (fn [st]
+                   (let [[tw th] (:size st)]
+                     (draw-frame (:runes st) title subtitle tw th (:frame st) seed)))
        :frame-ms 120})
     {:title title :scheme scheme :rng rng}))
 


### PR DESCRIPTION
Based on #113 (it builds on the title/death screens' input handling, which #113
guards). Independent of #114/#115/#120.

## The problem

The animated wait screens — title and death — capture `[tw th]` and scatter
their runes once, before the poll-based run-loop, and never re-read the terminal
size. So a resize or font-size change while sitting on either screen leaves it
frozen at the size it opened at: runes clustered for the old grid, text
off-center for the new one. `play.lg` already re-reads `term/size` every tick and
repaints; these screens didn't. The browser shell's font-size control makes it
easy to hit — cycle the font on the title and it doesn't reflow.

## The change

Thread `:size` and `:runes` through the loop state, and on the first tick after a
size change, re-scatter the runes and re-clear for the new dimensions. The
render reads size and runes from state instead of the captured values.

The resize path already wakes the loop — the shell nudges a blocked read-key with
a lone BEL, which the screens ignore (and still do). The size delta detected on
the next tick is what drives the re-layout.

The descending screen is a brief auto-advancing transition, so a resize there is
fleeting; it's left as-is.

## Verifying

Load the browser build, sit on the title screen, and cycle the font size: the
runes re-scatter and the title re-centers for the new grid. Before this, the
screen stayed frozen at the launch size.
