### PR TITLE
fix(render): incremental redraw during replay playback

### DIFF
--- a/main.lg
+++ b/main.lg
@@ -387,7 +387,13 @@
     (sfx/pause! 400)
     (reduce (fn [w action]
               (let [w' (dispatch/dispatch w action)]
-                (render/render-full w')
+                ;; Mirror the live loop (play/play-advance): an incremental
+                ;; dirty render per turn, full repaint only on a floor change.
+                ;; A full repaint every frame clears the whole screen first,
+                ;; which reads as a blank-then-redraw flicker on playback (#110).
+                (if (= (:depth w') (:depth w))
+                  (render/render-dirty w' w)
+                  (render/render-full w'))
                 ;; Keep the HUD stats tracking the replay as it plays out.
                 (bridge/emit-stats w')
                 (sfx/pause! 90)


### PR DESCRIPTION
## What

`play-replay` now redraws incrementally during playback — a dirty FOV-delta render per turn — instead of full-repainting every frame. Full repaint stays only for a floor change, where the whole viewport turns over anyway.

Independent of the render-perf stack (#145/#146/#149): the change is in `play-replay`, not `render.lg`, and `render-dirty` is already the live path on `main`.

## Why

`render-full` blanks the entire terminal before it repaints — it paints every row with the background colour, then draws the panels on top. The live game loop only pays that cost when it has to (floor change or resize); every normal turn goes through `render-dirty`, which touches only the cells that changed and never clears.

`play-replay` never adopted that split — it called `render-full` on every action. So each replayed turn cleared the screen and repainted it, and on the web build that blank-then-repaint reads as a full-screen flicker across the whole playback (#110).

## How

Mirror `play/play-advance`: compare `(:depth w')` against the pre-action depth, `render-dirty w' w` when they match, `render-full` on a floor change. `render-dirty` takes the previous world as its diff base — the reduce already carries it, so threading it in is the whole change.

I left out the live loop's resize branch on purpose. Replay has no interactive resize mid-playback; a stray resize would leave one stale frame until the next turn redraws, which isn't worth polling `term/size` every frame for. Easy to add back if that turns out to matter.

## Safety

Render-only. The seed chain and action log are untouched, so a replayed run stays bit-identical — same reconstruction, only fewer escapes drawing it. Verified in the browser: the replayed run animates cell-by-cell with the map, HUD, and log staying put frame to frame, no full-screen blank between turns. Existing suite passes.

Closes #110
