### PR TITLE
feat(console): (replay) + (bench) commands (Layer 2)

### DIFF
--- a/xsofy/console.lg
+++ b/xsofy/console.lg
@@ -19,6 +19,10 @@
    Its reference implementation is preserved on the console/dev-repl-cut1 branch."
   (:require [term]
             [pprint]
+            [os]
+            [js]
+            [xsofy.replay :as replay]
+            [xsofy.perf :as perf]
             [xsofy.render :as render]
             [xsofy.ui :as ui]))
 
@@ -47,14 +51,26 @@
 
 (defn- help-text []
   (str "commands (read-only):\n"
+       "  (replay)    replay code for this run\n"
        "  (seed)      seed-input + current rolling seed\n"
        "  (player)    player hp / position / depth\n"
        "  (location)  position / depth / turn\n"
+       "  (bench)     quick engine micro-benchmark (per-turn ms)\n"
        "  (help)      this list\n"
        "Esc or ` to close."))
 
 (def ^:private commands
   {'help     (fn [_ _] (help-text))
+   ;; Show the code in the panel and, on web, also fire the host replay-dump
+   ;; event (the same one the death-dump emits — see main.lg). A shell that
+   ;; wires an onEmit sink can then surface it outside the xterm (console.log,
+   ;; or a copyable element below the game); until such a handler exists the
+   ;; emit is a harmless no-op. The in-panel text is the shell-independent path.
+   'replay   (fn [w _]
+               (let [code (replay/encode-run-safe w)]
+                 (when (and code (= (os/os-name) "js"))
+                   (js/emit "xsofy/replay-dump" {:code code}))
+                 (or code "(unavailable: run has parameterized actions)")))
    'seed     (fn [w _] {:seed-input (:seed-input w) :seed (:seed w)})
    'player   (fn [w _] (let [p (get-in w [:entities :player])]
                          {:hp     (get-in p [:body :hp])
@@ -62,7 +78,12 @@
                           :pos    (:pos p)
                           :depth  (:depth w)}))
    'location (fn [w _] (let [p (get-in w [:entities :player])]
-                         {:pos (:pos p) :depth (:depth w) :turn (:turn w)}))})
+                         {:pos (:pos p) :depth (:depth w) :turn (:turn w)}))
+   ;; Self-contained: run-fixture builds its own throwaway worlds from the seeds,
+   ;; so bench never touches the live run. Kept small (3 seeds x 20 turns) so it
+   ;; returns in well under a second — the full sweep lives in bench/native.lg.
+   'bench    (fn [_ _] (dissoc (perf/run-fixture [:wait (fn [_] ".") 20] [0 1 2] 1)
+                               :per-seed))})
 
 (defn run-command
   "Parse `line` with the reader and dispatch its head against the read-only

--- a/xsofy/test/console_test.lg
+++ b/xsofy/test/console_test.lg
@@ -30,10 +30,14 @@
   (testing "(location) reports pos / depth / turn"
     (is (= {:pos [3 4] :depth 1 :turn 0}
            (:val (console/run-command world "(location)")))))
+  (testing "(replay) yields a code string for a clean run"
+    (let [r (console/run-command world "(replay)")]
+      (is (:ok r))
+      (is (string? (:val r)))))
   (testing "(help) lists the commands"
     (let [r (console/run-command world "(help)")]
       (is (:ok r))
-      (is (str/includes? (:val r) "seed")))))
+      (is (str/includes? (:val r) "replay")))))
 
 (deftest bare-symbol-resolves-like-a-call
   (testing "`help` without parens dispatches the same as (help)"


### PR DESCRIPTION
## What

Stacks on the read-only console (Layer 1, #144). Adds the two commands that integrate a subsystem — where every external dependency lands.

- `(replay)` — the run's replay code (`xsofy.replay`). On web it also fires the host `xsofy/replay-dump` event, the same one the death-dump emits, so a shell that wires an `onEmit` sink can surface the code outside the xterm (console.log, or a copyable element below the game). Inert until such a handler exists; the in-panel text is the shell-independent path.
- `(bench)` — a small `perf/run-fixture` over its own throwaway worlds (3 seeds × 20 turns), reporting per-turn p50/p95. Self-contained, so it never touches the live run — and it drives the same lg binary the game runs, so on web it profiles the actual device. The full sweep stays in `bench/native.lg`.

Adds the `xsofy.replay` / `xsofy.perf` / `os` / `js` requires and the `(replay)` test.

## Base

Stacked on Layer 1 (#144) — review that first; this diff is only the two commands and their requires.

## Why the split

The original single PR bundled the console UI, read-only reads, subsystem-integrating commands, and an arbitrary-eval path. Splitting by concern:

- **Layer 1 (this PR)** — the console + pure reads. No external dependency.
- **Layer 2 (stacked, #153)** — `(replay)` and `(bench)`, which pull in `xsofy.replay`, `xsofy.perf`, and the browser bridge.
- **Layer 3** — the arbitrary-eval REPL with mutations recorded as commits in the game-state DAG (@nnunley's review below). Its reference implementation is preserved on the `console/dev-repl-cut1` branch.


## Validation

Full lg suite green (2758 assertions).

To test, append `?mode=dev` to enable the console.
