### PR TITLE
ui(sidebar): move status bars below stats, above equipment

### DIFF
--- a/xsofy/render.lg
+++ b/xsofy/render.lg
@@ -434,11 +434,13 @@
               hp max-hp
               [140 30 30] [40 12 12] [220 180 160])
       (swap! row inc)
-      ;; player status bars
-      (reset! row (render-status-bars r @row player))
       ;; stats
       (ui/write-line r @row (str " Str " str_ "  Def " def-val) [140 130 110] ui/bg)
       (swap! row inc)
+      ;; player status bars — dynamic zone between core stats and equipment, so
+      ;; transient effects (frozen/poison/…) don't shove the always-present
+      ;; HP/Str lines around every tick.
+      (reset! row (render-status-bars r @row player))
       (ui/write-line r @row (str " " wep-name " (" dmg-str ")") [160 160 180] ui/bg)
       (swap! row inc)
       (ui/write-line r @row (str " " arm-name) [140 130 110] ui/bg)


### PR DESCRIPTION
## What

A small ergonomics/UX fix for the terminal experience:

Move the player status bars (frozen, poisoned, …) in the left sidebar from directly under the HP bar to below the `Str/Def` line, above the weapon/armor block.

Before / after:

```
 @ You            @ You
 HP ▓▓▓▓           HP ▓▓▓▓
 poisoned         Str 2  Def 7
 frozen           poisoned
 Str 2  Def 7     frozen
 dagger (2-4)     dagger (2-4)
 leather armor    leather armor
```

## Why

Status bars come and go as effects tick, so rendering them above the stats pushed the always-present `Str/Def` and equipment rows up and down every turn. The reflow sits right next to the numbers you read most, so it reads as noise.

Putting the statuses between the core stats and the equipment keeps them adjacent to HP, where health-related state belongs, but moves their expand-and-collapse into the dynamic middle of the panel instead of the stable rows.

## Scope

Sidebar only. The narrow-width topbar renders statuses horizontally (HP bar → badges → depth on one row), so it has no stat/equipment rows below the badges to displace — nothing to reorder there.

Pure render-order change in `render-sidebar`; no logic touched. Existing suite stays green (281 tests). Verified the new order by rendering the sidebar with `frozen` + `poisoned` active and checking the row layout.
