### PR TITLE
shell: portrait readiness: aspect cap + letterbox + resize nudge

### DIFF
--- a/tools/xsofy-shell.html
+++ b/tools/xsofy-shell.html
@@ -30,6 +30,15 @@
   font-display: swap;
   src: url(data:font/woff2;base64,d09GMgABAAAAABvkAAwAAAAAREAAABuSB+oMzAAAAAAAAAAAAAAAAAAAAAAAAAAAHDYGYACCFBEICvd011UBNgIkA4NIC4NIAAQgBYMeByAbhjGjon6wWnJkf5Vg0z320GJdj6ioU6n8piTHW7LSH9QjieCpKyMkmf2B3+b/AXXholxbjaKigEMswEgOiMVk4i6CyRQDl9+5KP/UvVmxKF8tyoEvVrA1zD1X6auABS6A3aLd/wDpx+/T+TajlQ5mpAMuSiAoKsPMruXNxfHXtzeJ3lWE0k9nvesQSbKPwSy1zbyEvIoO6UyOHUVN0TFpqyXgyVy3QvUVphLB/Kyk1F2g2rRvUt3P2Yt7BJOS+deZrnYAYCvgRsMCOLdjx24dpq/vL/mDvkX2nSwd+RSwc3mpISDbBSkOgcMuIIyGpG3YvZRpAt4JNoaZ1qUpmxXfAkPGYoWSe1d9dn4/taemWl9rxnJXcSFBkOlosOPuvu+3BSQAsAcahIEtLz5VBIuIlaoy8FSoCkvBs6ygWgmeYAsAYLXCcce25CGSGewAbKbaJALA4fBg5BiIIDEcmDAZLFJ/7QCUSeMAJFJUKSuU29XvrM3GzyMAk0MKACBgu0Ayk7UA4Ar2AEAGKA0ckJE8ZtuAsFvvBltwhHVwCI7DGRid997VwdXbbZfbbjeje6J7gXuhe6t7h3uPp8wLvMheKq8TXsNeeq+r3pO9Y73j/c5arQC4Qh7VQFC2b7t7t6f0yOV9uP8sWp8b8q0vNf7isyPPOp4GPg148veTVU+WP5E+CXkS/IT6qPTh7Ye3HhY+9Hro+HD2w1kP7jzoedA96g8kOPaQrFaoxV5myeUQWDbHTAvA/Gp7oCsjn049tgyJVOR1uG1RToRDVqlT/x7ToDo/OslaOMgw2A+/crbmul5n4aCgxRf7SFtSr2M80G9zb6W5KvKTjINGLihlSyAJDONaHpgv+bXr4Fz8ZsoREwul6pOZP7w6tRl+XadzpTpJp0tu8KNlqfAlxcNudZdLmN26YdwKnxi6DDUwPvdylZXLkKNsLQ9DXEp9OWYylBLb73Z04cekOr/c/129ItYVySaJ3QQ+3fv0JeJL7BHJQlrwwEI2jach0E5JESPatmkVBi61bibqIoeIvQMc6lIZ4X5BYGvh6UnYjVqMsNSFuxq1Liv8sZe9QKAFDIRFSqvu7/uIsIYziQ6hsRO+vHdvr+2+ObWjMYdZTIRckGHX/A33r8+4Uj1q/8snedbWGZHyksG9g3DYKxAwDCUcijyUgUjh/1LoTuqgGiFA+N7y8MeQK3UGlycvsTYcGd7tDnsUqNZnBd9pobpB4f0V1tPfFto3Qnk66PS6RI//I1/jcbi/XlaFhclcbsJSem2XPYBckbk+vbRRUmcBrHnJpv4lQgjyFQdVZs8ArO9o+wZUd3ETfz4I0+V3O75xbdsNRdWuVjs0c923G5/jomKBUKyzTpHBBaCs9wxFDaoR+cY++wy+ds/N+wtibjFmsIoaeLMBea0XTxo6WucFtGA0vjFeptUaLYiEyok+qnDDDdY5jzhmSJETsT83ClRHs7OdMrlfHphBinXNwswZqzNWWGu0kIDqcFt/WqA/mhKlroPdREdnc6yjdogRbXGOJJGdYmZGf1ds6GLuTvUzYrSbfAapcHOPQj2BmwmDGcgiq28rwZrw8I579zBkRgv4qAha2/lYl37oJYaqhr8zdzwKZP+tVHP+qZPMpUNAOTSsLsPb73SoAf/GGC5DKb9sysZaz+ZBt0wRM1gLuc4Wa242oS380FRM8nJnZ5J2KnOtpwe++XddpI/GnhbcSYuNycA0VTnV17hxM9zB5KlRlYbFcdA7BRBpUUifSioRkUlDQc1phjXT7zSwshulSYbSzkLAPfk+C6dB0bZIsj/mRlF5SgLUY3FiF1OStn+QjN9GmU6OmRmkSZaqEWn2fcMEJ+Tft1RPRnzJcOZMOMpMSWqSIMwuuutVAmJSNm+SFnh9lqWrGWdlSFAyGiuT81LR7Q7eRtKoI1g15V8cyWq4qVlcGygiis/o4//z6yDNMTbU1VrY/c5FItqz91itfiRoP2VG24HiWFGpDGUaoQrLbLojAcqksKC+A9qd1JVAMSWEJVNFzAKD2ryZz5nwpos2kRU6qjrWSchpPCI/FtmeLxpFZGK93DpdcEk7yKbpzhlQzOfKpU555dopWBmEGYhsCPPhzDeCjuEH6gFAPdi+1zm/n3N9QUeHufOyPhTtb60OtHETnksUsdW53jXfKlAymbUsKMshSCgmfpfMDca+sjgmvMYaNzWvZ+aZGtdFWuB5QdNZmDx2o51nt4BMxpsb119rRGeBQliGsI+QTyPmWezWq4wriYyG+V8BhEMSB8kKLYH98OWk4L9CmfTY52buAgwzstIh6ngXTKhHtbXc5KrsAYvIMLw+paEmaGXg7C0vhXm0YeBXL9HSrJcYSMAcJYSoPPeYDG0iX/2IsdGQ46k2+/h9e822zreCKjMPv/tud9CDUI1YqXbn1L17aGuXOmDN8tF77y0Pfqi48UU1Ap9JuUBQGXAzFYTYg9HgSG6MFcsanTdSOeEQwPKFvr1XzrI6DhxVRDDzRaOHdW0MBuoXw4KkvISNYcFabPMv5lc6CO9fN3FovKOi+Y42r5K5nHcKr2XNgS76PZ6BJmqt0E0dmg0H4+mN3bRIFpYWAlvvMtyMpTZ0TXUyJRUlUKvtcqKXRbRtw3W4znt8juFWF0gA4jafbFEX0K3c9o238No1Y7MT57tAJSDmMAzECd79pKUCNG5mgFVQe+IzULUmEk1Qzxb34lVZ9XZKS2nMuqQA+mSSbub+jpL4oO1o0WpZAygoaZ2n8bWiQAbODtWVpoC+Wj2rwQoXLpgpXSIZGiykeixeVXOBY6DN29Y0P2gLv9Q9osvrDH4pVW2BJoaorEnX9Q/VXX1/lcfOfo92WXdBWcGCgm2d0uBAIniDgbiTwZ2xBlNYi/VpsVGwLeqFciUAWORJqjpkIgKuDBF0HHAg9vyKOIqzg+Q0d5amOYp56Isu762zkjGByJ/hy3Gjkk93y35AeF+/P7DOcHTvBrNaMwvCkSFDq6J71VmGQc96r3+MAk2uWihjQqrOBlOT4khvC9gIOotqOHIgbJj376p3dUQGEwmfUKWt4AnrUQjXWAGF3NGvd5t09wFQLMtMYHPvvVgfOJuPmQbOUMuUzagFq+gFHVY7opA2jIktasIKNhZNRuQUrKhoyc8GKA1wUKEWW92dkZH1jpT14nBvH6huB/MQa8SPyJkIOlQ6lTEYhB4veRRLCgoL3oLqQ+LqYEKiFDcMJ0kJS9rGP4fRkIVyeJR7SVN91LTES5RmG6soFuYFyNvMcrlxprw97vb39cN5xQBZcoBd2g+TGhrcbh5mqTpbvsUVDHl4NFtSxgpAkgFvtbNUzSSvJ9qwJ47VPhCfi1iUemRSRWw1oUxe6TnNgwfpDws6WHr9Y7KPDBnK4QEHOSXbG+AtGPYdi5bcCWnbVtzI2SmKQyugXui1kbHRdd8KdKAXqFO0fCylASD5RDx/lMI4LxOzxre4aOXh36YG/xw2XKyWxYFVckIVM9I23Dub6DU5cpny0hAmg5dLhdCGrTT+RreZd/JlA03Fui4nTtRwbKPALii3LOsilBBDOOPEs3XYQYZT9FL0gIGTdLRYV+E0rFs2NHc5C0X13o1xd6jXN4g6rzYw4YzFmNnh5El67VmnMEeDVKaFM6JSIFhXrnh6rNy4Fpnn6IIMdmWLsU7WN/67EfCg7gK+TVOC50cJ0q2KMT4jwb1i7cF+ah/xtnB5URxi+ri/lRj6QhJ76Uu98bjtkym29b8xwT+DCgnCE+0pLHcS+7r0xCWyC5JYu6xvzA/GDRsTe4O1xzZUbTy34w6pU/SjcXFFwP1X4Tm2IndhqZ/oLeFdX87ibaLjG/je46NFY642LQiUXKjsJMfA6yW+Balwks5xt35Qe2DdjchlQAcM5u4M7g75rrzLjMy3OwpScFWEjQIGG7PB7pCvaKv93GLO7WV6qbtE0OdrbMvReErqB8M+qbPRPMx07PM09+O/F+mla1mKx3C+erdXcvdd1f5X67qrhD2CzfdS0GsdWmE5ZEzOoYe5OdFnJqaOJtcnb8gLGzKbMjdXwHqe6AB4UFqfX0ThFCR4FnkC1mZfJP7qwMGzf6i7fyUovKeXiPsMnJ6s3n4wbSO8UNDx9E7tc/qp+ymFIhq2ps5+enl9+4wuZ2S7+CuDrkGEQWdGc+6g//VTJpSbAjCgzrjA9ElZp0SlLHkwh3V17uGB20actTWbJuPXKXImy1ExKovYkeWH/qmspH+rJ3dPSBXX5d8yKJKXUL2HWmufRmcI/A7uNK3Jzj47dRtYW0/r+p5TktzjcOaMGl8GoHhNX1rt2DfcaQ1lJfL5W0PUQ3ysiMXl7+qca9LCCkRVVaL4wJjzHl0eqb6ROTmr/MNdOSm80zGIkdB2YJHjsjtr1kQmv6eH8nih0dD+t42N2h8CNm/eEN9HZoA53SuuImLLY3sAUAllm3NgEOuTMLa4J5fTfeJ6xKfwFIHVn50LTJvQaDw3BxQCbAIXi704hTceq6uc+PXbhIPsAgaaEQjWFrLywGW184V7CR70qcCiWRFfyiV2FvG/4vh/YmY+1YlDck6wR2xIIkNQRf/eFV9eC3BLIyzT4zPUT+0pCYyFVo2+dUWOk+T7VW6JzArfpdGdW9Dsu2Ddfrt/1+QMJiSwmYoYDlcew8Qc6JR0BKVTc3qhryKzQDZTLerX//LFKOb/+zX1Y3E5imaoGlPtywahGmGXEpVGNDKQscAwH0y5V79oki/fWDwrM22GRszlxRPSrYQ0/r9pbk9wl936PjlYfpWDQPg67Ulh9+729t0ylCkVS23l8TGLOxubwtvTAkafa7w+NOczM7zTVb/ehhZJO5MfmpHGSgiTJa+JPp/lFxovr72YVnpKXhK9zkNHdvSgdQGAxfDQGCEXRoz1T+T5uO5GnRC7romuTeJJPnEZ5zPBiGY06agNfEQOmMDFEwJLaUwxh47ZqUuSGETympiLOX4xu1ar/13nieGssBJuRfosbMKiqd40uF7yzwym38cyd/8gkdJvx1/cuKBq5vTVCxPl4hq+wPEYgPlisW3Yph4Ph9HSQmPb2ae40qBXczatLK5A0oyMGAY2S/Yqk/Ux9hxGGiNFJoDYBgcOSlJZUkFlpcBH63OvIj1vHB0bDeJyl2GUujjEQVlz8OprlyQVka5KKk0obFSIjvJ8nMIjTNgqiS7bBNxAJI7ovYqBe5Vt0NaobWy+ccMVDnqNz67o7X22ywo2mEq7xsZxfKwLf9P+dtAYqHX+j92+aMnpm+zy1aj37WbncQorHuLArxrtSEK3w8OZ0jbHNlyDGTBRgw1HgOwljgPPO9KA0MvhcH+MubOmkjgTzL+dUmVd0KkpmK79s5i4rkb/NLROtJMz7tcPxmdg5+TSBtZLcTsEa7DexCgDtd50vi3Jalk1NiBm+3Z1Q4NvqrQqXpfKvf+tb4wk4uLUMTEu459ATp/GwD8F9XqGHDpdxSkdG/VmB9P5nF0lCrX/UmFoSXQ0V85m0DGoaH7ZgjYhVVzTK0qK/zIH9eIt2TQwadBYhmVG5EHyumzHDr0/hOw6XudIJBtdHLht1oiuchiLFhfM13RphMGPgQhhcCUJEJhd4C8xS5ZfmM+ty80HF7hoPpUIUGBD+WIwlTYvbkEz3hpDE+G+0R2Nr4wwZ/VCB4QFBPEBYzEJF7Zc0fMoNYmsgb6/DfJ/X5nvzWwqakxKXYau1pmsOWW3f+PLDtAcZ41mRv12z8r57dS/8dMO7pjlGH9AMJoRljEqyASKSVy+SyFv+qLwjRaTs0NLakaiG6OIJdEC8cr38YzDB3jw2z9FLS23W1qKsjYo5ianzjWLueHxBNFIEPH/wHg384AeTZ+GWyQRl+/if9WZju+QvxXf/nviRHbsuDgh2sYt+cB1dB+gSZO585RDMNV6uH0DNuzH/dMUe75S2bP+5rz1QZMlJGyxcnlSIh5x7IxiyqfxKRzFOI7H04lwYOw9UmWDG1/7A6KOsdz61SOmq47PNJvAz3ylkk+GCUBxd6/677/y8k2oxUsfP6o6Bx1/B2Cg+M1Jd7DVL93v8a03mtE3gcJx5lF54clOmVZOAAZULdiwZDPLdFjOG3Te/8SsRoLwigbxt3QQGRfdgnLlvU4uKZiVkDbnx5gIyoP/BhHBadwyx+jEeo/2Q1ZHR97CTOFEYm7AgTloI3+Q5hx3y78yC55Xn9qZybnMsQZs0KN+uj3GqNbDg0E/5rSbv5tyvm9lnLO4YLppi0nIGgUshNEZEjEgMJtAs7jBqh9aVZbDg4FOE55XxCXykgplvIT2p7EciVKUxFUMpnMlJaVoXnLrLdxfmsAqF3P9L+vqJyF1TBpcKxZGncn8Arp9058rblhGv0JD56NRQrEMDDtGcAQW5rf+ckhMC5P0POuCWQce1ruR+XbuMT6S3I8PF3z8OevSM8TxbsE8Nel6NzOBkeK1eFL5779scbj73x37UZIc5+TZ55Mo8tCFNdp91g/pDpP7ShIZHqJKsi2SDNl4sK2N+m1B0yG3vjuC8AdnMcB3MifdsDpkS4WoGVrSV7yfMiPRbb7x8JBavTvF1Zudy/ksT8IHH/0VZur1Jhz/bEGSpnhHLzFNsGX6mevb8XR9fUVF77QJqMWLvGni8sS6lh3x0++H+hsGbNRoNpahFg/++utB6NehHnmaLo0kytkFtZZDWUBzP8XBqjnLATWpOmFNjfBI0eLiaPu7XDCcLJxWvfmoBzOpjJOWSG6mEnMiwZDmqj6tB8WhMtlUZzBkY6CSbCgBmwnef12/XnndkWxCMQR63XDLNDC1dl5f4QO5pPsMBheY+IaiIXw+YrEgSvLnDGiqWVJbaCX4jcjzYuUQYJ4NhWKuNJgcqWzj7V3Txr9xuU3JhZK326QE5eQvJZPIJLmlYBuVGpTHFw8M/Jf5RELlQirpxP6eymyx4uHm5q5xvP/Fbbw9SGaTB8Mw7MaUWqeu8+Aj0UnyOqdya54uLoCE1nfvFNP+d4yue1wEiy+3J1wvheIdNP1qMCxALUoNUun5rcXM59H96/EeygfWBp2gpb5W6jpKMDoZisT9/H5mgaovkweS1WzyIBmDGJrg5ngdjAOEbA2GE1l7cJbM7Ljb8Oac7VqTxUN5h1sFbhotantrff+Bna0sm8QF45J79zbhpjHkZcrvyeU3T8vBBoMj5vY4dDq0AL3gaBGM2hNNwbtHq5QH2gZ3ri80eTeKMjBj3FJe5WUd6mChZsU3RzHKhs1YoNN52L0AN00zNoPb0CDZ2W9QOOjnPOzTwBJsWcMtGwzJj+OIOwr0PMRENt3yjlhuKdXBWTqatG504vx37GgGwIbhZ5oa1s0W4BjL4/O1+Sc2Y2wGyDLmtLvXutaG2HznyA2h1Veuohavak1yjTPAMtjfn5KQficIlmIfYUqTUxT3FIpbo3KF/BaYNHkrG7OnXcJLL7BWycOIpKVrD+CBteKiEWD4wATjI85xnkK4j04Yht4csOTBcWjzzhlAnzr8zWlU3Xq1XJdKnm65ewcM9dQU9E0HWeB0RTlX/gDkhqneAJaLn+bpRi/dLd/ZBbh8AYf5qacFAwOZUCQsKsIiSSsPdgqmOAus3+UGTVtPsjaQ6sfWx265urqnpcnlb1cz3r6VV1ae3bW26x7nSfZqNEGaif68BR2aoeNCDt0z+ycoMxmZl4PFiC5Pulpl/YUMfeJ7Xk8AhhtuTfpXnvxAxTypDcSvyiMvmPI9pmFUKs/OPp2uMJb8DmgNexI5R8Y4f51iVM8oHc7rQkJ0eg9mRe/HwDjLpAmlG/YTw5DMZd10S4MscBNl6dm3SgUq0rjBvbaZSF67JeIeTHoJc3YMCVioRcqv8kPvRKD00OkK8JoAt61SN7jSYC3ABYEaej7+pHD/TkZUK+aqc4sxkGVN3WCnUdVWq6vUQTBg8/q7ASr+gHmHPH9cR+FerncrYRPlU28OvbCmBgziR+sv/H/VMhEihFf9r4a1DrKiXGBgwcAe9QoGFhfsoqNAffwYYzUscdPfDEjpanUBzhYIWgG8/rMRJMRGZ8NzKE1ioPxFAF0r4NrZXwsM0+cfCo5wVjf9WCgrILbNbsPUtWu/5nDTfpxTD7jcH9MjAHK65W+UP/B+q3RrTnazC14sO8el2f4EYJkYTxDxwVt//XUrc1/7KULfrcGlFRA9cXteHhuN22WHfp4+cR4eoczTL8mDHRZ8hA/Vz/Wxm7bJb274hBIDUPkjTV23kuuj211YS6hSPZir707guJyScunCil7NJFArhLsqPZVeQEBZvY3bwFZ7VPfSaooQRwb752cGM3OT6/zXNhMdesN7fXsdaUiLZ8fPXfyHHQYvjVwyrK9Rnb0MZUbmXXPqI3vxMoFk7r4OP5tvInKz2Ewh88u0OWciHNsXudQ7Nc8cnovXAsOjswStW7pThorvmYFyFI+CGwWb644cqZOhLHvVquw8jCiWjAEGxgMwIOqGbLrMEgBabhl4RCZ4eG08Ok4DMleVmDKLie9Cxf+v7h8wZaemxXOrG/pTz7A+6LZsN/9ij2nuYrTDdIqRuz70V3JnbeuOUrnYscoViBW1Kt/ntqtJaVqnyPjpM352QAeJu6YqKYvm5UYVhFJ4YcNLGoos6nLFf66cW8VAb8ooKcnw/nZNBufdTFws9aLBvy/nhQ6G0jnsECN+xtNcCw1mlbL/YWPjgOyclpkUxBIIqkFlBe1zaM/JBhoRrA1g6Gh8mGgG6obwjfOcOW7n1KVlxBFs3epzbjnGtLIa9b2oFUxuZqT2nNV6bprIfQjTrbN9kvl1gn3Mkb7ChTu++CSAib9Nvf66JPxx/gz2m0lTbI8CANx9ddMWAGDMs+jtv4/+ubgWZu0GgElAhkD/Qq1On9kYtClnrUBCeQ/kHLAHAD0oi+48kEECTANY4EWzPkM+EeyBZbJAOtr2YH+TPM7OIU+6uAHsrQ89MqIbBKC0PktmfY9NqmsDQFjdurz5rMnWj2HuC6/pssfOjR6ToVjS/tRHGcbNlW3a7EHizmG9mS3Y1NoAbZ4JYNxUq4XFURN7ESiFAAkDQumFAUhovYgwdIQooc2NCCrbYJBDQWVqETRZP4Nla71ZAmEX5oiNjELV+gjE9gPsJltfuBwkNXo55xj5NOyFqUAuQI/FkMPI8ssXgw2QbCcDtDmk+5PAAfbuT4apcHp/G0iG80vaWvvbgTdp6tYmwGwSDeKhAIpBBfIlsw5cIRF4Op+AFVABK0FVTymgCKo18a0QPyQpQAo7STWS2g1gMIPIY6KuMFVQTINgCAEmBMYgEEbOaqRICpvEtY8VtYnzoWIhShOPhxUAcfSkQjEQAFIFy6cSR9JeRCY6aqAcKhS2q0CBm1ANQMIKJWER8KpLIBDo5LEswuwqKEYGQAJBNIzuLDvcha5hA8dTsh6MDQAA) format('woff2');
 }
+
+/* Portrait aspect cap. The minimal -w-shell none frame lets its terminal mount
+   (#terminal on v1.11.1; renamed #app on newer let-go) fill the viewport; on a
+   phone in portrait that stretches the grid full-height and crowds out the
+   on-screen keyboard. Cap the mount to 55vh so the grid stays legible and leaves
+   room below. min-height:0 lets the flex item shrink under a larger font on
+   landscape/desktop, where no cap applies. */
+#terminal { min-height: 0; }
+@media (orientation: portrait) { body #terminal { flex: 0 0 auto; height: 55vh; } }
 </style>
 <script>
 (function () {
@@ -69,9 +78,19 @@
     if (pending) { term.write(pending); pending = ''; }
     if (mode === 'worker') {
       window.LetGoHost.setSize(term.cols, term.rows);
-      term.onResize(({cols, rows}) => window.LetGoHost.setSize(cols, rows));
+      term.onResize(({cols, rows}) => {
+        window.LetGoHost.setSize(cols, rows);
+        // Nudge a blocked read-key with a lone BEL (0x07) so the game re-renders
+        // at the new grid size without waiting for a keypress — a native SIGWINCH
+        // analog. parse-key returns :unknown for BEL, and the game's
+        // read-dismiss-key! (main.lg, shipped in #138) discards it, so it never
+        // counts as a real keypress.
+        window.LetGoHost.sendInput("\x07");
+      });
       term.onData((d) => window.LetGoHost.sendInput(d));
     }
+    // Apply the letterbox on first paint (after the initial open+fit above).
+    refit();
   });
   // Debounced so a drag/rotate burst settles on the final size, not an
   // intermediate one. visualViewport catches the mobile URL-bar show/hide,
@@ -79,7 +98,33 @@
   let refitPending;
   function refit() {
     clearTimeout(refitPending);
-    refitPending = setTimeout(() => { try { fit.fit(); } catch (_) {} }, 100);
+    refitPending = setTimeout(() => {
+      // Clear the letterbox padding before fitting so fit() measures the full
+      // box, not the previously-padded one (which would ratchet inward).
+      const host = term.element ? term.element.parentElement : null; // the frame mount (#terminal)
+      if (host) { host.style.padding = "0px"; }
+      try { fit.fit(); } catch (_) {}
+      // Letterbox the sub-cell fit remainder. The grid is a whole number of
+      // fixed-size cells, so up to ~one cell is left over per axis; xterm pins
+      // the grid top-left, pooling the slack on the right/bottom edges. Pad to
+      // place it: centered on X, top-aligned with a small fixed margin on Y so
+      // the grid hugs the top and the keyboard space (from the 55vh cap) stays
+      // below, instead of the grid centering in the capped band.
+      const screen = host ? host.querySelector(".xterm-screen") : null;
+      if (host && screen) {
+        const slackX = host.clientWidth - screen.clientWidth;
+        const slackY = host.clientHeight - screen.clientHeight;
+        if (slackX > 1) {
+          const p = Math.floor(slackX / 2) + "px";
+          host.style.paddingLeft = p; host.style.paddingRight = p;
+        }
+        if (slackY > 1) {
+          const top = Math.min(8, slackY); // small top margin; the rest sits below
+          host.style.paddingTop = top + "px";
+          host.style.paddingBottom = (slackY - top) + "px";
+        }
+      }
+    }, 100);
   }
   window.addEventListener('resize', refit);
   window.addEventListener('orientationchange', refit);


### PR DESCRIPTION
**Remaining mobile stack readiness component**

This PR shifts direction slightly from the standing/original stack plan to separate the essential mobile shell from the opinionated heavyweight key interface and all of its trappings. We can still land that later, but for now getting the basic portrait-mode terminal experience smoothed out is possible without bringing in that specific design.

Portrait test: leaves plenty of room on the bottom for keyboard.

<img width="250" height="321" alt="image" src="https://github.com/user-attachments/assets/9d51e5aa-d128-458f-b9ba-352ed9c2f951" />

<img width="310" height="202" alt="image" src="https://github.com/user-attachments/assets/adf4ed7d-dfb7-4561-baff-a6963d89ef0a" />

---

## Details

Extracts the portrait-good parts of the mobile stack onto the plain shell, on `v1.11.1` (`#terminal` mount), independent of the opinionated touch shell (#135). Part of the shell-lane split described in #128.

**What it adds** (all in `tools/xsofy-shell.html`, +47/−2):
- **Portrait aspect cap** — `#terminal` capped to `55vh` in portrait so the grid stays legible and leaves room for the on-screen keyboard, instead of stretching full-height. `min-height:0` lets the mount shrink under a larger font on landscape/desktop, where no cap applies.
- **Letterbox** — the sub-cell fit remainder is padded so the grid sits centered on X and top-aligned on Y (algorithm from #136, adapted to the plain shell's `refit`).
- **BEL resize nudge** — on a grid change the shell sends a lone `0x07`, waking a blocked `read-key` so the game re-renders at the new size without a keypress (a SIGWINCH analog). This pairs with the game-side guard already merged in #138, which discards the BEL so it never counts as input.

**No pin move.** Stays on `v1.11.1`/`#terminal`; the diff is the shell file only, so `.let-go-version` and the e2e/smoke tests are untouched.

**Validated in-browser** (Playwright, COI-isolated) at 390×844 and 844×390:
- cap engages in portrait only (`#terminal` = 55% / 100% of viewport height);
- grid renders with runes (Fairfax HD, no tofu), centered X, top-aligned Y;
- no console errors, `crossOriginIsolated === true`;
- a portrait↔landscape resize does **not** dismiss the title screen — the BEL nudge is discarded by the guard, confirming the shell↔game contract end-to-end.

The touch shell (D-pad, OPTIONS panel, force-touch) is deliberately out of scope — this is the platform-readiness slice so portrait is a good experience regardless of whether the touch shell is adopted later.
