### PR TITLE
topbar: narrow-width in-grid HP/status bar

### DIFF
--- a/xsofy/render.lg
+++ b/xsofy/render.lg
@@ -473,6 +473,58 @@
             (let [next-row (render-creature-entry r @row c)]
               (reset! row (or next-row (+ @row 2)))))))))))
 
+;; --- Top Bar (narrow-width HP/status; replaces the folded sidebar) ---
+;; One row, left-aligned (it does NOT fill the width): a fixed-width HP bar
+;; using the same width + colors as the sidebar's, then status-effect badges,
+;; then depth. Renders in the terminal grid, so native TUI and WASM get it
+;; identically — the browser chrome HUD is no longer HP's only home.
+
+;; Status badge: a 3-char tag ("poi", "bur"), painted on the effect's own bg
+;; color so the color carries the signal. A one-cell-per-effect variant for
+;; ultra-narrow rows can come later as an automatic overflow fallback.
+(defn- topbar-badge-text [st]
+  (let [nm (:name st)]
+    (subs nm 0 (min 3 (count nm)))))
+
+(defn render-topbar [world r]
+  (when r
+    (ui/clear-rect r)
+    (when-let [player (get-in world [:entities :player])]
+      (let [hp     (or (get-in player [:body :hp]) 0)
+            max-hp (or (get-in player [:body :max-hp]) 1)
+            ;; HP bar: same width + palette the sidebar uses, left-aligned.
+            hp-w    (min ui/sidebar-width (:w r))
+            hp-rect (assoc r :w hp-w)]
+        (ui/bar hp-rect 0 (str " HP " hp "/" max-hp)
+                hp max-hp [140 30 30] [40 12 12] [220 180 160])
+        ;; Badges, then depth, flowed left→right after the HP bar. Each badge
+        ;; is clipped out (not truncated) if it won't fit whole.
+        (let [statuses (status/entity-active-statuses player)
+              gap 1
+              y (:y r)
+              right (+ (:x r) (:w r))]
+          (loop [col (+ (:x r) hp-w gap) ss statuses]
+            (if (seq ss)
+              (let [st  (first ss)
+                    txt (topbar-badge-text st)
+                    w   (count txt)]
+                (when (<= (+ col w) right)
+                  (let [[fr fg fb] (:color st)
+                        [br bg bb] (or (get-in status/status-defs [(:stype st) :bg]) [30 30 30])]
+                    (term/move-cursor col y)
+                    (term/set-fg fr fg fb)
+                    (term/set-bg br bg bb)
+                    (term/write txt)))
+                (recur (+ col w gap) (rest ss)))
+              ;; depth tag after the badges
+              (let [dtxt (str "D" (:depth world))]
+                (when (<= (+ col (count dtxt)) right)
+                  (let [[br bg bb] ui/bg]
+                    (term/move-cursor col y)
+                    (term/set-fg 120 120 120)
+                    (term/set-bg br bg bb)
+                    (term/write dtxt)))))))))))
+
 ;; --- Log Panel ---
 
 (defn format-log-entry [entry]
@@ -1305,6 +1357,7 @@
     ;; render panels
     (render-map world mr)
     (render-map-entities world mr)
+    (render-topbar world (:topbar panels))
     (render-sidebar world (:sidebar panels))
     (render-log world (:log panels))
     (render-status world (:status panels))
@@ -1331,6 +1384,7 @@
       ;; Camera shifted — viewport contents moved; redraw map fully.
       (do (render-map world mr)
           (render-map-entities world mr)
+          (render-topbar world (:topbar panels))
           (render-sidebar world (:sidebar panels))
           (render-log world (:log panels))
           (render-status world (:status panels))
@@ -1361,6 +1415,7 @@
                                (when vis (get stains [opx opy]))
                                (when vis (get gases [opx opy]))))))
         (render-map-entities world mr)
+        (render-topbar world (:topbar panels))
         (render-sidebar world (:sidebar panels))
         (render-log world (:log panels))
         (render-status world (:status panels))

--- a/xsofy/render.lg
+++ b/xsofy/render.lg
@@ -508,15 +508,19 @@
               (let [st  (first ss)
                     txt (topbar-badge-text st)
                     w   (count txt)]
-                (when (<= (+ col w) right)
+                (if (<= (+ col w) right)
                   (let [[fr fg fb] (:color st)
                         [br bg bb] (or (get-in status/status-defs [(:stype st) :bg]) [30 30 30])]
                     (term/move-cursor col y)
                     (term/set-fg fr fg fb)
                     (term/set-bg br bg bb)
-                    (term/write txt)))
-                (recur (+ col w gap) (rest ss)))
-              ;; depth tag after the badges
+                    (term/write txt)
+                    (recur (+ col w gap) (rest ss)))
+                  ;; This badge is clipped whole; later badges won't fit either.
+                  ;; Stop advancing so the depth tag can still use the space the
+                  ;; badge couldn't — a shorter "D1" may fit where "poi" didn't.
+                  (recur col nil)))
+              ;; depth tag after the badges (or after the first clipped badge)
               (let [dtxt (str "D" (:depth world))]
                 (when (<= (+ col (count dtxt)) right)
                   (let [[br bg bb] ui/bg]

--- a/xsofy/test/ui_test.lg
+++ b/xsofy/test/ui_test.lg
@@ -150,3 +150,16 @@
                                :frame-ms 0})]
       (is (= {:exit :go :final-frame 2} result) "returns the reduced result")
       (is (= [-1 0 1 2] @rendered) "each animated frame was rendered before exit"))))
+
+;; --- layout floor (#119 review) -------------------------------------------
+;; When the sidebar folds, the top bar claims a row; the log threshold must
+;; account for it so the map keeps its 10-row floor. Regression: the threshold
+;; measured against total height, ignored topbar-h, and left a 9-row map at
+;; 67-79x14.
+(deftest topbar-keeps-map-floor
+  (testing "map stays >= 10 rows across narrow widths at height 14"
+    (doseq [w [66 67 72 79 80]]
+      (is (>= (:h (:map (ui/layout w 14))) 10) (str "width " w))))
+  (testing "documented reference sizes render a 10-row map"
+    (is (= 10 (:h (:map (ui/layout 66 14)))) "66x14")
+    (is (= 10 (:h (:map (ui/layout 80 14)))) "80x14")))

--- a/xsofy/ui.lg
+++ b/xsofy/ui.lg
@@ -142,14 +142,16 @@
         ;; trigger for now; a touch-forced variant is a later phase.
         show-topbar? (not show-sidebar?)
         topbar-h     (if show-topbar? 1 0)
-        ;; Drop the log when short: below gh=14 (log-height + status-height
-        ;; + 10) the log starves the map. Status (1 row) shows the
-        ;; keybinding hint, which only fits at ~67 cols — below that it
-        ;; truncates mid-token to something useless. Under WASM the HTML
-        ;; bar already shows the action set, so dropping the row when
-        ;; narrow costs nothing and buys the map an extra line.
-        show-log?    (>= gh (+ log-height status-height 10))
+        ;; Status (1 row) shows the keybinding hint, which only fits at ~67 cols
+        ;; — below that it truncates mid-token to something useless, so drop it.
         show-status? (and (>= gh 2) (>= gw 67))
+        status-h     (if show-status? status-height 0)
+        ;; Drop the log when short so the map keeps a 10-row floor. Base the
+        ;; check on the height left AFTER the top bar and status claim their
+        ;; rows — measuring against gh ignored topbar-h and squeezed the map to
+        ;; 9 at 67-79x14. Under WASM the HTML bar already shows the action set,
+        ;; so dropping the log when narrow costs nothing and buys the map a line.
+        show-log?    (>= (- gh topbar-h status-h) (+ log-height 10))
         ;; Steal the top row for the bar before any other split. `body` is the
         ;; game rect minus that row; sidebar/map/log/status lay out inside it.
         ;; When the bar is off (wide), topbar-h is 0 and body == full.
@@ -159,7 +161,6 @@
                          (rect-split-h body sidebar-width)
                          [nil body])
         log-h    (if show-log?    log-height    0)
-        status-h (if show-status? status-height 0)
         [map-area bottom]      (rect-split-v main (- body-h log-h status-h))
         [log-area status-area] (rect-split-v bottom log-h)]
     {:topbar  (when show-topbar? topbar-area)

--- a/xsofy/ui.lg
+++ b/xsofy/ui.lg
@@ -135,6 +135,13 @@
         ;; host's info bar carries the same data (HP / depth / quest), so
         ;; losing the sidebar here costs nothing under the WASM build.
         show-sidebar? (>= gw (+ sidebar-width 60))
+        ;; When the sidebar folds, HP + status effects lose their in-grid home
+        ;; (they'd survive only in the browser chrome — nothing for native/SSH).
+        ;; Reclaim them into a one-row top bar (render-topbar). Mutually
+        ;; exclusive with the sidebar, so wide layouts are untouched. Width-only
+        ;; trigger for now; a touch-forced variant is a later phase.
+        show-topbar? (not show-sidebar?)
+        topbar-h     (if show-topbar? 1 0)
         ;; Drop the log when short: below gh=14 (log-height + status-height
         ;; + 10) the log starves the map. Status (1 row) shows the
         ;; keybinding hint, which only fits at ~67 cols — below that it
@@ -143,14 +150,20 @@
         ;; narrow costs nothing and buys the map an extra line.
         show-log?    (>= gh (+ log-height status-height 10))
         show-status? (and (>= gh 2) (>= gw 67))
+        ;; Steal the top row for the bar before any other split. `body` is the
+        ;; game rect minus that row; sidebar/map/log/status lay out inside it.
+        ;; When the bar is off (wide), topbar-h is 0 and body == full.
+        [topbar-area body] (rect-split-v full topbar-h)
+        body-h       (- gh topbar-h)
         [sidebar main] (if show-sidebar?
-                         (rect-split-h full sidebar-width)
-                         [nil full])
+                         (rect-split-h body sidebar-width)
+                         [nil body])
         log-h    (if show-log?    log-height    0)
         status-h (if show-status? status-height 0)
-        [map-area bottom]      (rect-split-v main (- gh log-h status-h))
+        [map-area bottom]      (rect-split-v main (- body-h log-h status-h))
         [log-area status-area] (rect-split-v bottom log-h)]
-    {:map     map-area
+    {:topbar  (when show-topbar? topbar-area)
+     :map     map-area
      :sidebar sidebar
      :log     (when show-log?    log-area)
      :status  (when show-status? status-area)}))


### PR DESCRIPTION

Part of the mobile stack (umbrella: #128). Base: `mobile/render`.

When the sidebar folds on a narrow terminal, HP and status still need a home: this puts them in-grid as a top bar, and holds the map's 10-row floor so the play area doesn't vanish under it.

## Non-obvious

- **This is the cross-lane join.** The mobile shell stacks on top of this slice — the touch shell drops its own browser-chrome HP readout precisely because this in-grid bar exists, so the information lives in one place.
- A clipped status badge no longer suppresses the depth tag next to it.

## Verify

Narrow the terminal until the sidebar folds: HP/status appears in-grid at the top, and the map keeps its row floor.
