### PR TITLE
perf(render): skip frame-to-frame unchanged cells (appearance diff)

### DIFF
--- a/xsofy/render.lg
+++ b/xsofy/render.lg
@@ -70,9 +70,9 @@
 ;; --- SGR pen (render-perf: lossless set-fg/set-bg elision) ---
 ;; let-go's `term` is a raw-emit primitive — every set-fg/set-bg writes an SGR
 ;; escape immediately, so the map loop re-sends identical fg/bg for every cell
-;; even across same-color runs (walls, memory, blanked cells). SGR attributes
-;; persist across cursor moves, so re-emitting an unchanged color is pure waste —
-;; bytes on native, and a Go→JS→xterm.js crossing per call on WASM.
+;; even across long same-color runs (walls, memory, blanked cells). SGR
+;; attributes persist across cursor moves, so re-emitting an unchanged color is
+;; pure waste — bytes on native, and a Go→JS→xterm.js crossing per call on WASM.
 ;;
 ;; The pen records the last fg/bg we emitted and skips a set-fg/set-bg whose
 ;; color already matches. move-cursor and write are untouched, so this is
@@ -100,6 +100,25 @@
     (when (not= (:bg @sgr-pen) c)
       (term/set-bg r g b)
       (swap! sgr-pen assoc :bg c))))
+
+;; --- Appearance buffer (render-perf: skip frame-to-frame unchanged cells) ---
+;; The real per-move waste isn't redundant same-color runs (SGR elision above
+;; barely fires — per-cell lighting + jitter make neighbors distinct); it's that
+;; render-dirty re-emits the ENTIRE visible FOV every move even though lights are
+;; static terrain sources, so most visible cells are byte-identical to last
+;; frame. This buffer records each world cell's last drawn appearance
+;; [ch fr fg fb br bg bb]; render-map-tile skips a cell whose appearance is
+;; unchanged. Animated tiles (dancing water/lava, fire — randomized each frame)
+;; naturally differ and still redraw; static stone/floor/wall away from the move
+;; drop out.
+;;
+;; Keyed by WORLD [x y] (not screen position) so it survives nothing — a camera
+;; shift moves every cell on screen, so the buffer MUST be cleared then (else a
+;; cell whose color is unchanged but whose screen position moved would be
+;; skipped and never drawn at its new spot). render-map clears it, and render-map
+;; runs on exactly the full-repaint cases (render-full, camera shift, floor
+;; change, resize). The FOV-delta path does not clear it, so the diff stays live.
+(def cell-appearance (atom {}))
 
 ;; Dead-zone as a fraction of the EFFECTIVE viewport, per axis. The camera
 ;; holds while the player roams this central box; crossing it scrolls the
@@ -218,11 +237,12 @@
                (>= ty 0) (< ty (:h r)))
       [(+ (:x r) tx) (+ (:y r) ty)])))
 
-(defn render-map-tile [r x y tile visible remembered light-val stain gas]
-  (when-let [[col row] (map-cell r x y)]
-    (term/move-cursor col row)
-    (cond
-      visible
+(defn- tile-appearance
+  "Pure: the [ch fr fg fb br bg bb] a cell should display this frame. Animated
+   tiles use rand-int, so their appearance differs every call by design."
+  [x y tile visible remembered light-val stain gas]
+  (cond
+    visible
       (let [style (style-tile tile)
             ch (get terrain/tile-chars tile "?")
             ;; per-tile color variation
@@ -274,24 +294,30 @@
               bg2 (if gas (fx/gas-tint bg1 gas) bg1)]
           (let [[fr fg fb] (light/apply-light fg1 (or light-val [0 0 0]))
                 [br bgg bb] (light/apply-light bg2 (or light-val [0 0 0]))]
-            (pen-fg! fr fg fb)
-            (pen-bg! br bgg bb)
-            (term/write ch))))
+            [ch fr fg fb br bgg bb])))
 
       remembered
       (let [style (style-tile remembered)
             ch (get terrain/tile-chars remembered "?")
             [fr fg fb] (memory-color (:fg style))
             [br bgg bb] (memory-color (:bg style))]
-        (pen-fg! fr fg fb)
-        (pen-bg! br bgg bb)
-        (term/write ch))
+        [ch fr fg fb br bgg bb])
 
       :else
       (let [[br bgg bb] ui/bg]
-        (pen-fg! br bgg bb)
-        (pen-bg! br bgg bb)
-        (term/write " ")))))
+        [" " br bgg bb br bgg bb])))
+
+(defn render-map-tile [r x y tile visible remembered light-val stain gas]
+  (when-let [[col row] (map-cell r x y)]
+    (let [app (tile-appearance x y tile visible remembered light-val stain gas)]
+      ;; skip cells byte-identical to last frame (see cell-appearance)
+      (when (not= app (get @cell-appearance [x y]))
+        (let [[ch fr fg fb br bgg bb] app]
+          (term/move-cursor col row)
+          (pen-fg! fr fg fb)
+          (pen-bg! br bgg bb)
+          (term/write ch))
+        (swap! cell-appearance assoc [x y] app)))))
 
 (defn render-map [world r]
   (let [{:keys [terrain width height fov memory]} world
@@ -301,6 +327,11 @@
         cx (or (:cx r) 0)
         cy (or (:cy r) 0)]
     (pen-reset!)   ; start of a contiguous penned batch (see sgr-pen)
+    ;; render-map is the full-repaint path (render-full, camera shift, floor
+    ;; change, resize). Drop the appearance buffer so every cell redraws over the
+    ;; freshly-blanked/scrolled screen; it repopulates as we draw. The FOV-delta
+    ;; path never calls render-map, so there the buffer persists and the diff runs.
+    (reset! cell-appearance {})
     ;; Walk screen cells and translate back to world coords, so we cover the
     ;; visible world window [cx, cx+w) × [cy, cy+h) (clamped to the map). The
     ;; old world-origin range [0, w) × [0, h) missed every on-screen cell once
@@ -663,6 +694,10 @@
         gases (or (:gases world) {})
         pos-ent (dirty-cell-entities (:entities world) dirty)]
     (pen-reset!)   ; vfx overlays emit raw between restores; start clean (see sgr-pen)
+    ;; render-vfx-frame painted these cells raw without touching the appearance
+    ;; buffer, so the buffer still holds their base appearance. Invalidate them
+    ;; or the diff would skip the restore and leave the overlay tint stuck.
+    (swap! cell-appearance (fn [m] (reduce dissoc m dirty)))
     (doseq [[x y] dirty]
       ;; render-map-tile + render-entity both use map-cell internally,
       ;; which clips correctly in camera coords. Don't add an outer
@@ -1437,12 +1472,21 @@
       (let [lights (or (:lights world) [])
             stains (or (:stains world) {})
             gases (or (:gases world) {})]
-        ;; Iterate in the original FOV-set order (not sorted): several tile types
-        ;; (fire/water/lava) draw their color from the global rand stream in
-        ;; tile-appearance, so reordering iteration would reshuffle which cell
-        ;; consumes which draw — cosmetically harmless (that stream is unseeded,
-        ;; so the shimmer varies run to run regardless) but a needless behavior
-        ;; change. The pen still elides same-color runs where they occur.
+        ;; Entities are drawn over their tile by render-map-entities, not through
+        ;; the appearance buffer. So a monster that moved leaves its glyph in the
+        ;; buffer's *tile* slot unchanged — the diff would skip repainting the
+        ;; vacated cell and strand a ghost (base render-dirty avoids this by
+        ;; repainting all of new-fov). Invalidate every cell an entity occupies
+        ;; this frame or last, forcing those tiles to redraw beneath the entities.
+        (let [ent-cells (into #{}
+                              (concat (keep :pos (vals (:entities world)))
+                                      (keep :pos (vals (:entities prev-world)))))]
+          (swap! cell-appearance (fn [m] (reduce dissoc m ent-cells))))
+        ;; Iterate in the original FOV-set order (not sorted): fire/water/lava
+        ;; draw their color from the global rand stream in tile-appearance, so
+        ;; reordering would reshuffle which cell consumes which draw. Harmless
+        ;; (that stream is unseeded — shimmer varies run to run anyway) but a
+        ;; needless behavior change, so keep base order.
         (pen-reset!)   ; start of the FOV-delta penned batch (see sgr-pen)
         (doseq [[x y] old-fov]
           (when-not (contains? new-fov [x y])

--- a/xsofy/test/render_test.lg
+++ b/xsofy/test/render_test.lg
@@ -93,3 +93,73 @@
   ;; destructure nil — they fall back to the game's default dimensions.
   (testing "no TTY → [ui/game-width ui/game-height] defaults"
     (is (= [100 36] (render/term-dims)))))
+
+;; --- Render-perf golden tests (SGR elision #145 + appearance diff #146) ---
+;; The perf work is render-only, but its correctness rests on invariants that are
+;; easy to break silently: a seeded render must be reproducible, the diff must
+;; skip unchanged cells and redraw changed ones, and the pen must never change the
+;; color a cell ends up showing. These drive render-map-tile through with-out-str
+;; (term/* writes to *out*) and assert on the captured escape stream plus the
+;; appearance buffer. A prior manual check was glyph-only and missed a color-order
+;; regression; these cover color.
+
+(def render-test-rect {:x 1 :y 1 :w 12 :h 12 :cx 0 :cy 0})
+
+(defn reset-render-perf-state! []
+  (render/pen-reset!)
+  (reset! render/cell-appearance {}))
+
+(deftest render-is-reproducible-under-a-seed
+  ;; fire/water/lava draw color from the global rand stream, so a render pass is
+  ;; only deterministic when that stream is seeded. This is the property that
+  ;; makes iteration order safe to reason about — #145 leaves the FOV-delta loop
+  ;; unsorted precisely so it consumes draws in a stable order.
+  (testing "same seed → identical output for an animated (fire) tile"
+    (reset-render-perf-state!)
+    (set-rand-seed! 1234)
+    (let [a (with-out-str (render/render-map-tile render-test-rect 3 3 15 true nil [0 0 0] nil nil))]
+      (reset-render-perf-state!)
+      (set-rand-seed! 1234)
+      (let [b (with-out-str (render/render-map-tile render-test-rect 3 3 15 true nil [0 0 0] nil nil))]
+        (is (pos? (count a)))
+        (is (= a b))))))
+
+(deftest static-tile-color-is-rand-independent
+  ;; A static floor tile jitters deterministically by (x,y), not from rand, so
+  ;; how many draws preceded it cannot change its color. This is why reordering
+  ;; the delta loop can never affect static terrain.
+  (testing "floor tile renders identically across different rand states"
+    (reset-render-perf-state!)
+    (set-rand-seed! 1)
+    (let [a (with-out-str (render/render-map-tile render-test-rect 4 4 1 true nil [0 0 0] nil nil))]
+      (reset-render-perf-state!)
+      (set-rand-seed! 999)
+      (dotimes [_ 50] (rand-int 100))            ; advance the shared stream
+      (let [b (with-out-str (render/render-map-tile render-test-rect 4 4 1 true nil [0 0 0] nil nil))]
+        (is (= a b))))))
+
+(deftest appearance-diff-skips-unchanged-cell
+  (testing "a second identical render of a cell produces no output"
+    (reset-render-perf-state!)
+    (let [first-out  (with-out-str (render/render-map-tile render-test-rect 5 5 1 true nil [0 0 0] nil nil))
+          second-out (with-out-str (render/render-map-tile render-test-rect 5 5 1 true nil [0 0 0] nil nil))]
+      (is (pos? (count first-out)))              ; first paints
+      (is (= "" second-out))                     ; second is skipped by the diff
+      (is (some? (get @render/cell-appearance [5 5]))))))
+
+(deftest appearance-diff-redraws-changed-cell
+  (testing "changing the light value re-emits the cell"
+    (reset-render-perf-state!)
+    (with-out-str (render/render-map-tile render-test-rect 6 6 1 true nil [0 0 0] nil nil))
+    (let [lit-out (with-out-str (render/render-map-tile render-test-rect 6 6 1 true nil [120 120 120] nil nil))]
+      (is (pos? (count lit-out))))))
+
+(deftest pen-elides-redundant-color
+  ;; Two cells resolving to the same color emit the fg SGR once, not twice.
+  ;; Out-of-fov cells all paint the constant background color, so they collide.
+  (testing "same-color cells share one set-fg within a batch"
+    (reset-render-perf-state!)
+    (let [out (with-out-str
+                (render/render-map-tile render-test-rect 7 7 nil false nil nil nil nil)
+                (render/render-map-tile render-test-rect 8 7 nil false nil nil nil nil))]
+      (is (= 1 (count (re-seq #"38;2" out)))))))


### PR DESCRIPTION
## What

Skips redrawing map cells whose appearance hasn't changed since the last frame.
`render-map-tile` now computes a cell's `[glyph fg bg]`, compares it against a
per-cell buffer of what was last drawn there, and emits only on a difference.
Visible output is unchanged — a skipped cell is one already showing the right
thing.

Stacked on the SGR-elision PR (`perf/render-sgr-elision`); review/merge that
first.

## Why

`render-dirty` re-emits the entire visible FOV on every move. But the game's
lights are static terrain sources (torches, lava, fire — collected once), so with
the camera held, most visible cells are byte-identical to the previous frame; we
were repainting them for nothing. On a movement burst this is the dominant
render-side cost.

Measured over a fixed movement sequence on a water-heavy map: **~35% fewer
`set-fg`/`set-bg` and ~21% fewer output bytes.** Drier maps do better (less
animation); the WASM build should benefit more, since each skipped emit is a
crossing into the JS host avoided. Animated tiles (dancing water/lava, fire)
differ every frame by design and still redraw; what drops out is the static
stone, floor, and wall away from the move.

## Keeping the buffer honest

A cell's appearance is only part of what's on screen, so three cases would
otherwise leave stale pixels; each is handled:

- **Full repaints clear the buffer.** `render-map` (used by `render-full`, camera
  shift, floor change, resize) draws over a freshly blanked or scrolled screen,
  so the buffer is dropped and everything redraws. The FOV-delta path never calls
  it, so there the diff stays live.
- **Moved entities.** Entities are drawn over their tile by a separate pass, not
  through the buffer, so a monster that moved would leave a ghost glyph on the
  vacated cell (the tile "didn't change"). Every current-or-former entity cell is
  invalidated each frame so its tile repaints beneath the entities.
- **VFX overlays** paint raw over cells without updating the buffer, so the
  restore step invalidates the cells it redraws — otherwise the overlay tint
  would stick.

This buffer-coherence bookkeeping is the real cost of the approach. It also makes
the case for a longer-term move to a full back-buffer (paint-to-buffer, diff on
flush) where that coherence is structural rather than a set of targeted
invalidations — a bigger change, noted here as the natural next step, not part of
this PR.

## Safety

Render-only — no effect on the seed, action log, or world state, so determinism
and replay are unaffected. Verified by comparing the displayed cells (colors
included) over a fixed input sequence: static terrain and glyphs are identical
before and after. Animated tiles already vary run to run via the unseeded `rand`
stream, unaffected either way.

This PR also adds golden tests that lock the losslessness down: driving
`render-map-tile` through `with-out-str`, they assert a seeded render is
reproducible, a static tile's color is independent of `rand` state, the diff
skips an unchanged cell and re-emits a changed one, and the pen emits one
`set-fg` for two same-color cells. They close a coverage gap a review flagged —
the earlier check was glyph-only and would not have caught a color-order
regression.
