### PR TITLE
feat(shell): replay link in the config pane (#126)

### DIFF
--- a/main.lg
+++ b/main.lg
@@ -459,18 +459,19 @@
          :death
          (let [[tw th] (term/size)
                _ (sfx/clear-screen tw th)  ;; initial clear; the loop re-clears + re-scatters on resize
-               ;; Dev repro capture of this organic run's replay code. Trigger is
-               ;; per-platform: ?dump-replay= URL param on web (js/url-param),
-               ;; XSOFY_DUMP_REPLAY env var natively — and any dev build
-               ;; (?mode=dev), whose shell renders the emit as a replay link in
-               ;; the config pane. Gated so players never see it.
+               ;; Capture this organic run's replay code at its final state. On
+               ;; web this always fires: the shell's config pane renders the emit
+               ;; as a player-facing ?replay= link (the live per-10-turn capture
+               ;; in ui-bridge can lag a few turns; death re-emits exactly).
+               ;; Natively it stays opt-in via XSOFY_DUMP_REPLAY (or the
+               ;; ?dump-replay= param for parity).
                ;; Sink differs because *err* aliases *out* in WASM (one host writer
                ;; for both — let-go rendermain), so writing *err* there paints the
                ;; game screen. On web route the dump off-terminal via a js/emit host
                ;; event; natively keep stderr (redirect 2>file to capture past the TUI).
                _ (when-let [trig (or (js/url-param "dump-replay")
                                      (os/getenv "XSOFY_DUMP_REPLAY")
-                                     (when (= (js/url-param "mode") "dev") "dev"))]
+                                     (when (= (os/os-name) "js") "web"))]
                    (when (> (count trig) 0)
                      (let [code (replay/encode-run-safe world)
                            payload (or code "(unavailable: run has parameterized actions)")]

--- a/main.lg
+++ b/main.lg
@@ -461,13 +461,16 @@
                _ (sfx/clear-screen tw th)  ;; initial clear; the loop re-clears + re-scatters on resize
                ;; Dev repro capture of this organic run's replay code. Trigger is
                ;; per-platform: ?dump-replay= URL param on web (js/url-param),
-               ;; XSOFY_DUMP_REPLAY env var natively. Gated so players never see it.
+               ;; XSOFY_DUMP_REPLAY env var natively — and any dev build
+               ;; (?mode=dev), whose shell renders the emit as a replay link in
+               ;; the config pane. Gated so players never see it.
                ;; Sink differs because *err* aliases *out* in WASM (one host writer
                ;; for both — let-go rendermain), so writing *err* there paints the
                ;; game screen. On web route the dump off-terminal via a js/emit host
                ;; event; natively keep stderr (redirect 2>file to capture past the TUI).
                _ (when-let [trig (or (js/url-param "dump-replay")
-                                     (os/getenv "XSOFY_DUMP_REPLAY"))]
+                                     (os/getenv "XSOFY_DUMP_REPLAY")
+                                     (when (= (js/url-param "mode") "dev") "dev"))]
                    (when (> (count trig) 0)
                      (let [code (replay/encode-run-safe world)
                            payload (or code "(unavailable: run has parameterized actions)")]

--- a/main.lg
+++ b/main.lg
@@ -476,7 +476,7 @@
                      (let [code (replay/encode-run-safe world)
                            payload (or code "(unavailable: run has parameterized actions)")]
                        (if (= (os/os-name) "js")
-                         (js/emit "xsofy/replay-dump" {:code payload})
+                         (js/emit "xsofy/replay-dump" {:code payload :turn (or (:turn world) 0)})
                          (do (write! *err* (str "replay-code: " payload "\n"))
                              (flush! *err*))))))
                ;; Animate the death screen via the poll-based event loop: a

--- a/tools/xsofy-shell.html
+++ b/tools/xsofy-shell.html
@@ -413,11 +413,12 @@ body.dpad-cool #xsofy-shell button.dpad .label { color: rgba(168, 198, 224, 0.55
     <button class="font-cycle dev-only" id="xs-touch-toggle" title="Force touch controls visible (overrides the landscape auto-hide)">
       <span class="glyph">▦</span><span class="seg-label">touch</span><span id="xs-touch-state">auto</span>
     </button>
-    <!-- Replay link — appears once a dev-build death capture lands (the game
-         emits xsofy/replay-dump; see main.lg :death). Tapping it replays the
-         run; long-press for the OS copy/share sheet. Dev-only + hidden until
-         a code arrives. -->
-    <a class="font-cycle dev-only stat-hidden" id="xs-replay-link" title="Reproduce this run">
+    <!-- Replay link — appears once the run's first capture lands (the game
+         emits xsofy/replay-dump live every ~10 turns and at death). Tapping
+         it replays the run; long-press for the OS copy/share sheet. A player
+         feature (not tier-gated); hidden until a code arrives and reset on
+         each new run so it can never link a stale run. -->
+    <a class="font-cycle stat-hidden" id="xs-replay-link" title="Reproduce this run">
       <span class="glyph">▶</span><span class="seg-label">replay</span><span id="xs-replay-code"></span>
     </a>
     <!-- Build provenance — ungated (bug reports need it, nooga/xsofy#44).
@@ -935,11 +936,18 @@ body.dpad-cool #xsofy-shell button.dpad .label { color: rgba(168, 198, 224, 0.55
   cycleEl?.addEventListener('mousedown', (e) => e.preventDefault());
   initFontSize();
 
-  // --- Replay link: the dev-build capture (ui_bridge emits xsofy/replay-dump
-  // live every ~10 turns, main.lg on death) becomes a reproducible link in
-  // the config pane. Unavailable codes (parameterized-action runs) stay
-  // hidden rather than rendering a dead link. ---
+  // --- Replay link: the game's capture (ui_bridge emits xsofy/replay-dump
+  // live every ~10 turns, main.lg exactly at death) becomes a reproducible
+  // link in the config pane. Unavailable codes (parameterized-action runs)
+  // stay hidden rather than rendering a dead link. Reset on every new run
+  // (xsofy/startup) so the chip can never link a previous run. ---
   const replayLinkEl = $('xs-replay-link'), replayCodeEl = $('xs-replay-code');
+  window.addEventListener('xsofy/startup', () => {
+    if (!replayLinkEl) return;
+    replayLinkEl.classList.add('stat-hidden');
+    replayLinkEl.removeAttribute('href');
+    if (replayCodeEl) replayCodeEl.textContent = '';
+  });
   window.addEventListener('xsofy/replay-dump', (e) => {
     const code = e.detail?.code;
     if (!replayLinkEl || !code || code.startsWith('(unavailable')) return;

--- a/tools/xsofy-shell.html
+++ b/tools/xsofy-shell.html
@@ -935,15 +935,21 @@ body.dpad-cool #xsofy-shell button.dpad .label { color: rgba(168, 198, 224, 0.55
   cycleEl?.addEventListener('mousedown', (e) => e.preventDefault());
   initFontSize();
 
-  // --- Replay link: the death-time dev capture (main.lg emits
-  // xsofy/replay-dump on any ?mode=dev death) becomes a reproducible link in
+  // --- Replay link: the dev-build capture (ui_bridge emits xsofy/replay-dump
+  // live every ~10 turns, main.lg on death) becomes a reproducible link in
   // the config pane. Unavailable codes (parameterized-action runs) stay
   // hidden rather than rendering a dead link. ---
   const replayLinkEl = $('xs-replay-link'), replayCodeEl = $('xs-replay-code');
   window.addEventListener('xsofy/replay-dump', (e) => {
     const code = e.detail?.code;
     if (!replayLinkEl || !code || code.startsWith('(unavailable')) return;
-    replayLinkEl.href = location.pathname + '?replay=' + encodeURIComponent(code);
+    // Carry the session context (mode/dpad/…) into the replay URL — dropping
+    // ?mode=dev made the link land in a chrome-less play tier that read as
+    // "nothing happened". The code carries its own seed.
+    const qs = new URLSearchParams(location.search);
+    qs.delete('seed');
+    qs.set('replay', code);
+    replayLinkEl.href = location.pathname + '?' + qs.toString();
     if (replayCodeEl) replayCodeEl.textContent = code.length > 9 ? code.slice(0, 8) + '…' : code;
     replayLinkEl.classList.remove('stat-hidden');
   });

--- a/tools/xsofy-shell.html
+++ b/tools/xsofy-shell.html
@@ -958,7 +958,11 @@ body.dpad-cool #xsofy-shell button.dpad .label { color: rgba(168, 198, 224, 0.55
     qs.delete('seed');
     qs.set('replay', code);
     replayLinkEl.href = location.pathname + '?' + qs.toString();
-    if (replayCodeEl) replayCodeEl.textContent = code.length > 9 ? code.slice(0, 8) + '…' : code;
+    // Label with the capture turn — meaningful to a human, unlike a code
+    // prefix. Falls back to the code snippet if the emit predates :turn.
+    if (replayCodeEl) replayCodeEl.textContent =
+      (e.detail.turn != null) ? ('t' + e.detail.turn)
+                              : (code.length > 9 ? code.slice(0, 8) + '…' : code);
     replayLinkEl.classList.remove('stat-hidden');
   });
 

--- a/tools/xsofy-shell.html
+++ b/tools/xsofy-shell.html
@@ -309,6 +309,10 @@ body.dpad-cool #xsofy-shell button.dpad .label { color: rgba(168, 198, 224, 0.55
    shrunk info bar. */
 #xsofy-shell .font-cycle { flex: 0 0 auto; flex-direction: row; align-items: center; gap: 0.25rem; min-height: 2.2rem; min-width: 0; padding: 0.15rem 0.6rem; border-radius: 5px; font-size: 11px; line-height: 1.2; color: var(--bar-dim); }
 #xsofy-shell .font-cycle .glyph { font-size: 12px; color: var(--bar-fg); }
+/* Anchor chips (the replay link) borrow the button chip look — anchors don't
+   get the #xsofy-shell button rules. */
+#xsofy-shell a.font-cycle { display: flex; background: rgba(245, 176, 65, 0.06); border: 1px solid var(--bar-rule); text-decoration: none; }
+#xsofy-shell a.font-cycle:active { background: rgba(245, 176, 65, 0.22); border-color: var(--bar-accent); }
 
 /* Phone landscape (short viewport) — split the shell to the RIGHT instead of
    stacking it below the terminal (which leaves a phone only ~130px of game).
@@ -409,6 +413,13 @@ body.dpad-cool #xsofy-shell button.dpad .label { color: rgba(168, 198, 224, 0.55
     <button class="font-cycle dev-only" id="xs-touch-toggle" title="Force touch controls visible (overrides the landscape auto-hide)">
       <span class="glyph">▦</span><span class="seg-label">touch</span><span id="xs-touch-state">auto</span>
     </button>
+    <!-- Replay link — appears once a dev-build death capture lands (the game
+         emits xsofy/replay-dump; see main.lg :death). Tapping it replays the
+         run; long-press for the OS copy/share sheet. Dev-only + hidden until
+         a code arrives. -->
+    <a class="font-cycle dev-only stat-hidden" id="xs-replay-link" title="Reproduce this run">
+      <span class="glyph">▶</span><span class="seg-label">replay</span><span id="xs-replay-code"></span>
+    </a>
     <!-- Build provenance — ungated (bug reports need it, nooga/xsofy#44).
          Populated from build-info.json: tools/write-build-info.sh in CI/make
          wasm, serve.sh locally; absent = ad-hoc bundle, chip stays empty. -->
@@ -923,6 +934,19 @@ body.dpad-cool #xsofy-shell button.dpad .label { color: rgba(168, 198, 224, 0.55
   });
   cycleEl?.addEventListener('mousedown', (e) => e.preventDefault());
   initFontSize();
+
+  // --- Replay link: the death-time dev capture (main.lg emits
+  // xsofy/replay-dump on any ?mode=dev death) becomes a reproducible link in
+  // the config pane. Unavailable codes (parameterized-action runs) stay
+  // hidden rather than rendering a dead link. ---
+  const replayLinkEl = $('xs-replay-link'), replayCodeEl = $('xs-replay-code');
+  window.addEventListener('xsofy/replay-dump', (e) => {
+    const code = e.detail?.code;
+    if (!replayLinkEl || !code || code.startsWith('(unavailable')) return;
+    replayLinkEl.href = location.pathname + '?replay=' + encodeURIComponent(code);
+    if (replayCodeEl) replayCodeEl.textContent = code.length > 9 ? code.slice(0, 8) + '…' : code;
+    replayLinkEl.classList.remove('stat-hidden');
+  });
 
   // --- Force-touch: capability OR the persisted dev override sets
   // body.force-touch (reveals the touch UI in every orientation). The class

--- a/xsofy/play.lg
+++ b/xsofy/play.lg
@@ -80,6 +80,7 @@
   (let [prev (:world state)
         new-world (apply-auto-stops (dispatch/dispatch world key) world)
         _ (bridge/emit-stats new-world)
+        _ (bridge/emit-replay-code new-world)
         cur-size (term/size)
         resized (not= cur-size (:size state))
         floor-changed (not= (:depth new-world) (:depth prev))]

--- a/xsofy/ui_bridge.lg
+++ b/xsofy/ui_bridge.lg
@@ -1,5 +1,6 @@
 (ns xsofy.ui-bridge
-  (:require [js]))
+  (:require [js]
+            [xsofy.replay :as replay]))
 
 ;; Outbound channel from the game to whatever HTML/JS shell is hosting it.
 ;; Builds on let-go's (js/emit ...) — see ../let-go fork on branch
@@ -53,6 +54,22 @@
                     :max-hp (get-in player [:body :max-hp] 1)
                     :depth  (or (:depth world) 1)
                     :turn   (or (:turn world) 0)}))))
+
+(defn emit-replay-code
+  "Dev-only live capture of the current run's replay code (:replay-dump —
+   the same channel the death-time capture in main.lg uses). The HTML
+   shell's config pane renders it as a ?replay= link, so a dev build can
+   share/reproduce a run without dying first. Throttled to every 10th
+   turn: encode cost grows with the action log, and the chip lagging a
+   few turns is fine. The first turn always emits, so the chip is live
+   from a run's first action. Skips runs whose codes are unavailable
+   (parameterized actions) — encode-run-safe returns nil there."
+  [world]
+  (let [t (or (:turn world) 0)]
+    (when (and (= (js/url-param "mode") "dev")
+               (or (<= t 1) (zero? (mod t 10))))
+      (when-let [code (replay/encode-run-safe world)]
+        (emit :replay-dump {:code code})))))
 
 (defn emit-term-size
   "Fired at game-loop entry and whenever the terminal reports a new size

--- a/xsofy/ui_bridge.lg
+++ b/xsofy/ui_bridge.lg
@@ -56,18 +56,19 @@
                     :turn   (or (:turn world) 0)}))))
 
 (defn emit-replay-code
-  "Dev-only live capture of the current run's replay code (:replay-dump —
-   the same channel the death-time capture in main.lg uses). The HTML
-   shell's config pane renders it as a ?replay= link, so a dev build can
-   share/reproduce a run without dying first. Throttled to every 10th
-   turn: encode cost grows with the action log, and the chip lagging a
-   few turns is fine. The first turn always emits, so the chip is live
-   from a run's first action. Skips runs whose codes are unavailable
-   (parameterized actions) — encode-run-safe returns nil there."
+  "Live capture of the current run's replay code (:replay-dump — the same
+   channel the death-time capture in main.lg uses). The HTML shell's
+   config pane renders it as a ?replay= link, so any run can be
+   shared/reproduced without dying first — a player feature, not
+   dev-gated. Throttled to every 10th turn: encode cost grows with the
+   action log, and the chip lagging a few turns is fine (death re-emits
+   the exact final state). The first turn always emits, so the chip is
+   live from a run's first action. Skips runs whose codes are unavailable
+   (parameterized actions) — encode-run-safe returns nil there. Native:
+   js/emit is a validated no-op."
   [world]
   (let [t (or (:turn world) 0)]
-    (when (and (= (js/url-param "mode") "dev")
-               (or (<= t 1) (zero? (mod t 10))))
+    (when (or (<= t 1) (zero? (mod t 10)))
       (when-let [code (replay/encode-run-safe world)]
         (emit :replay-dump {:code code})))))
 

--- a/xsofy/ui_bridge.lg
+++ b/xsofy/ui_bridge.lg
@@ -70,7 +70,7 @@
   (let [t (or (:turn world) 0)]
     (when (or (<= t 1) (zero? (mod t 10)))
       (when-let [code (replay/encode-run-safe world)]
-        (emit :replay-dump {:code code})))))
+        (emit :replay-dump {:code code :turn t})))))
 
 (defn emit-term-size
   "Fired at game-loop entry and whenever the terminal reports a new size


### PR DESCRIPTION
Closes #126. Reframed from the earlier help-screen shape — #137's config pane is the natural surface now, so this stacks on #137.

## The gap (#126)

`?dump-replay=` fires `(js/emit "xsofy/replay-dump" {:code …})` on death, but nothing web-side listened: the code never surfaced on the primary (mobile) test surface. Native capture (`XSOFY_DUMP_REPLAY` → stderr) already works and is unchanged.

## This change

- Game: every web run captures live — a bridge emit every 10th turn (and on turn 1, so the chip is current from a run's first action), plus the death capture firing unconditionally on web for the exact final state. Death isn't special: `encode-run-safe` works on any live world. Native stays opt-in (`XSOFY_DUMP_REPLAY` / `?dump-replay=`).
- Shell: the emit becomes a chip in the ⚙ config pane — a `?replay=` link that reproduces the run in one tap (long-press for the OS copy/share sheet), carrying the session params (mode etc.; seed dropped — the code brings its own). Emits already arrive as window CustomEvents, so there's no new host plumbing. Unavailable codes (parameterized-action runs) keep the chip hidden rather than rendering a dead link, and the chip resets on every new run so it can never link a stale one. Not tier-gated: sharing/reproducing a run is a player feature.

## vs the earlier shape

The previous draft rendered a replay-code page inside the game's help screen. The config pane is the better surface: no game-render involvement, tap-to-reproduce instead of transcribing a code by hand, and the same coverage on the mobile test surface. The help-screen implementation is preserved on a local archive branch if the on-demand mid-run capture turns out to be wanted too.

## Verification

- Full loop in browser emulation against the built bundle: turn-1 emit fires, the chip reveals with the real code, and following the link boots the replay (HUD renders, dev chrome preserved). Chip stays hidden for unavailable codes and in the play tier. Native suite: 284 tests, 0 failures.
- Known sharp edge (pre-existing, out of scope here): an invalid `?replay=` code is a fatal decode error ("nth index out of bounds") — filed as #159.

_Config pane with the chip:

<img width="575" height="325" alt="image" src="https://github.com/user-attachments/assets/9f459812-8175-42b1-bfe3-f50e0684ecc3" />

https://xsofy.quest/pr-preview/pr-150/?replay=AQAAAAAilCqbAwthdXRvZXhwbG9yZQVyaWdodARsZWZ0AAAAAwAUAQQCEA

<!-- SCREENSHOT: replay chip -->
