### PR TITLE
screens/nudge-guard: ignore the shell's resize nudge on modal reads

### DIFF
--- a/main.lg
+++ b/main.lg
@@ -358,6 +358,23 @@
         [quest rng]  (title/generate-quest rng)]
     (assemble-world seed title scheme quest)))
 
+;; The shell nudges a blocked read-key with a lone BEL (0x07) on a browser
+;; resize so the game re-renders at the new size (see xsofy-shell.html
+;; refit()). Any screen that dismisses on a bare (term/read-key) with no key
+;; filtering treats that nudge as a real keypress and closes itself — the
+;; same bug xsofy.title guarded against (a lone BEL, matched exactly: space
+;; also parses to :unknown and must still count as a real dismiss key).
+;; Screens that read a key only to discard it and dismiss unconditionally
+;; (:rune-codex, :help) should block on this instead of a raw
+;; (term/read-key) so a resize during either screen can't silently close it.
+(defn read-dismiss-key!
+  "Block for a real keypress, transparently discarding the shell's lone-BEL
+   resize nudge instead of treating it as the dismiss key."
+  []
+  (loop []
+    (let [k (term/read-key)]
+      (if (= k (str (char 7))) (recur) k))))
+
 (defn play-replay
   "Decode a replay code, reconstruct the run, and step through its actions with
    a short delay so the run plays out on screen. Returns the final world so the
@@ -399,14 +416,14 @@
 
          :rune-codex
          (do (render/render-rune-codex world)
-             (term/read-key)
+             (read-dismiss-key!)
              (let [w (dissoc world :screen)]
                (render/render-full w)
                (recur w w (term/size))))
 
          :help
          (do (render/render-help-screen world)
-             (term/read-key)
+             (read-dismiss-key!)
              (let [w (dissoc world :screen)]
                (render/render-full w)
                (recur w w (term/size))))
@@ -499,7 +516,7 @@
              (if *in-wasm*
                (do
                  (render/render-hazard-prompt world "Start a new game?")
-                 (if (= (term/read-key) "y")
+                 (if (= (read-dismiss-key!) "y")
                    (let [w (new-game)]
                      (render/render-full w)
                      (recur w w (term/size)))
@@ -514,7 +531,7 @@
            (render/render-full world)
            (let [prompt (or (:hazard-prompt world) "Are you sure?")
                  k (do (render/render-hazard-prompt world prompt)
-                       (term/read-key))
+                       (read-dismiss-key!))
                  w (if (= k "y")
                      (world/confirm-hazard-step world)
                      (world/cancel-hazard-step world))]
@@ -528,7 +545,7 @@
                           "Are you sure you want to restart?"
                           "Are you sure you want to quit?")
                  k (do (render/render-hazard-prompt world prompt)
-                       (term/read-key))
+                       (read-dismiss-key!))
                  w (if (= k "y")
                      (if *in-wasm*
                        (new-game)

--- a/xsofy/title.lg
+++ b/xsofy/title.lg
@@ -191,7 +191,13 @@
                                      (sfx/clear-screen nw nh)
                                      (assoc st :frame payload :size cur
                                             :runes (sfx/scatter-runes nw nh 40 scheme)))))
-                       :action (reduced st)   ;; any key ends the title
+                       ;; Any key ends the title — except the shell's resize
+                       ;; nudge (a lone BEL, 0x07), which wakes read-key on a
+                       ;; browser resize but is not a user keypress. Without this
+                       ;; guard the nudge auto-dismisses the title. Match BEL
+                       ;; exactly rather than via parse-key: space also parses to
+                       ;; :unknown and must still start the game.
+                       :action (if (= payload (str (char 7))) st (reduced st))
                        st)))
        :render   (fn [st]
                    (let [[tw th] (:size st)]


### PR DESCRIPTION

Part of the mobile stack (umbrella: #128). Base: `mobile/landscape`.

On a browser resize the shell wakes a blocked `read-key` with a lone BEL (0x07) so the game re-renders at the new size. A screen that dismisses on a bare `read-key` would treat that nudge as a keypress and close itself. This guards the modal and prompt reads (title, rune codex, help, and the hazard/quit prompts) so a resize can't silently dismiss them.

## Non-obvious

- **Web-only, and it belongs in the mobile lane.** It exists to defend against behavior only the shell emits (`refit()`'s nudge); natively nothing sends a BEL. That's why it's here and not with the shared-render slices.
- It matches the BEL byte exactly rather than parsing the key — a space also parses to `:unknown`, and a space must still count as a real dismiss.

## Verify

Open a modal (rune codex, help, or the title) and resize the browser: the screen stays open instead of auto-dismissing.
