### PR TITLE
fix(shell): portrait cap uses dvh, not vh (clears the iOS URL bar)

### DIFF
--- a/tools/xsofy-shell.html
+++ b/tools/xsofy-shell.html
@@ -34,11 +34,15 @@
 /* Portrait aspect cap. The minimal -w-shell none frame lets its terminal mount
    (#terminal on v1.11.1; renamed #app on newer let-go) fill the viewport; on a
    phone in portrait that stretches the grid full-height and crowds out the
-   on-screen keyboard. Cap the mount to 55vh so the grid stays legible and leaves
-   room below. min-height:0 lets the flex item shrink under a larger font on
+   on-screen keyboard. Cap the mount to 55dvh so the grid stays legible and
+   leaves room below. dvh (dynamic viewport height), not vh: vh is the LARGE
+   viewport (as if the URL bar were retracted), so on iOS at rest it over-counts
+   by the URL bar's height and the grid's bottom slips behind the bar; dvh tracks
+   the currently-visible area, so the cap self-corrects as the URL bar shows and
+   hides. min-height:0 lets the flex item shrink under a larger font on
    landscape/desktop, where no cap applies. */
 #terminal { min-height: 0; }
-@media (orientation: portrait) { body #terminal { flex: 0 0 auto; height: 55vh; } }
+@media (orientation: portrait) { body #terminal { flex: 0 0 auto; height: 55dvh; } }
 </style>
 <script>
 (function () {

--- a/tools/xsofy-shell.html
+++ b/tools/xsofy-shell.html
@@ -112,7 +112,7 @@
       // fixed-size cells, so up to ~one cell is left over per axis; xterm pins
       // the grid top-left, pooling the slack on the right/bottom edges. Pad to
       // place it: centered on X, top-aligned with a small fixed margin on Y so
-      // the grid hugs the top and the keyboard space (from the 55vh cap) stays
+      // the grid hugs the top and the keyboard space (from the 55dvh cap) stays
       // below, instead of the grid centering in the capped band.
       const screen = host ? host.querySelector(".xterm-screen") : null;
       if (host && screen) {


### PR DESCRIPTION
## What

The portrait aspect cap from #143 measured in `vh`; this switches it to `dvh`. One line in `tools/xsofy-shell.html` (plus the comment):

```css
@media (orientation: portrait) { body #terminal { flex: 0 0 auto; height: 55dvh; } }
```

The `55` value is unchanged — only the unit.

## Why

`vh` is the **large** viewport: 100vh is the height as if the browser's URL bar were retracted. On iOS Safari the URL bar is showing at rest, so `55vh` measures against a taller box than is actually visible, over-counting by the bar's height. The result: the bottom of the grid sits behind the URL bar in portrait.

`dvh` (dynamic viewport height) tracks the currently-visible area instead, so the cap shrinks when the URL bar is showing and grows when it retracts. The grid stays fully visible without a hand-tuned constant — I'd otherwise have had to guess the bar's height (~50vh worked, but only by luck of my device).

#143 already listens on `visualViewport` to re-fit on URL-bar changes, but that only re-lays the xterm grid inside a box whose height was still `vh` — it reacted to the bar without the CSS ever being viewport-aware. `dvh` closes that gap in the layout itself.

## Scope

Portrait-only: the change is entirely inside the `@media (orientation: portrait)` rule, so landscape and desktop fall through to the unchanged fill behavior and cannot be affected.

## Validation

On-device, iPhone Safari, portrait with the keyboard open: the full grid, topbar, and message line sit above both the URL bar and the keyboard, with nothing clipped.

This class of bug is invisible to a fixed headless viewport: with no dynamic URL bar, `vh` and `dvh` render identically, so it only shows up on a real device.

screenshot (iphone 13 pro):

<img width="293" height="633" alt="image" src="https://github.com/user-attachments/assets/b24eca94-e508-496c-8169-5c748821c6a6" />
