### PR TITLE
feat(console): read-only dev command console (Layer 1)

### DIFF
--- a/main.lg
+++ b/main.lg
@@ -17,6 +17,7 @@
             [xsofy.screenfx :as sfx]
             [xsofy.debug :as dbg]
             [xsofy.dispatch :as dispatch]
+            [xsofy.console :as console]
             [xsofy.seed :as seed]
             [xsofy.replay :as replay]
             [xsofy.ui-bridge :as bridge]))
@@ -556,6 +557,29 @@
                  (render/render-full w)
                  (recur w w (term/size)))
                w)))
+
+         :console
+         ;; Quake-style dev REPL. The game is already on screen (the play loop
+         ;; just drew it and toggling the console doesn't change the world), so
+         ;; we do NOT repaint it here — the panel just draws over the top rows.
+         ;; The only full repaint in the open/close cycle is on close, to erase
+         ;; the panel. Runs on its own poll loop with a RAW-key source (line
+         ;; editing needs literal chars, not parsed game actions). Returns the
+         ;; world unchanged — the console is read-only (Cut 0). See xsofy.console.
+         (let [size (term/size)
+               result (ui/run-loop
+                        ;; frame-ms 30 matches the play loop's input cadence (it
+                        ;; floors to 30ms under wasm anyway) so typing feels the
+                        ;; same as the game. Cheap now that render-console is
+                        ;; dirty-checked — a faster loop won't repaint while idle.
+                        {:sources  [(ui/input-source ui/raw-key->event) (ui/clock-source 0)]
+                         :state    (console/init-state world size)
+                         :step     console/handle-key
+                         :render   console/render-console
+                         :frame-ms 30})
+               w (dissoc result :screen)]
+           (render/render-full w)
+           (recur w w (term/size)))
 
          ;; default: game screen — the poll-based turn loop (input +
          ;; clock-driven auto-actions / ambient animation); see run-play-loop.

--- a/xsofy/console.lg
+++ b/xsofy/console.lg
@@ -1,0 +1,270 @@
+(ns xsofy.console
+  "Quake-style dev console: a read-only command surface over the running game.
+
+   It is a game-side :screen (see xsofy.main game-loop), driven through the same
+   poll-based event loop (xsofy.ui/run-loop) as every other screen, so it works
+   identically in the native TUI and in the browser (wasm) with no shell change
+   and no build flag. Backtick opens it; it is dev-gated (see xsofy.input/dev?).
+
+   READ-ONLY by construction (Cut 0). Input is parsed with the real reader but
+   the head is dispatched against a fixed whitelist (see `commands`) — there is
+   no `eval`, so a typed form can only run a curated, side-effect-free command.
+   The world goes in and comes back out unchanged, so the console can never fold
+   the seed, grow the :action-log, or taint a run. That is the whole safety
+   model: not policed, structural.
+
+   The arbitrary-eval REPL (with staged mutations recorded as commits in the
+   game-state DAG, xsofy.dag — its 'external injection' / checkpoint-hash case)
+   is the follow-up (Cut 1), gated behind a god flag on top of this same surface.
+   Its reference implementation is preserved on the console/dev-repl-cut1 branch."
+  (:require [term]
+            [pprint]
+            [xsofy.render :as render]
+            [xsofy.ui :as ui]))
+
+;; --- Key constants --------------------------------------------------------
+;; Built from (char N) so the source stays plain ASCII (no invisible control
+;; bytes in the file). ESC-prefixed sequences are what term/read-key returns
+;; for the arrow / nav keys.
+
+(def ^:private ESC (str (char 27)))
+(def ^:private DEL (str (char 127)))
+(def ^:private BS  (str (char 8)))
+(def ^:private ETX (str (char 3)))        ;; Ctrl-C
+(def ^:private K-LEFT  (str ESC "[D"))
+(def ^:private K-RIGHT (str ESC "[C"))
+(def ^:private K-UP    (str ESC "[A"))
+(def ^:private K-DOWN  (str ESC "[B"))
+(def ^:private K-HOME  (str ESC "[H"))
+(def ^:private K-END   (str ESC "[F"))
+(def ^:private K-PGUP  (str ESC "[5~"))
+(def ^:private K-PGDN  (str ESC "[6~"))
+
+;; --- Command surface ------------------------------------------------------
+;; The read-only whitelist. Each command is (fn [world args] -> value); the
+;; value is pretty-printed into the scrollback. Commands only READ the world
+;; (or run self-contained diagnostics), so none can perturb the live run.
+
+(defn- help-text []
+  (str "commands (read-only):\n"
+       "  (seed)      seed-input + current rolling seed\n"
+       "  (player)    player hp / position / depth\n"
+       "  (location)  position / depth / turn\n"
+       "  (help)      this list\n"
+       "Esc or ` to close."))
+
+(def ^:private commands
+  {'help     (fn [_ _] (help-text))
+   'seed     (fn [w _] {:seed-input (:seed-input w) :seed (:seed w)})
+   'player   (fn [w _] (let [p (get-in w [:entities :player])]
+                         {:hp     (get-in p [:body :hp])
+                          :max-hp (get-in p [:body :max-hp])
+                          :pos    (:pos p)
+                          :depth  (:depth w)}))
+   'location (fn [w _] (let [p (get-in w [:entities :player])]
+                         {:pos (:pos p) :depth (:depth w) :turn (:turn w)}))})
+
+(defn run-command
+  "Parse `line` with the reader and dispatch its head against the read-only
+   command whitelist. No `eval`: an unknown or non-whitelisted form is reported,
+   never executed, so the console can't mutate the run. Both `(help)` and a bare
+   `help` resolve. Returns {:ok bool :val <value>}."
+  [world line]
+  (let [form (try (read-string line) (catch e ::parse-error))]
+    (if (= form ::parse-error)
+      {:ok false :val "parse error"}
+      (let [head (cond (seq? form)    (first form)
+                       (symbol? form) form
+                       :else          nil)
+            args (when (seq? form) (rest form))]
+        (if-let [cmd (get commands head)]
+          (try {:ok true :val (cmd world args)}
+               (catch e {:ok false :val (str e)}))
+          {:ok false :val (str "unknown command: " (pr-str form) " — try (help)")})))))
+
+;; --- Render bookkeeping ---------------------------------------------------
+;; Split render signatures so we repaint the minimum. last-panel covers the
+;; scrollback/border (redrawn only when output/scroll/size change); last-prompt
+;; covers the input line (redrawn on every keystroke). Typing only rewrites the
+;; ONE prompt row — a single-row overwrite doesn't flicker, so the console stays
+;; smooth without any terminal synchronized-output support. Both reset per open
+;; so the first frame always paints. See render-console.
+(def ^:private last-panel  (atom nil))
+(def ^:private last-prompt (atom nil))
+
+;; --- Console state --------------------------------------------------------
+
+(defn init-state
+  "Seed the run-loop state for the console screen from the live `world`."
+  [world size]
+  (reset! last-panel nil)    ;; force a first full paint; clear any prior session
+  (reset! last-prompt nil)
+  {:world world :size size :frame 0
+   :input "" :cursor 0
+   :history [] :hist-idx nil
+   :output [{:s "let-go dev console — type a command, Enter to run, Esc/` to close.  (help) for commands" :k :note}]
+   :scroll 0})
+
+;; A length-1 key that is NOT one of these control strings is printable input
+;; (covers typed ASCII and rune glyphs); avoids char-code arithmetic. Multi-byte
+;; escape sequences (arrows etc.) are length > 1, so they're excluded already.
+(def ^:private control-keys
+  #{"\r" "\n" "\t" ESC DEL BS ETX})
+
+(defn- printable? [k]
+  (and (string? k) (= 1 (count k)) (not (contains? control-keys k))))
+
+(defn- record
+  "Append a scrollback line and reset scroll to the bottom."
+  [st s k] (-> st (update :output conj {:s s :k k}) (assoc :scroll 0)))
+
+(defn- record-lines
+  "Record a possibly-multi-line string as one scrollback row per line, so
+   pretty-printed (indented) values keep their layout in the panel."
+  [st s k]
+  (reduce (fn [st ln] (record st ln k)) st (split (str s) "\n")))
+
+(defn- submit
+  "Run the current input line as a whitelist command, record echo + result, and
+   push the line to history. The world is never mutated — read-only by design,
+   so there is nothing to adopt back and nothing beneath to repaint."
+  [st]
+  (let [line (:input st)]
+    (if (= 0 (count line))
+      (assoc st :hist-idx nil)
+      (let [{:keys [ok val]} (run-command (:world st) line)
+            ;; strings (help text, the replay code) print raw; everything else
+            ;; goes through pprint so maps/vectors read nicely.
+            text (if (string? val) val (pprint/pprint-str val))]
+        (-> st
+            (record (str "» " line) :in)
+            (record-lines text (if ok :ok :err))
+            (assoc :input "" :cursor 0
+                   :hist-idx nil
+                   :history (conj (:history st) line)))))))
+
+(defn- recall
+  "History up/down. dir -1 = older, +1 = newer."
+  [st dir]
+  (let [h (:history st)
+        n (count h)]
+    (if (= 0 n)
+      st
+      (let [idx (:hist-idx st)
+            idx' (cond
+                   (= dir -1) (if (nil? idx) (dec n) (max 0 (dec idx)))
+                   :else      (if (nil? idx) nil (inc idx)))]
+        (if (or (nil? idx') (>= idx' n))
+          (assoc st :input "" :cursor 0 :hist-idx nil)
+          (let [line (nth h idx')]
+            (assoc st :input line :cursor (count line) :hist-idx idx')))))))
+
+(defn- edit
+  "Apply a raw printable/editing key to the input line."
+  [st k]
+  (let [in (:input st) c (:cursor st)]
+    (cond
+      (printable? k)
+      (assoc st :input (str (subs in 0 c) k (subs in c)) :cursor (inc c))
+
+      (or (= k DEL) (= k BS))                        ;; Backspace / Del
+      (if (> c 0)
+        (assoc st :input (str (subs in 0 (dec c)) (subs in c)) :cursor (dec c))
+        st)
+
+      (= k K-LEFT)  (assoc st :cursor (max 0 (dec c)))
+      (= k K-RIGHT) (assoc st :cursor (min (count in) (inc c)))
+      (= k K-HOME)  (assoc st :cursor 0)
+      (= k K-END)   (assoc st :cursor (count in))
+      (= k K-UP)    (recall st -1)
+      (= k K-DOWN)  (recall st 1)
+      (= k K-PGUP)  (update st :scroll inc)
+      (= k K-PGDN)  (update st :scroll (fn [s] (max 0 (dec s))))
+      :else st)))
+
+(defn handle-key
+  "run-loop :step for the console. [:action k] edits the line / runs / closes;
+   [:tick f] advances the cursor-blink frame (and repaints the game on resize).
+   Returns state, or (reduced world) to close. The world is returned UNCHANGED —
+   the console is read-only, so the game-loop resumes exactly where it left off."
+  [st ev]
+  (let [[tag payload] ev]
+    (case tag
+      :action
+      (let [k payload]
+        (cond
+          (or (= k ESC) (= k "`")) (reduced (:world st))  ;; Esc / ` close
+          (= k :eof)                    (reduced (:world st))
+          (or (= k "\r") (= k "\n"))    (submit st)
+          :else                          (edit st k)))
+      :tick
+      (let [sz (term/size)]
+        (if (= sz (:size st))
+          (assoc st :frame payload)
+          (do (render/render-full (:world st))         ;; resized: repaint beneath
+              (assoc st :frame payload :size sz))))
+      st)))
+
+;; --- Render (the drop-down panel) -----------------------------------------
+;; Opaque panel over the top of the terminal; the game (painted by the caller
+;; on entry, and by handle-key on resize) shows below it — the Quake drop-down
+;; look. We only ever repaint the top rows here.
+
+(def ^:private border [120 180 140])
+(def ^:private fg-in  [150 150 100])
+(def ^:private fg-ok  [180 210 170])
+(def ^:private fg-err [230 130 120])
+(def ^:private fg-txt [210 205 180])
+
+(defn- line-fg [k]
+  (case k :in fg-in :ok fg-ok :err fg-err fg-txt))
+
+(defn- draw-prompt
+  "Write the prompt line (» input) and a steady inverted block cursor into the
+   panel's inner rect. This is the ONLY thing a keystroke repaints — one row."
+  [inner input c]
+  (let [prow (dec (:h inner))
+        col (+ 2 c)
+        ch (if (< c (count input)) (subs input c (inc c)) " ")]
+    (ui/write-line inner prow (str "» " input) fg-txt ui/bg)
+    (ui/write-at inner col prow ch ui/bg fg-txt)))   ;; inverted cell
+
+(defn render-console
+  "Repaint the minimum. When the scrollback / scroll / size changes (run, scroll,
+   resize) redraw the whole panel; otherwise — the common case, typing — rewrite
+   only the prompt row. A single-row overwrite doesn't flash, so typing stays
+   smooth with no synchronized-output dependency. Idle frames change nothing, so
+   both branches no-op."
+  [st]
+  (let [[tw th] (or (:size st) (term/size))
+        ph (min th (max 10 (quot th 2)))
+        ;; matches ui/box's inner rect for r=(rect 1 1 tw ph): (rect 2 2 w-2 h-2)
+        inner (ui/rect 2 2 (- tw 2) (- ph 2))
+        panel-sig  [(:scroll st) (count (:output st)) tw th]
+        prompt-sig [(:input st) (:cursor st)]]
+    (cond
+      (not= panel-sig @last-panel)
+      (do (reset! last-panel panel-sig)
+          (reset! last-prompt prompt-sig)
+          (let [r (ui/rect 1 1 tw ph)
+                title "let-go console"]
+            (ui/clear-rect r)
+            (let [box-inner (ui/box r title border ui/bg)
+                  h (:h box-inner)
+                  vis (max 1 (dec h))              ;; rows for scrollback (last = prompt)
+                  out (:output st)
+                  n (count out)
+                  s (:scroll st)
+                  start (max 0 (- n vis s))
+                  end (min n (+ start vis))
+                  shown (subvec out start end)]
+              (dotimes [i (count shown)]
+                (let [e (nth shown i)]
+                  (ui/write-line box-inner i (str " " (:s e)) (line-fg (:k e)) ui/bg)))
+              (draw-prompt box-inner (:input st) (:cursor st))))
+          (term/flush))
+
+      (not= prompt-sig @last-prompt)
+      (do (reset! last-prompt prompt-sig)
+          (draw-prompt inner (:input st) (:cursor st))
+          (term/flush)))))

--- a/xsofy/dispatch.lg
+++ b/xsofy/dispatch.lg
@@ -15,7 +15,7 @@
 (def ^:private ui-actions
   #{:messages :help :inventory :rune-codex
     :equip-menu :unequip-menu :drop-menu :use-menu
-    :quit})
+    :toggle-console :quit})
 
 ;; Non-actions: input that maps to no game action at all — an unbound key
 ;; (:unknown), a terminal-resize wake byte (:resize), or nil. Unlike UI actions
@@ -23,7 +23,10 @@
 ;; or a stray keystroke or a window resize would advance the seed and grow the
 ;; :action-log, silently breaking (seed, action-log) replay determinism.
 (def ^:private ignored-actions
-  #{:unknown :resize :eof})
+  ;; :console-taint is the dev-console sentinel — it never reaches live dispatch
+  ;; (the console appends it to :action-log directly, not as a keypress), so this
+  ;; is just a safety no-op; `replay` below truncates the run at it.
+  #{:unknown :resize :eof :console-taint})
 
 (defn action-type
   "The dispatch key for an action: a bare keyword as-is, or the :type of a
@@ -80,9 +83,15 @@
 (defn replay
   "Reconstruct a world by replaying `actions` on a fresh deterministic world
    built from `seed`. Returns the final world. Because dispatch is pure and
-   the seed chain is reproduced exactly, this equals the original live play."
+   the seed chain is reproduced exactly, this equals the original live play.
+
+   Stops at a :console-taint sentinel: a dev-console touch can't be reproduced
+   from actions, so the run reconstructs faithfully up to that point and no
+   further (rather than replaying a divergent tail)."
   [w h seed actions]
-  (reduce dispatch (world/make-world w h seed) actions))
+  (reduce dispatch
+          (world/make-world w h seed)
+          (take-while (fn [a] (not= (action-type a) :console-taint)) actions)))
 
 ;; Game-state-level dispatch (dispatch-gs / replay-gs) lives in xsofy.dag — it
 ;; layers the commit DAG over this world-level dispatch. Keeping it there avoids

--- a/xsofy/input.lg
+++ b/xsofy/input.lg
@@ -1,6 +1,17 @@
-(ns xsofy.input)
+(ns xsofy.input
+  (:require [js]
+            [os]))
 
-(def key-bindings
+(defn dev?
+  "Dev builds unlock the let-go dev console (backtick). Gated so players never
+   see it: ?mode=dev on web (js/url-param), XSOFY_DEV env natively (os/getenv).
+   Both host calls are cross-platform no-ops off their platform (return nil), the
+   same seam xsofy.seed/boot-param rides."
+  []
+  (or (= (js/url-param "mode") "dev")
+      (let [e (os/getenv "XSOFY_DEV")] (and e (> (count e) 0)))))
+
+(def base-key-bindings
   [{:action :up          :category :movement   :label "Move up"          :keys ["\u001b[A" "k" "8"] :help-keys ["k" "8" "Up"]}
    {:action :down        :category :movement   :label "Move down"        :keys ["\u001b[B" "j" "2"] :help-keys ["j" "2" "Down"]}
    {:action :left        :category :movement   :label "Move left"        :keys ["\u001b[D" "h" "4"] :help-keys ["h" "4" "Left"]}
@@ -29,6 +40,15 @@
    {:action :messages    :category :information :label "Open message log" :keys ["m"] :help-keys ["m"]}
    {:action :help        :category :information :label "Open keybindings" :keys ["?"] :help-keys ["?"]}
    {:action :quit        :category :system     :label "Quit"              :keys ["\u001b" (str (char 3))] :help-keys ["Esc" "Ctrl-C"]}])
+
+(def console-binding
+  {:action :toggle-console :category :system :label "Dev console"
+   :keys ["`"] :help-keys ["`"]})
+
+;; The dev console binding is appended only in dev builds, so parse-key (and the
+;; help screen, which reads key-bindings) surface it exclusively when dev? is on.
+(def key-bindings
+  (if (dev?) (conj base-key-bindings console-binding) base-key-bindings))
 
 (defn key-matches? [k binding]
   (some (fn [key] (= k key)) (:keys binding)))

--- a/xsofy/replay.lg
+++ b/xsofy/replay.lg
@@ -227,15 +227,28 @@
                         (when (>= run 1000000)
                           (throw (ex-info "replay: implausible run length" {:run run})))
                         (recur (inc r) off2
-                               (into acc (repeat run (nth dict di)))))))]
-      {:seed seed :actions actions})))
+                               (into acc (repeat run (nth dict di)))))))
+          ;; A dev-console-touched run carries a :console-taint sentinel; stop the
+          ;; replay there (drop it and everything after) and report the boundary.
+          ti (first (keep-indexed (fn [idx a] (when (= a :console-taint) idx)) actions))]
+      (if ti
+        {:seed seed :actions (subvec actions 0 ti) :console-truncated? true}
+        {:seed seed :actions actions}))))
 
 (defn encode-run
   "Convenience: replay code for a finished world (its :seed-input + :action-log).
    The log may mix bare keywords and parameterized map actions (item use/equip/
-   unequip/drop/enchant routed through dispatch) — the wire format carries both."
+   unequip/drop/enchant routed through dispatch) — the wire format carries both.
+
+   For a dev-console-touched run the log carries a :console-taint sentinel; we
+   keep it as the last entry and drop everything after it, so the code is minimal
+   and self-describing — a decoder sees the sentinel and knows the replay stops
+   there (the console change isn't reproducible from actions). See xsofy.console."
   [world]
-  (encode (:seed-input world) (or (:action-log world) [])))
+  (let [log (or (:action-log world) [])
+        i   (first (keep-indexed (fn [idx a] (when (= a :console-taint) idx)) log))
+        log (if i (subvec log 0 (inc i)) log)]
+    (encode (:seed-input world) log)))
 
 (defn encode-run-safe
   "Like encode-run, but returns nil instead of throwing if encoding fails for any

--- a/xsofy/test/console_test.lg
+++ b/xsofy/test/console_test.lg
@@ -1,0 +1,86 @@
+(ns xsofy.test.console-test
+  "Tests for xsofy.console — the read-only command surface (Cut 0) and the line
+   editor. The submit/enter path renders the game beneath the panel (needs a
+   terminal), so it is exercised in the native/web manual run; here we test the
+   pure pieces: run-command (what submit wraps) and the render-free editing keys."
+  (:require [test :refer [deftest is testing]]
+            [string :as str]
+            [xsofy.console :as console]))
+
+(def world
+  {:entities {:player {:body {:hp 5 :max-hp 20} :pos [3 4]}}
+   :turn 0 :depth 1 :seed-input 42 :seed 99 :action-log []})
+
+(def ESC (str (char 27)))
+(def DEL (str (char 127)))
+
+;; --- command surface ------------------------------------------------------
+
+(deftest read-only-commands-return-values
+  (testing "(seed) reports the seed pair, world untouched"
+    (let [r (console/run-command world "(seed)")]
+      (is (:ok r))
+      (is (= {:seed-input 42 :seed 99} (:val r)))))
+  (testing "(player) reports hp / pos / depth"
+    (let [r (console/run-command world "(player)")]
+      (is (:ok r))
+      (is (= 5 (get-in r [:val :hp])))
+      (is (= [3 4] (get-in r [:val :pos])))
+      (is (= 1 (get-in r [:val :depth])))))
+  (testing "(location) reports pos / depth / turn"
+    (is (= {:pos [3 4] :depth 1 :turn 0}
+           (:val (console/run-command world "(location)")))))
+  (testing "(help) lists the commands"
+    (let [r (console/run-command world "(help)")]
+      (is (:ok r))
+      (is (str/includes? (:val r) "seed")))))
+
+(deftest bare-symbol-resolves-like-a-call
+  (testing "`help` without parens dispatches the same as (help)"
+    (is (:ok (console/run-command world "help")))))
+
+(deftest unknown-form-is-reported-not-run
+  (testing "a non-whitelisted head is refused, never evaluated — no eval path"
+    (let [r (console/run-command world "(no-such-fn-xyz)")]
+      (is (not (:ok r)))
+      (is (str/includes? (:val r) "unknown command"))))
+  (testing "a mutating-looking form is equally inert: there is no eval, so it
+            resolves to 'unknown command', it does not run"
+    (is (not (:ok (console/run-command world "(hp! 100)"))))))
+
+(deftest parse-error-is-caught-not-thrown
+  (testing "an unbalanced form reports :ok false instead of killing the loop"
+    (is (not (:ok (console/run-command world "(seed"))))))
+
+;; --- line editor ----------------------------------------------------------
+
+(deftest typing-inserts-at-cursor
+  (let [st (-> (console/init-state world [80 24])
+               (console/handle-key [:action "a"])
+               (console/handle-key [:action "b"]))]
+    (is (= "ab" (:input st)))
+    (is (= 2 (:cursor st)))))
+
+(deftest backspace-deletes-before-cursor
+  (let [st (-> (console/init-state world [80 24])
+               (console/handle-key [:action "x"])
+               (console/handle-key [:action "y"])
+               (console/handle-key [:action DEL]))]
+    (is (= "x" (:input st)))
+    (is (= 1 (:cursor st)))))
+
+(deftest history-up-recalls-the-last-line
+  (testing "Up (ESC[A) with populated history restores the newest entry"
+    (let [st (-> (assoc (console/init-state world [80 24]) :history ["(seed)" "(player)"])
+                 (console/handle-key [:action (str ESC "[A")]))]
+      (is (= "(player)" (:input st)))
+      (is (= 8 (:cursor st))))))
+
+(deftest esc-and-backtick-close-returning-the-world-unchanged
+  (testing "either close key exits the loop, handing the SAME world back (read-only)"
+    (let [st (console/init-state world [80 24])
+          r1 (console/handle-key st [:action ESC])
+          r2 (console/handle-key st [:action "`"])]
+      (is (reduced? r1))
+      (is (reduced? r2))
+      (is (= world (deref r1))))))

--- a/xsofy/test/run.lg
+++ b/xsofy/test/run.lg
@@ -20,6 +20,7 @@
             [xsofy.test.ui-test]
             [xsofy.test.play-test]
             [xsofy.test.menu-dispatch-test]
-            [xsofy.test.input-test]))
+            [xsofy.test.input-test]
+            [xsofy.test.console-test]))
 
 (run-tests)

--- a/xsofy/world.lg
+++ b/xsofy/world.lg
@@ -1792,6 +1792,7 @@
     :help (assoc world :screen :help)
     :pickup (pickup world)
     :inventory (assoc world :screen :inventory)
+    :toggle-console (assoc world :screen :console)
     :rune-codex (assoc world :screen :rune-codex)
     :equip-menu (assoc world :screen :quick-menu :menu-action :equip)
     :unequip-menu (assoc world :screen :quick-menu :menu-action :unequip)


### PR DESCRIPTION
## What

Reshapes this PR from an eval REPL into a **read-only command console** — the first of three layers.

A Quake-style dev console (backtick, dev-gated) as a game-side `:screen`. Input is parsed with the real reader, but the head is dispatched against a fixed whitelist — there is no `eval`, so a typed form can only run a curated, side-effect-free command. The world goes in and comes back unchanged, so the console can't fold the seed, grow the `:action-log`, or taint a run. The safety is structural, not policed.

## Commands

All pure world-map reads, with no coupling beyond the UI and world-as-data:

- `(seed)` — seed-input + current rolling seed
- `(player)` — hp / position / depth
- `(location)` — position / depth / turn
- `(help)` — the command list

Both `(help)` and a bare `help` resolve; an unknown or non-whitelisted form is reported, never run.

## Why the split

The original single PR bundled the console UI, read-only reads, subsystem-integrating commands, and an arbitrary-eval path. Splitting by concern:

- **Layer 1 (this PR)** — the console + pure reads. No external dependency.
- **Layer 2 (stacked, #153)** — `(replay)` and `(bench)`, which pull in `xsofy.replay`, `xsofy.perf`, and the browser bridge.
- **Layer 3** — the arbitrary-eval REPL with mutations recorded as commits in the game-state DAG (@nnunley's review below). Its reference implementation is preserved on the `console/dev-repl-cut1` branch.

## Validation

Full lg suite green (2756 assertions). Read-only verified: running every command against a live world leaves it byte-identical.

