### PR TITLE
screens/reflow: reflow title and death screens on resize

### DIFF
--- a/main.lg
+++ b/main.lg
@@ -431,8 +431,7 @@
 
          :death
          (let [[tw th] (term/size)
-               runes (render/death-runes tw th)  ;; scatter ONCE — stable across frames
-               _ (sfx/clear-screen tw th)  ;; clear ONCE, not per-frame — was the flicker source
+               _ (sfx/clear-screen tw th)  ;; initial clear; the loop re-clears + re-scatters on resize
                ;; Dev repro capture of this organic run's replay code. Trigger is
                ;; per-platform: ?dump-replay= URL param on web (js/url-param),
                ;; XSOFY_DUMP_REPLAY env var natively. Gated so players never see it.
@@ -456,7 +455,14 @@
                step (fn [st ev]
                       (let [[tag payload] ev]
                         (case tag
-                          :tick (assoc st :frame payload)
+                          :tick (let [cur (or (term/size) (:size st))]
+                                  (if (= cur (:size st))
+                                    (assoc st :frame payload)
+                                    ;; resized: re-scatter + clear for the new size
+                                    (let [[nw nh] cur]
+                                      (sfx/clear-screen nw nh)
+                                      (assoc st :frame payload :size cur
+                                             :runes (render/death-runes nw nh)))))
                           :action
                           (let [k payload]
                             (cond
@@ -469,9 +475,9 @@
                           st)))
                result (ui/run-loop
                         {:sources  [(ui/input-source ui/raw-key->event) (ui/clock-source 0)]
-                         :state    {:frame 0 :scroll 0}
+                         :state    {:frame 0 :scroll 0 :size [tw th] :runes (render/death-runes tw th)}
                          :step     step
-                         :render   (fn [st] (render/render-death-screen world runes (:scroll st) (:frame st)))
+                         :render   (fn [st] (render/render-death-screen world (:runes st) (:scroll st) (:frame st)))
                          :frame-ms 120})]
            (cond
              (= result :new-game)

--- a/xsofy/title.lg
+++ b/xsofy/title.lg
@@ -153,22 +153,34 @@
         [tw th] (or (term/size) [100 36])
         [title rng]  (generate-title rng)
         subtitle "Press any key"
-        [scheme rng] (pick-scheme rng)
-        runes (sfx/scatter-runes tw th 40 scheme)]
+        [scheme rng] (pick-scheme rng)]
     (sfx/clear-screen tw th)
     ;; Animate via the poll-based event loop: a cosmetic clock advances the
     ;; particle frame each tick; any key ends the screen. Never blocks while
     ;; idle, so it stays responsive in native + wasm (see xsofy.ui / #56).
+    ;; :size and :runes live in state so a resize / font-size change mid-title
+    ;; re-scatters for the new dims and repaints. Without it the screen stays
+    ;; frozen at the size it opened at — play.lg already re-reads size per
+    ;; tick; the animated wait screens didn't.
     (ui/run-loop
       {:sources  [(ui/input-source ui/raw-key->event) (ui/clock-source 0)]
-       :state    {:frame 0}
+       :state    {:frame 0 :size [tw th] :runes (sfx/scatter-runes tw th 40 scheme)}
        :step     (fn [st ev]
                    (let [[tag payload] ev]
                      (case tag
-                       :tick   (assoc st :frame payload)
+                       :tick   (let [cur (or (term/size) (:size st))]
+                                 (if (= cur (:size st))
+                                   (assoc st :frame payload)
+                                   ;; resized: re-scatter + clear for the new size
+                                   (let [[nw nh] cur]
+                                     (sfx/clear-screen nw nh)
+                                     (assoc st :frame payload :size cur
+                                            :runes (sfx/scatter-runes nw nh 40 scheme)))))
                        :action (reduced st)   ;; any key ends the title
                        st)))
-       :render   (fn [st] (draw-frame runes title subtitle tw th (:frame st) seed))
+       :render   (fn [st]
+                   (let [[tw th] (:size st)]
+                     (draw-frame (:runes st) title subtitle tw th (:frame st) seed)))
        :frame-ms 120})
     {:title title :scheme scheme :rng rng}))
 


### PR DESCRIPTION

Part of the mobile stack (umbrella: #128). Base: `mobile/topbar`.

The animated wait screens (title, death) froze at the size they opened at — `play.lg` already re-reads terminal size each tick, but these didn't. On a resize or font-size change they now re-scatter their runes and re-clear for the new dimensions.

## Non-obvious

- **Shared-render, not a shell concern.** It works natively (terminal resize) and on the web (font / viewport change), with no dependency on the mobile shell — which is why it sits in this lane and not with the mobile slices.
- The screen's size and runes live in the run-loop state, so a mid-screen resize re-scatters instead of repainting at the stale size.

## Verify

Open the title or death screen and resize the terminal (or change font size): the runes re-scatter to the new size instead of freezing.
