### PR TITLE
build-info: build-info.json generator shared by make and CI

### DIFF
--- a/.github/actions/build-wasm/action.yml
+++ b/.github/actions/build-wasm/action.yml
@@ -45,3 +45,11 @@ runs:
       env:
         XSOFY_WASM_INDEX: ${{ inputs.dist }}/index.html
       run: let-go tools/patch_wasm_coi.lg
+
+    # 4. Build provenance for the shell's debug-bar chip. The shell fetches
+    #    build-info.json; generating it here (the single bundle build) keeps the
+    #    deploy, the smoke gate, and PR previews consistent and stops the fetch
+    #    from 404-ing — the smoke gate counts any console error as a failure.
+    - name: Write build-info.json
+      shell: bash
+      run: bash tools/write-build-info.sh "${{ inputs.dist }}"

--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,11 @@ wasm: ## Build the WASM web app into $(DIST): client-owned shell + COI bridge
 	# lifecycle, which the shell contract (window.LetGoHost) and a static host (e.g.
 	# GitHub Pages, which can't send COOP/COEP) don't cover. Tracked as a follow-up seam.
 	XSOFY_WASM_INDEX=$(DIST)/index.html $(LG) tools/patch_wasm_coi.lg
+	# Build provenance for the shell's debug-bar chip. The shell fetches
+	# build-info.json; without it the fetch 404s and the browser smoke gate
+	# (which counts any console error as a failure) fails. Same generator the
+	# CI build-wasm action runs, so local and Actions builds match.
+	bash tools/write-build-info.sh $(DIST)
 
 e2e: wasm ## Build+patch the bundle, then run the headless-WASM @playwright/test suite (boot + seeded regression)
 	cd tests/e2e && npm install --no-audit --no-fund && npx playwright install chromium

--- a/tools/write-build-info.sh
+++ b/tools/write-build-info.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Write build-info.json (build provenance for the shell's debug-bar chip) into
+# the given dist dir. Shared by `make wasm` and the build-wasm CI action so
+# local and Actions builds produce the same manifest: the shell fetches it, and
+# the browser smoke gate counts a 404 as a failure. A local `make wasm` that
+# skipped this left `make e2e` / `make browser-smoke` failing on the missing
+# manifest (nooga/xsofy#116 / #113 review).
+set -euo pipefail
+
+dist="${1:?usage: write-build-info.sh <dist-dir>}"
+
+letgo="unknown"
+if [ -f .let-go-version ]; then
+  letgo="$(awk '!/^[[:space:]]*(#|$)/ {print $1; exit}' .let-go-version)"
+fi
+
+cat > "$dist/build-info.json" <<JSON
+{
+  "xsofy": "$(git rev-parse HEAD)",
+  "let-go": "$letgo",
+  "date": "$(date -u +%Y-%m-%d)"
+}
+JSON


### PR DESCRIPTION

Part of the mobile stack (umbrella: #128). Base: `main`.

A small generator that writes `dist/build-info.json` (xsofy sha, let-go version, build date) from one place, called by both `make wasm` and the CI build-wasm action.

## Non-obvious

- **First in the stack, on purpose.** The mobile shell fetches `build-info.json` for its build/version chip, and the browser-smoke gate counts a fetch 404 (any console error) as a failure. Generating it wherever the bundle is built keeps every downstream shell PR's smoke gate green. Merging this ahead of the shell is the ordering constraint the umbrella calls out.
- **Off `main`, disjoint.** It touches only the `Makefile`, the CI action, and the generator script, so it can merge independently of everything else.

## Verify

`make wasm` writes `dist/build-info.json`; the CI build-wasm step writes the same manifest.
