### PR TITLE
feat(mobile): touch relayout — 4-row grid, mirrored, persistent y/n + keyset row

### DIFF
--- a/tools/xsofy-shell.html
+++ b/tools/xsofy-shell.html
@@ -23,6 +23,12 @@
      Fairfax HD has no Reserved Font Name, so the subset keeps the family name.
      License: tools/fonts/LICENSE-FairfaxHD-OFL.txt. -->
 <style>
+/* Own the color scheme so iOS Safari doesn't dark-mode-transform our fixed dark
+   terminal (title runes + lighting tints render wrong under Dark Mode + the
+   @font-face below — a documented Safari combination, #135 finding F3). The
+   shell is always dark, so declare it; mirrored as a <meta> at boot (below) for
+   the earliest race-free signal. */
+:root { color-scheme: dark; }
 @font-face {
   font-family: 'Fairfax HD';
   font-style: normal;
@@ -43,9 +49,119 @@
    font on landscape/desktop, where no cap applies. */
 #app { min-height: 0; }
 @media (orientation: portrait) { body #app { flex: 0 0 auto; height: 55dvh; } }
+/* force-touch caps: a coarse-pointer device (or the dev toggle) reveals the
+   touch UI in every orientation, so the terminal has to yield room the same way
+   portrait does. Landscape gets a taller slice than portrait's 55dvh. The
+   .force-touch class is set on <body> by the plumbing below; it also retargets
+   #app, which is #xsofy-shell's sibling, not a descendant. */
+body.force-touch #app { flex: 0 0 auto; height: 55dvh; }
+@media (orientation: landscape) {
+  body.force-touch #app { flex: 0 0 auto; height: calc(100vh - 260px); }
+}
+
+/* Client shell scaffold. Blank structural host mounted as #app's flex sibling
+   (the same stacking the slot-model #shell-bottom had): the containers, the
+   orientation/force-touch layout hooks, and the dev-tier class contract — but
+   NO chrome. The info/touch rows are empty and the theming, buttons, and
+   game-event wiring are a follow-up slice that appends into this structure
+   without restructuring it. */
+#xsofy-shell {
+  display: flex;
+  flex-direction: column;
+  /* Landscape: size to content (an empty row → zero height, invisible).
+     Portrait/force-touch override to flex:1 so the shell absorbs the space
+     under the capped terminal — what #shell-bottom did under the slot model. */
+  flex: 0 0 auto;
+  min-height: 0;
+}
+@media (orientation: portrait) {
+  #xsofy-shell { flex: 1 1 auto; overflow: auto; }
+}
+body.force-touch #xsofy-shell { flex: 1 1 auto; overflow: auto; }
+
+#xsofy-shell .row { display: flex; flex-shrink: 0; }
+
+/* Touch container — structural grid (D-pad left, action column right) plus the
+   orientation/force-touch display switch that IS the touch-visibility hook. The
+   layout applies unconditionally (harmless while display:none); only the
+   none↔grid switch is conditional. .pad/.actions are populated by the
+   controls slice. */
+#xsofy-shell .touch {
+  display: none;
+  grid-template-columns: 3fr 2fr;
+  grid-template-rows: 1fr;
+  flex: 1;
+  min-height: 0;
+}
+@media (orientation: portrait) { #xsofy-shell .touch { display: grid; } }
+body.force-touch #xsofy-shell .touch { display: grid; }
+/* Landscape force-touch — constrain the D-pad to a usable width instead of
+   letting it span a 1024+px viewport, and center it. */
+@media (orientation: landscape) {
+  body.force-touch #xsofy-shell .touch {
+    max-width: 560px;
+    width: 100%;
+    margin-left: auto;
+    margin-right: auto;
+    flex: 0 0 auto;
+  }
+}
+#xsofy-shell .pad,
+#xsofy-shell .actions {
+  display: grid;
+  min-width: 0;
+  min-height: 0;
+  /* Explicit 100% breaks the circular sizing: without it, 1fr rows resolve
+     against content size, which the rows themselves determine — so they
+     collapse. */
+  height: 100%;
+}
+#xsofy-shell .pad { grid-template-columns: repeat(3, 1fr); grid-template-rows: repeat(3, 1fr); }
+#xsofy-shell .actions { grid-template-columns: 1fr 1fr; grid-template-rows: repeat(3, 1fr); }
+
+/* Dev-tier visibility contract. Two axes: the OPTIONS tile reveals player
+   options at runtime (mode-debug), while diagnostics (mode-urldiag) and dev
+   tooling (mode-dev) are URL-gated only — set here now so the controls slice
+   only has to add tier-classed elements, not re-plumb the gating. Nothing
+   carries these classes yet, so every rule is inert until then. */
+#xsofy-shell:not(.mode-debug)   .debug-only { display: none; }
+#xsofy-shell:not(.mode-urldiag) .diag-only  { display: none; }
+#xsofy-shell:not(.mode-dev)     .dev-only   { display: none; }
+#xsofy-shell.mode-debug .play-only          { display: none; }
 </style>
+
+<!-- Blank scaffold: empty info + touch rows, mounted as #app's sibling. The
+     controls slice appends the title/quest/diagnostics chips into .info and the
+     D-pad/action tiles into .pad/.actions — the structure and IDs are here so
+     that slice is purely additive. -->
+<div id="xsofy-shell" class="mode-play">
+  <div class="row info"></div>
+  <div class="row touch">
+    <div class="pad" id="xs-pad"></div>
+    <div class="actions" id="xs-actions"></div>
+  </div>
+</div>
+
 <script>
 (function () {
+  // --- Mobile viewport + color scheme. The -w-shell none frame's <head> omits
+  // both (let-go's host.html carried them under the slot model); inject them so
+  // mobile Safari scales correctly and owns its (fixed dark) appearance rather
+  // than dark-mode-transforming our colors. Guarded so a frame that already
+  // sets them wins. ---
+  if (!document.querySelector('meta[name="viewport"]')) {
+    const m = document.createElement('meta');
+    m.name = 'viewport';
+    m.content = 'width=device-width, initial-scale=1, viewport-fit=cover';
+    document.head.appendChild(m);
+  }
+  if (!document.querySelector('meta[name="color-scheme"]')) {
+    const cs = document.createElement('meta');
+    cs.name = 'color-scheme';
+    cs.content = 'dark';
+    document.head.appendChild(cs);
+  }
+
   const termEl = document.getElementById('app');
   // ?font=system bypasses the bundled rune face and renders in the platform
   // mono — a debug/preference escape hatch. Runes (U+16A0–16FF) then fall back
@@ -132,6 +248,37 @@
   }
   window.addEventListener('resize', refit);
   window.addEventListener('orientationchange', refit);
-  if (window.visualViewport) window.visualViewport.addEventListener('resize', refit);
+  if (window.visualViewport) {
+    window.visualViewport.addEventListener('resize', refit);
+    // The URL bar can slide without a resize event — its show/hide arrives as a
+    // visualViewport scroll. Re-letterbox on it so the grid tracks the bar.
+    window.visualViewport.addEventListener('scroll', refit);
+  }
+
+  // --- Force-touch detection (plumbing; the toggle UI is a later slice). A
+  // coarse primary pointer (phone/tablet) needs the on-screen controls in every
+  // orientation, so drive body.force-touch from capability OR a persisted dev
+  // override. The class lives on <body> because it also retargets #app (the
+  // terminal), which is #xsofy-shell's sibling, not a descendant. ---
+  const coarsePointer = !!window.matchMedia?.('(pointer: coarse)')?.matches;
+  const forceTouchEnabled = localStorage.getItem('xsofy/force-touch') === '1';
+  document.body.classList.toggle('force-touch', coarsePointer || forceTouchEnabled);
+
+  // --- Dev-tier gating (plumbing; the runtime OPTIONS toggle is a later slice).
+  // Seed the tier from ?mode= (debug|dev → diagnostics/dev tooling) or the last
+  // persisted state, and stamp the mode classes onto #xsofy-shell so the tier-
+  // gated CSS above has its contract. mode-play is the permanent base; dev is a
+  // strict superset of debug. Nothing is tier-classed yet, so this is inert
+  // until the controls slice adds gated elements. ---
+  const shellRoot = document.getElementById('xsofy-shell');
+  const urlMode = new URLSearchParams(location.search).get('mode');
+  const devMode = urlMode === 'dev';
+  let shellState = localStorage.getItem('xsofy/shell-state');
+  if (urlMode === 'dev' || urlMode === 'debug') shellState = 'debug';
+  else if (urlMode === 'play') shellState = 'play';
+  else if (shellState !== 'debug') shellState = 'play';
+  shellRoot.classList.toggle('mode-debug', shellState === 'debug' || devMode);
+  shellRoot.classList.toggle('mode-dev', devMode);
+  shellRoot.classList.toggle('mode-urldiag', urlMode === 'debug' || urlMode === 'dev');
 })();
 </script>

--- a/tools/xsofy-shell.html
+++ b/tools/xsofy-shell.html
@@ -234,6 +234,38 @@ body.force-touch #xsofy-shell .touch { display: grid; }
    stays one line. */
 #xsofy-shell .font-cycle { flex: 0 0 auto; min-height: 0; min-width: 0; padding: 0.15rem 0.45rem; border-radius: 5px; font-size: 11px; line-height: 1.2; color: var(--bar-dim); }
 #xsofy-shell .font-cycle .glyph { font-size: 12px; color: var(--bar-fg); }
+
+/* Phone landscape (short viewport) — split the shell to the RIGHT instead of
+   stacking it below the terminal (which leaves a phone only ~130px of game).
+   Terminal keeps the left ~70% so the game's own left HUD sidebar has the width
+   to stay open — unlike portrait, where the narrow terminal drops it. Portrait's
+   exact control block — side-by-side D-pad + the multi-pane action column (cycle
+   + all panes intact) — is transplanted verbatim into a ~30% right column: we
+   only REPOSITION it, not reshape it. Scoped by max-height so tablet/desktop
+   force-touch opt-in (taller viewports) keeps the centered strip above. First
+   cut — ratio tuned on-device (F18). Must follow the landscape force-touch rules
+   above: equal specificity, so source order decides which wins on a phone (both
+   media queries match). */
+@media (orientation: landscape) and (max-height: 500px) {
+  body.force-touch              { flex-direction: row; }
+  body.force-touch #app         { height: 100vh; flex: 1 1 auto; min-width: 0; }
+  body.force-touch #xsofy-shell {
+    flex: 0 0 30%;
+    height: 100vh;
+    overflow: auto;
+    border-top: none;
+    border-left: 1px solid var(--bar-rule);
+  }
+  /* Keep portrait's touch grid verbatim (base .touch = 3fr/2fr D-pad|actions,
+     panes intact). Only undo the 560px strip-centering from the landscape block
+     above and restore fill sizing (that block pins 60px rows). */
+  body.force-touch #xsofy-shell .touch { max-width: none; width: auto; margin: 0; }
+  body.force-touch #xsofy-shell .pad,
+  body.force-touch #xsofy-shell .actions { grid-template-rows: repeat(3, 1fr); height: 100%; }
+  /* Narrow rail: collapse the info bar to a single column so title/quest don't
+     fight the fixed-width chips for space. */
+  body.force-touch #xsofy-shell .info { grid-template-columns: minmax(0, 1fr); }
+}
 </style>
 
 <!-- Blank scaffold: empty info + touch rows, mounted as #app's sibling. The

--- a/tools/xsofy-shell.html
+++ b/tools/xsofy-shell.html
@@ -56,7 +56,10 @@
    #app, which is #xsofy-shell's sibling, not a descendant. */
 body.force-touch #app { flex: 0 0 auto; height: 55dvh; }
 @media (orientation: landscape) {
-  body.force-touch #app { flex: 0 0 auto; height: calc(100vh - 260px); }
+  /* Reserve the touch UI's height so the terminal doesn't overflow it. Budget:
+     info bar (52) + 4 pad rows @60px (240) + gaps/padding (~35) ~= 330. Bumped
+     from 260 when the pad went 3->4 rows (a fixed-60px row landscape path). */
+  body.force-touch #app { flex: 0 0 auto; height: calc(100vh - 330px); }
 }
 
 /* Client shell scaffold. Blank structural host mounted as #app's flex sibling
@@ -88,8 +91,16 @@ body.force-touch #xsofy-shell { flex: 1 1 auto; overflow: auto; }
    controls slice. */
 #xsofy-shell .touch {
   display: none;
-  grid-template-columns: 3fr 2fr;
+  /* Mirrored layout: action column on the LEFT (2fr), D-pad on the RIGHT (3fr).
+     Puts Esc/BACK at the far top-left (see ACTION_COLUMN order) where it sits on a
+     QWERTY keyboard. The DOM is ordered actions-then-pad to match these tracks so
+     both stay in grid row 1 (a grid-column swap without the DOM reorder bumps
+     .actions to row 2 under sparse auto-flow — the source of the old top gap). */
+  grid-template-columns: 2fr 3fr;
   grid-template-rows: 1fr;
+  /* Top-align both blocks (override .row's align-items:center) so the D-pad's top
+     row and the action block's top row start at the same height. */
+  align-items: start;
   flex: 1;
   min-height: 0;
 }
@@ -116,8 +127,8 @@ body.force-touch #xsofy-shell .touch { display: grid; }
      collapse. */
   height: 100%;
 }
-#xsofy-shell .pad { grid-template-columns: repeat(3, 1fr); grid-template-rows: repeat(3, 1fr); }
-#xsofy-shell .actions { grid-template-columns: 1fr 1fr; grid-template-rows: repeat(3, 1fr); }
+#xsofy-shell .actions { grid-template-columns: 1fr 1fr; grid-template-rows: repeat(4, 1fr); }
+#xsofy-shell .pad { grid-template-columns: repeat(3, 1fr); grid-template-rows: repeat(4, 1fr); }
 
 /* Dev-tier visibility contract. Two axes: the OPTIONS tile reveals player
    options at runtime (mode-debug), while diagnostics (mode-urldiag) and dev
@@ -153,7 +164,7 @@ body.force-touch #xsofy-shell .touch { display: grid; }
 #xsofy-shell .pad, #xsofy-shell .actions { gap: 0.3rem; }
 @media (orientation: landscape) {
   body.force-touch #xsofy-shell .pad,
-  body.force-touch #xsofy-shell .actions { grid-template-rows: repeat(3, 60px); height: auto; }
+  body.force-touch #xsofy-shell .actions { grid-template-rows: repeat(4, 60px); height: auto; }
 }
 
 /* Two-row info bar. Single-row crammed title/quest/stats/chips into ~375px and
@@ -167,21 +178,27 @@ body.force-touch #xsofy-shell .touch { display: grid; }
   grid-template-columns: minmax(0, 1fr) auto;
   grid-template-rows: auto auto;
   column-gap: 0.6rem;
-  row-gap: 0.35rem;
+  row-gap: 0.15rem;
   align-items: start;
-  padding-top: 0.5rem;
+  padding-top: 0.3rem;
   border-bottom: 1px solid var(--bar-rule);
-  /* Fixed tall height so opening/closing options never resizes the bar — the
-     tile stays anchored top-right and the options fill the space below it,
-     which is empty in play. */
-  min-height: 88px;
+  /* Hard height so opening/closing options never resizes the bar. min-height was
+     only a floor — the debug row's chips could still grow it past 56 and make the
+     bar flip; a fixed height + border-box keeps it constant (the single-line
+     chips below are sized to fit). Options fill the space below the tile, empty
+     in play. */
+  box-sizing: border-box;
+  height: 52px;
+  overflow: hidden;
 }
 #xsofy-shell .info .title { grid-area: 1 / 1; color: var(--bar-fg); font-weight: 500; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; min-width: 0; }
-#xsofy-shell .info .chips { grid-area: 1 / 2; justify-self: end; display: flex; }
-#xsofy-shell .info .debug-row { grid-area: 2 / 2; justify-self: end; display: flex; flex-direction: row; align-items: center; gap: 0.5rem; }
+/* Right controls row: spans BOTH text rows (grid-row 1/3), vertically centered,
+   right-aligned — one row of full-height chips instead of two half-height stacks
+   (the left column keeps its two text rows). */
+#xsofy-shell .info .debug-row { grid-area: 1 / 2 / 3 / 3; justify-self: end; align-self: center; display: flex; flex-direction: row; align-items: center; gap: 0.4rem; }
 /* Options/back tile — compact icon button (⚙ / ←) pinned top-right, dashed like
    the action grid's nav tile so it reads as chrome, not content. */
-#xsofy-shell .shell-cycle { background: rgba(245, 176, 65, 0.02); border-style: dashed; width: 2.1rem; min-height: 1.9rem; display: flex; align-items: center; justify-content: center; }
+#xsofy-shell .shell-cycle { background: rgba(245, 176, 65, 0.02); border-style: dashed; width: 2.2rem; min-height: 2.2rem; display: flex; align-items: center; justify-content: center; }
 #xsofy-shell .shell-cycle .label { color: var(--bar-accent); font-size: 1.05rem; line-height: 1; }
 /* Hold-to-repeat is a touch affordance — desktop keyboards repeat at the OS
    level, so hide the toggle on a fine pointer (still shown under force-touch). */
@@ -232,7 +249,11 @@ body.force-touch #xsofy-shell .touch { display: grid; }
 #xsofy-shell .actions .filler { visibility: hidden; }
 /* Font-size cycle lives in the info row: compact, intrinsic height so the row
    stays one line. */
-#xsofy-shell .font-cycle { flex: 0 0 auto; min-height: 0; min-width: 0; padding: 0.15rem 0.45rem; border-radius: 5px; font-size: 11px; line-height: 1.2; color: var(--bar-dim); }
+/* Info-bar chips (font size, repeat, force-touch, options tile). Lay glyph +
+   value on ONE line (flex-direction:row overrides the button column) so the chip
+   height is constant as the value changes — that height jitter was flipping the
+   shrunk info bar. */
+#xsofy-shell .font-cycle { flex: 0 0 auto; flex-direction: row; align-items: center; gap: 0.25rem; min-height: 2.2rem; min-width: 0; padding: 0.15rem 0.6rem; border-radius: 5px; font-size: 11px; line-height: 1.2; color: var(--bar-dim); }
 #xsofy-shell .font-cycle .glyph { font-size: 12px; color: var(--bar-fg); }
 
 /* Phone landscape (short viewport) — split the shell to the RIGHT instead of
@@ -261,7 +282,7 @@ body.force-touch #xsofy-shell .touch { display: grid; }
      above and restore fill sizing (that block pins 60px rows). */
   body.force-touch #xsofy-shell .touch { max-width: none; width: auto; margin: 0; }
   body.force-touch #xsofy-shell .pad,
-  body.force-touch #xsofy-shell .actions { grid-template-rows: repeat(3, 1fr); height: 100%; }
+  body.force-touch #xsofy-shell .actions { grid-template-rows: repeat(4, 1fr); height: 100%; }
   /* Narrow rail: collapse the info bar to a single column so title/quest don't
      fight the fixed-width chips for space. */
   body.force-touch #xsofy-shell .info { grid-template-columns: minmax(0, 1fr); }
@@ -277,17 +298,12 @@ body.force-touch #xsofy-shell .touch { display: grid; }
     <span class="title play-only" id="xs-title">—</span>
     <span class="quest play-only" id="xs-quest"></span>
     <span class="build debug-only" id="xs-build" title="Build provenance — written by local-scripts/deploy.sh"></span>
-    <div class="chips">
-      <!-- Row 1 / col 2: the OPTIONS/back tile, pinned top-right and alone.
-           Icon toggles ⚙ (open options) ↔ ← (back to play); dev tier is URL-only. -->
-      <button class="font-cycle shell-cycle" id="xs-shell-cycle" title="Options">
-        <span class="label" id="xs-shell-cycle-label">⚙</span>
-      </button>
-    </div>
+    <!-- Right controls: ONE horizontal row spanning both text rows (grid-row
+         1/3), vertically centered, so the buttons get the bar's full height
+         instead of two half-height stacks. Play shows just the ⚙ tile; debug
+         adds the perf stats + option chips to its left. Tier classes gate each
+         item, so it's just ⚙ in play. -->
     <div class="debug-row">
-      <!-- Row 2 / col 2: URL-gated perf stats, then the player-option chips —
-           one horizontal row, right-aligned, under the tile. Tier classes gate
-           each item, so this row is empty in play. -->
       <span class="stats">
         <span class="diag-only stat-hidden"><span class="k">t</span><span id="xs-turn">·</span></span>
         <span class="diag-only stat-hidden" id="xs-perf-turn-wrap"><span class="k">@t</span><span id="xs-perf-turn">·</span></span>
@@ -308,17 +324,25 @@ body.force-touch #xsofy-shell .touch { display: grid; }
       <!-- Dev tooling (?mode=dev only): force the phone touch UI visible on
            desktop/tablet-landscape for testing — not a player pref. -->
       <button class="font-cycle dev-only" id="xs-touch-toggle" title="Force touch controls visible (overrides the landscape auto-hide)">
-        <span class="glyph">▦</span><span id="xs-touch-state">off</span>
+        <span class="glyph">▦</span><span id="xs-touch-state">auto</span>
+      </button>
+      <!-- OPTIONS/back tile — always visible; toggles ⚙ (open) ↔ ← (back). Last
+           in the row so it anchors the right edge in both play (alone) and debug
+           (chips fill in to its left). -->
+      <button class="font-cycle shell-cycle" id="xs-shell-cycle" title="Options">
+        <span class="label" id="xs-shell-cycle-label">⚙</span>
       </button>
     </div>
   </div>
   <div class="row touch">
-    <!-- Both grids are populated by the script below from PANES. The right
-         column (.actions) is identical on every pane — persistent muscle memory
-         for GET/INV/DESC/FIRE/BACK + the pane nav. The left grid (.pad) swaps
-         content per pane: movement on Pane 1, item/meta actions on Pane 2. -->
-    <div class="pad" id="xs-pad"></div>
+    <!-- Mirrored layout: .actions is the LEFT column, .pad (D-pad) the RIGHT.
+         DOM order matches column order (actions then pad) so the grid keeps both
+         in row 1 — don't reorder without also swapping the grid tracks. Both are
+         populated by the script below from PANES. The action column is identical
+         on every pane (persistent muscle memory for BACK/GET/DESC/FIRE/INV + the
+         pane nav); the D-pad swaps content per pane. -->
     <div class="actions" id="xs-actions"></div>
+    <div class="pad" id="xs-pad"></div>
   </div>
 </div>
 
@@ -566,21 +590,34 @@ body.force-touch #xsofy-shell .touch { display: grid; }
   // only the left 3x3 swaps content. Turn-based, so giving up the D-pad on a
   // non-movement pane is fine — one nav tap restores it. ---
   const ESC = '\u001b';
-  const RIGHT_COLUMN = [
-    { key: 'g', glyph: 'g', label: 'GET' },
+  // The persistent action column (left side, same on every pane), 2 cols x 4
+  // rows. Esc/BACK leads so it lands top-left — with the mirrored layout that's
+  // the far top-left of the touch UI (QWERTY Esc). YES/NO and the keyset selector
+  // live in the D-pad's persistent top row now (see renderTouch); this block
+  // carries the common commands. Row-major fill (2 cols):
+  //   BACK  DESC
+  //   GET   FIRE
+  //   USE   INV
+  //   WAIT  MSG
+  const ACTION_COLUMN = [
     { key: ESC, glyph: 'esc', label: 'BACK' },
     { key: '>', glyph: '>', label: 'DESC' },
+    { key: 'g', glyph: 'g', label: 'GET' },
     { key: 'f', glyph: 'f', label: 'FIRE' },
+    { key: 'a', glyph: 'a', label: 'USE' },
     { key: 'i', glyph: 'i', label: 'INV' },
+    { key: '.', glyph: '·', label: 'WAIT', repeat: true },
+    { key: 'm', glyph: 'm', label: 'MSG' },
   ];
   const PANES = [
     { // Pane 1 — movement D-pad with auto-explore at center. Directions
-      // hold-repeat; AUTO does not (one tap starts the run).
+      // hold-repeat; AUTO does not (one tap starts the run). Fills the 3-row body
+      // below the persistent YES/NO/keyset top row.
       label: 'MOVE',
       pad: [
-        { key: 'y', glyph: '↖', repeat: true }, { key: 'k', glyph: '↑', repeat: true }, { key: 'u', glyph: '↗', repeat: true },
-        { key: 'h', glyph: '←', repeat: true }, { key: 'x', glyph: 'x', label: 'AUTO' }, { key: 'l', glyph: '→', repeat: true },
-        { key: 'b', glyph: '↙', repeat: true }, { key: 'j', glyph: '↓', repeat: true }, { key: 'n', glyph: '↘', repeat: true },
+        { key: 'y', glyph: '↖', label: 'y', repeat: true }, { key: 'k', glyph: '↑', label: 'k', repeat: true }, { key: 'u', glyph: '↗', label: 'u', repeat: true },
+        { key: 'h', glyph: '←', label: 'h', repeat: true }, { key: 'x', glyph: 'x', label: 'AUTO' }, { key: 'l', glyph: '→', label: 'l', repeat: true },
+        { key: 'b', glyph: '↙', label: 'b', repeat: true }, { key: 'j', glyph: '↓', label: 'j', repeat: true }, { key: 'n', glyph: '↘', label: 'n', repeat: true },
       ],
     },
     { // Pane 2 — item & meta actions; bottom row is yes/no for game prompts.
@@ -594,11 +631,13 @@ body.force-touch #xsofy-shell .touch { display: grid; }
     },
     { // Pane 3 — straight letter keys for menu selection (inventory, rune
       // inscription, item slots). No hold-repeat: held letters would spam picks.
-      label: 'KEYS', padCols: 4, padRows: 3,
+      // a–i fills the 3-row body under the persistent top row (j–l dropped when
+      // the top row went persistent; revisit if menus need past i).
+      label: 'KEYS',
       pad: [
-        { key: 'a', glyph: 'a' }, { key: 'b', glyph: 'b' }, { key: 'c', glyph: 'c' }, { key: 'd', glyph: 'd' },
-        { key: 'e', glyph: 'e' }, { key: 'f', glyph: 'f' }, { key: 'g', glyph: 'g' }, { key: 'h', glyph: 'h' },
-        { key: 'i', glyph: 'i' }, { key: 'j', glyph: 'j' }, { key: 'k', glyph: 'k' }, { key: 'l', glyph: 'l' },
+        { key: 'a', glyph: 'a' }, { key: 'b', glyph: 'b' }, { key: 'c', glyph: 'c' },
+        { key: 'd', glyph: 'd' }, { key: 'e', glyph: 'e' }, { key: 'f', glyph: 'f' },
+        { key: 'g', glyph: 'g' }, { key: 'h', glyph: 'h' }, { key: 'i', glyph: 'i' },
       ],
     },
   ];
@@ -617,17 +656,9 @@ body.force-touch #xsofy-shell .touch { display: grid; }
     return btn;
   }
 
-  function renderTouch() {
-    const padEl = $('xs-pad'), actEl = $('xs-actions');
-    const pane = PANES[currentPane];
-    padEl.innerHTML = ''; actEl.innerHTML = '';
-    // Per-pane grid override (KEYS is denser); clearing lets the CSS default win.
-    padEl.style.gridTemplateColumns = pane.padCols ? `repeat(${pane.padCols}, 1fr)` : '';
-    padEl.style.gridTemplateRows = pane.padRows ? `repeat(${pane.padRows}, 1fr)` : '';
-    for (const spec of pane.pad) padEl.appendChild(tileFor(spec));
-    for (const spec of RIGHT_COLUMN) actEl.appendChild(tileFor(spec));
-    // Nav tile at slot 6 — swaps panes, doesn't send a key, so it's not routed
-    // through bindButton (no hold-repeat). Label names the destination.
+  // Keyset selector (pane switcher) — swaps panes, sends no key, so it's not
+  // routed through bindButton (no hold-repeat). Label names the target pane.
+  function makeNav() {
     const nav = document.createElement('button');
     nav.className = 'nav';
     nav.innerHTML = `<span class="label">${PANES[(currentPane + 1) % PANES.length].label + ' →'}</span>`;
@@ -638,7 +669,26 @@ body.force-touch #xsofy-shell .touch { display: grid; }
       renderTouch();
     });
     nav.addEventListener('mousedown', (e) => e.preventDefault());
-    actEl.appendChild(nav);
+    return nav;
+  }
+
+  function renderTouch() {
+    const padEl = $('xs-pad'), actEl = $('xs-actions');
+    const pane = PANES[currentPane];
+    padEl.innerHTML = ''; actEl.innerHTML = '';
+    // Per-pane grid override (KEYS is denser); clearing lets the CSS default win.
+    padEl.style.gridTemplateColumns = pane.padCols ? `repeat(${pane.padCols}, 1fr)` : '';
+    padEl.style.gridTemplateRows = pane.padRows ? `repeat(${pane.padRows}, 1fr)` : '';
+    // Persistent top row above the D-pad: YES / NO / keyset-selector. Same on
+    // every pane, so game prompts and pane-switching stay one tap away no matter
+    // which pane's body is showing below.
+    padEl.appendChild(tileFor({ key: 'y', glyph: 'y', label: 'YES' }));
+    padEl.appendChild(tileFor({ key: 'n', glyph: 'n', label: 'NO' }));
+    padEl.appendChild(makeNav());
+    // Swappable body (rows 2-4): the current pane's tiles.
+    for (const spec of pane.pad) padEl.appendChild(tileFor(spec));
+    // Left action column — all key tiles now (NAV lives in the pad top row).
+    for (const spec of ACTION_COLUMN) actEl.appendChild(tileFor(spec));
   }
 
   // Hold-to-repeat for opted-in tiles: after REPEAT_INITIAL ms, re-fire every
@@ -711,7 +761,9 @@ body.force-touch #xsofy-shell .touch { display: grid; }
     // Capability forces it on (a touch device can't turn off its only input
     // method); the toggle only matters on fine-pointer devices.
     document.body.classList.toggle('force-touch', coarsePointer || forceTouchEnabled);
-    if (touchStateEl) touchStateEl.textContent = forceTouchEnabled ? 'on' : 'off';
+    // "force" vs "auto": forced pins the touch UI on; unforced ("auto") falls
+    // back to pointer-capability detection (coarse => shown), not truly off.
+    if (touchStateEl) touchStateEl.textContent = forceTouchEnabled ? 'force' : 'auto';
     if (touchToggleEl) touchToggleEl.style.opacity = forceTouchEnabled ? '' : '0.5';
   }
   paintForceTouchState();

--- a/tools/xsofy-shell.html
+++ b/tools/xsofy-shell.html
@@ -128,6 +128,112 @@ body.force-touch #xsofy-shell .touch { display: grid; }
 #xsofy-shell:not(.mode-urldiag) .diag-only  { display: none; }
 #xsofy-shell:not(.mode-dev)     .dev-only   { display: none; }
 #xsofy-shell.mode-debug .play-only          { display: none; }
+
+/* ============================================================
+   controls + style — opinionated chrome layered onto the scaffold above.
+   Theming, the info-bar grid, and the button/tile look. These rules only add
+   appearance to the structure already established; they don't restructure it.
+   ============================================================ */
+#xsofy-shell {
+  --bar-bg: #110d08;
+  --bar-fg: #ede1c4;
+  --bar-dim: #7a6d52;
+  --bar-accent: #f5b041;
+  --bar-rule: rgba(245, 176, 65, 0.18);
+  background: var(--bar-bg);
+  color: var(--bar-fg);
+  font-family: "JetBrains Mono", ui-monospace, "SF Mono", Menlo, monospace;
+  font-size: 13px;
+  user-select: none;
+  -webkit-user-select: none;
+  border-top: 1px solid var(--bar-rule);
+}
+#xsofy-shell .row { align-items: center; gap: 0.6rem; padding: 0.45rem 0.75rem; }
+#xsofy-shell .touch { gap: 0.5rem; padding: 0.5rem 0.6rem 0.7rem; }
+#xsofy-shell .pad, #xsofy-shell .actions { gap: 0.3rem; }
+@media (orientation: landscape) {
+  body.force-touch #xsofy-shell .pad,
+  body.force-touch #xsofy-shell .actions { grid-template-rows: repeat(3, 60px); height: auto; }
+}
+
+/* Two-row info bar. Single-row crammed title/quest/stats/chips into ~375px and
+   lost the right half of both proper-noun strings on every phone:
+     row 1:  [ title ]   [ OPTIONS tile ]
+     row 2:  [ quest ]   [ stats + option chips ]
+   The left column carries the proper-noun strings; minmax(0,1fr) lets it shrink
+   below content width so text-overflow:ellipsis fires. */
+#xsofy-shell .info {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  grid-template-rows: auto auto;
+  column-gap: 0.6rem;
+  row-gap: 0.35rem;
+  align-items: start;
+  padding-top: 0.5rem;
+  border-bottom: 1px solid var(--bar-rule);
+  /* Fixed tall height so opening/closing options never resizes the bar — the
+     tile stays anchored top-right and the options fill the space below it,
+     which is empty in play. */
+  min-height: 88px;
+}
+#xsofy-shell .info .title { grid-area: 1 / 1; color: var(--bar-fg); font-weight: 500; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; min-width: 0; }
+#xsofy-shell .info .chips { grid-area: 1 / 2; justify-self: end; display: flex; }
+#xsofy-shell .info .debug-row { grid-area: 2 / 2; justify-self: end; display: flex; flex-direction: row; align-items: center; gap: 0.5rem; }
+/* Options/back tile — compact icon button (⚙ / ←) pinned top-right, dashed like
+   the action grid's nav tile so it reads as chrome, not content. */
+#xsofy-shell .shell-cycle { background: rgba(245, 176, 65, 0.02); border-style: dashed; width: 2.1rem; min-height: 1.9rem; display: flex; align-items: center; justify-content: center; }
+#xsofy-shell .shell-cycle .label { color: var(--bar-accent); font-size: 1.05rem; line-height: 1; }
+/* Hold-to-repeat is a touch affordance — desktop keyboards repeat at the OS
+   level, so hide the toggle on a fine pointer (still shown under force-touch). */
+@media (hover: hover) and (pointer: fine) {
+  body:not(.force-touch) #xsofy-shell .touch-only { display: none; }
+}
+/* Self-revealing perf cells: hidden until their datum is emitted, so the bar
+   shows only live numbers, not dead middots. */
+#xsofy-shell .stat-hidden { display: none; }
+/* Ellipsize the quest from the LEFT so the meaningful suffix (the item name)
+   survives truncation — "…of Borrowed Confidence", not "seeking C…". */
+#xsofy-shell .info .quest { grid-area: 2 / 1; color: var(--bar-dim); font-size: 11px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; min-width: 0; direction: rtl; text-align: left; }
+/* Build-provenance chip (debug only) — shares the title's cell (title is
+   play-only, so they never collide). SHA stays drag-selectable for bug reports. */
+#xsofy-shell .info .build { grid-area: 1 / 1; color: var(--bar-dim); font-size: 10px; white-space: normal; line-height: 1.2; overflow-wrap: anywhere; min-width: 0; font-variant-numeric: tabular-nums; user-select: text; -webkit-user-select: text; }
+#xsofy-shell .info .stats { display: flex; align-items: center; gap: 0.6rem; color: var(--bar-accent); font-variant-numeric: tabular-nums; }
+#xsofy-shell .info .stats .k { color: var(--bar-dim); }
+
+#xsofy-shell button {
+  font-family: inherit;
+  font-size: 14px;
+  color: var(--bar-fg);
+  background: rgba(245, 176, 65, 0.06);
+  border: 1px solid var(--bar-rule);
+  border-radius: 8px;
+  padding: 0.55rem 0.5rem;
+  cursor: pointer;
+  touch-action: manipulation;
+  -webkit-tap-highlight-color: rgba(245, 176, 65, 0.25);
+  transition: background 0.08s ease, border-color 0.08s ease;
+  min-height: 44px;
+  min-width: 44px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-direction: column;
+  line-height: 1.1;
+}
+#xsofy-shell button:active,
+#xsofy-shell button.pressed { background: rgba(245, 176, 65, 0.22); border-color: var(--bar-accent); }
+#xsofy-shell button .glyph { font-size: 16px; color: var(--bar-accent); }
+#xsofy-shell button .label { font-size: 10px; color: var(--bar-dim); letter-spacing: 0.05em; margin-top: 2px; }
+/* Pane-cycle tile — dashed so the swap affordance reads as chrome, not an action. */
+#xsofy-shell button.nav { background: rgba(245, 176, 65, 0.02); border-style: dashed; }
+#xsofy-shell button.nav .glyph { font-size: 13px; letter-spacing: 0.15em; color: var(--bar-fg); }
+#xsofy-shell button.nav .label { color: var(--bar-accent); }
+/* Empty slot in a pane — holds grid alignment without a tappable target. */
+#xsofy-shell .actions .filler { visibility: hidden; }
+/* Font-size cycle lives in the info row: compact, intrinsic height so the row
+   stays one line. */
+#xsofy-shell .font-cycle { flex: 0 0 auto; min-height: 0; min-width: 0; padding: 0.15rem 0.45rem; border-radius: 5px; font-size: 11px; line-height: 1.2; color: var(--bar-dim); }
+#xsofy-shell .font-cycle .glyph { font-size: 12px; color: var(--bar-fg); }
 </style>
 
 <!-- Blank scaffold: empty info + touch rows, mounted as #app's sibling. The
@@ -135,8 +241,50 @@ body.force-touch #xsofy-shell .touch { display: grid; }
      D-pad/action tiles into .pad/.actions — the structure and IDs are here so
      that slice is purely additive. -->
 <div id="xsofy-shell" class="mode-play">
-  <div class="row info"></div>
+  <div class="row info">
+    <span class="title play-only" id="xs-title">—</span>
+    <span class="quest play-only" id="xs-quest"></span>
+    <span class="build debug-only" id="xs-build" title="Build provenance — written by local-scripts/deploy.sh"></span>
+    <div class="chips">
+      <!-- Row 1 / col 2: the OPTIONS/back tile, pinned top-right and alone.
+           Icon toggles ⚙ (open options) ↔ ← (back to play); dev tier is URL-only. -->
+      <button class="font-cycle shell-cycle" id="xs-shell-cycle" title="Options">
+        <span class="label" id="xs-shell-cycle-label">⚙</span>
+      </button>
+    </div>
+    <div class="debug-row">
+      <!-- Row 2 / col 2: URL-gated perf stats, then the player-option chips —
+           one horizontal row, right-aligned, under the tile. Tier classes gate
+           each item, so this row is empty in play. -->
+      <span class="stats">
+        <span class="diag-only stat-hidden"><span class="k">t</span><span id="xs-turn">·</span></span>
+        <span class="diag-only stat-hidden" id="xs-perf-turn-wrap"><span class="k">@t</span><span id="xs-perf-turn">·</span></span>
+        <span class="diag-only stat-hidden"><span class="k">u</span><span id="xs-update">·</span><span class="k">ms</span></span>
+        <span class="diag-only stat-hidden"><span class="k">r</span><span id="xs-render">·</span><span class="k">ms</span></span>
+        <span class="diag-only stat-hidden"><span class="k">i</span><span id="xs-input-lag">·</span><span class="k">ms</span></span>
+        <span class="diag-only stat-hidden"><span class="k">c</span><span id="xs-cells">·</span></span>
+        <span class="diag-only stat-hidden" id="xs-dims"><span id="xs-cols">·</span>×<span id="xs-rows">·</span></span>
+      </span>
+      <!-- Player options: font size = accessibility; hold-to-repeat is a touch
+           affordance (.touch-only) — hidden on desktop, where the OS handles it. -->
+      <button class="font-cycle debug-only touch-only" id="xs-repeat-toggle" title="Toggle hold-to-repeat">
+        <span class="glyph">↻</span><span id="xs-repeat-state">on</span>
+      </button>
+      <button class="font-cycle debug-only" id="xs-font-cycle" title="Cycle char size">
+        <span class="glyph">Aa</span><span id="xs-font-px">22</span>
+      </button>
+      <!-- Dev tooling (?mode=dev only): force the phone touch UI visible on
+           desktop/tablet-landscape for testing — not a player pref. -->
+      <button class="font-cycle dev-only" id="xs-touch-toggle" title="Force touch controls visible (overrides the landscape auto-hide)">
+        <span class="glyph">▦</span><span id="xs-touch-state">off</span>
+      </button>
+    </div>
+  </div>
   <div class="row touch">
+    <!-- Both grids are populated by the script below from PANES. The right
+         column (.actions) is identical on every pane — persistent muscle memory
+         for GET/INV/DESC/FIRE/BACK + the pane nav. The left grid (.pad) swaps
+         content per pane: movement on Pane 1, item/meta actions on Pane 2. -->
     <div class="pad" id="xs-pad"></div>
     <div class="actions" id="xs-actions"></div>
   </div>
@@ -166,7 +314,7 @@ body.force-touch #xsofy-shell .touch { display: grid; }
   // ?font=system bypasses the bundled rune face and renders in the platform
   // mono — a debug/preference escape hatch. Runes (U+16A0–16FF) then fall back
   // to the viewer's system fonts, which may tofu where none cover them.
-  const MONO = '"DejaVu Sans Mono", "Menlo", monospace';
+  const MONO = '"JetBrains Mono", ui-monospace, "SF Mono", Menlo, monospace';
   const sysFont = new URLSearchParams(location.search).get('font') === 'system';
   const term = new Terminal({
     fontFamily: sysFont ? MONO : '"Fairfax HD", ' + MONO,
@@ -255,30 +403,334 @@ body.force-touch #xsofy-shell .touch { display: grid; }
     window.visualViewport.addEventListener('scroll', refit);
   }
 
-  // --- Force-touch detection (plumbing; the toggle UI is a later slice). A
-  // coarse primary pointer (phone/tablet) needs the on-screen controls in every
-  // orientation, so drive body.force-touch from capability OR a persisted dev
-  // override. The class lives on <body> because it also retargets #app (the
-  // terminal), which is #xsofy-shell's sibling, not a descendant. ---
-  const coarsePointer = !!window.matchMedia?.('(pointer: coarse)')?.matches;
-  const forceTouchEnabled = localStorage.getItem('xsofy/force-touch') === '1';
-  document.body.classList.toggle('force-touch', coarsePointer || forceTouchEnabled);
+  // ============================================================
+  // controls + style — info-bar wiring, the D-pad/action tiles, and the player
+  // options. All of it hangs off the scaffold's containers and mode classes.
+  // ============================================================
 
-  // --- Dev-tier gating (plumbing; the runtime OPTIONS toggle is a later slice).
-  // Seed the tier from ?mode= (debug|dev → diagnostics/dev tooling) or the last
-  // persisted state, and stamp the mode classes onto #xsofy-shell so the tier-
-  // gated CSS above has its contract. mode-play is the permanent base; dev is a
-  // strict superset of debug. Nothing is tier-classed yet, so this is inert
-  // until the controls slice adds gated elements. ---
+  // Shell-owned font sizing (replaces the fork's host-side _lgSetFontSize). Safe
+  // before term.open: it sets the option (the boot-time fit picks it up) and the
+  // pre-open fit inside refit is caught.
+  function setTermFontSize(n) {
+    if (typeof n !== 'number' || n < 6 || n > 64) return;
+    term.options.fontSize = n;
+    refit();
+  }
+
+  const $ = (id) => document.getElementById(id);
+  const titleEl = $('xs-title');
+  const questEl = $('xs-quest');
+  const turnEl = $('xs-turn');
+
+  // Capitalize a quest-item name for the bar. Keep it terse.
+  function nameOf(q) {
+    if (!q) return '';
+    if (typeof q === 'string') return q;
+    const n = q.name || q[':name'] || q[':item']?.name;
+    return n ? `seeking ${n}` : '';
+  }
+
+  // Build provenance chip: fetch the JSON dropped in by deploy.sh, render it dim
+  // in the debug info bar. Silently no-ops in local dev (no file).
+  const buildEl = $('xs-build');
+  if (buildEl) {
+    fetch('build-info.json', { cache: 'no-store' })
+      .then((r) => (r.ok ? r.json() : null))
+      .then((d) => {
+        if (!d) return;
+        const xs = (d.xsofy || '').slice(0, 7);
+        const lg = (d['let-go'] || '');
+        const dt = d.date || '';
+        buildEl.innerHTML = `xsofy ${xs}${dt ? ' ·' + dt : ''}<br>lg ${lg}`;
+      })
+      .catch(() => {});
+  }
+
+  window.addEventListener('xsofy/startup', (e) => {
+    const d = e.detail || {};
+    titleEl.textContent = d.title || '—';
+    questEl.textContent = nameOf(d.quest);
+    // Reset + re-hide the turn counter on a new run; it self-reveals after the
+    // first real tick, so the bar never shows a dead "t·"/"t0".
+    turnEl.textContent = '0';
+    turnEl.parentElement.classList.add('stat-hidden');
+  });
+
+  // @t reports the turn the perf measurements were taken for; by design it lags
+  // t (current turn) by exactly 1. Showing both when they're +1 apart is noise —
+  // hide @t in that case, reveal it only on real drift (perf pipeline stuck).
+  let lastTurn = null, lastPerfTurn = null;
+  const perfTurnWrap = $('xs-perf-turn-wrap');
+  function paintPerfTurnDrift() {
+    if (!perfTurnWrap) return;
+    const inSync = lastTurn != null && lastPerfTurn != null
+      && Number(lastTurn) - Number(lastPerfTurn) === 1;
+    perfTurnWrap.classList.toggle('stat-hidden', lastPerfTurn == null || inSync);
+  }
+
+  window.addEventListener('xsofy/stats', (e) => {
+    const d = e.detail || {};
+    // hp/max-hp/depth are still emitted but shown by the in-grid HUD now; only
+    // the debug turn counter reads here.
+    if (d.turn != null) {
+      turnEl.textContent = d.turn;
+      turnEl.parentElement.classList.remove('stat-hidden');  // self-reveal
+      lastTurn = d.turn;
+      paintPerfTurnDrift();
+    }
+  });
+
+  // Terminal size — the debug bar shows current cols×rows so dimension-specific
+  // layout bugs are reproducible without guesswork.
+  const colsEl = $('xs-cols'), rowsEl = $('xs-rows'), dimsEl = $('xs-dims');
+  window.addEventListener('xsofy/term-size', (e) => {
+    const d = e.detail || {};
+    if (d.cols != null && colsEl) colsEl.textContent = d.cols;
+    if (d.rows != null && rowsEl) rowsEl.textContent = d.rows;
+    if (d.cols != null && d.rows != null) dimsEl?.classList.remove('stat-hidden');
+  });
+
+  // Per-turn engine vs render split. Display lags one turn to match the map's
+  // top-right gauge (which can't show the current turn's number without
+  // rendering twice): on turn N's event we paint turn N-1's held values, then
+  // stash N for N+1.
+  const updateEl = $('xs-update'), renderEl = $('xs-render'), inputLagEl = $('xs-input-lag');
+  const perfTurnEl = $('xs-perf-turn'), cellsEl = $('xs-cells');
+  let pendingPerf = null;
+  window.addEventListener('xsofy/perf', (e) => {
+    if (pendingPerf) {
+      if (pendingPerf.update != null) { updateEl.textContent = pendingPerf.update; updateEl.parentElement.classList.remove('stat-hidden'); }
+      if (pendingPerf.render != null) { renderEl.textContent = pendingPerf.render; renderEl.parentElement.classList.remove('stat-hidden'); }
+      if (pendingPerf['input-lag'] != null) { inputLagEl.textContent = pendingPerf['input-lag']; inputLagEl.parentElement.classList.remove('stat-hidden'); }
+      if (pendingPerf.cells != null) { cellsEl.textContent = pendingPerf.cells; cellsEl.parentElement.classList.remove('stat-hidden'); }
+      if (pendingPerf.turn != null) { perfTurnEl.textContent = pendingPerf.turn; lastPerfTurn = pendingPerf.turn; paintPerfTurnDrift(); }
+    }
+    pendingPerf = e.detail || null;
+  });
+
+  // Pointer-driven key injection. pointerdown so taps register the instant the
+  // finger lands. sendInput accepts raw bytes — they go through the same path as
+  // xterm keystrokes, so no game-side code knows the difference.
+  function press(btn) {
+    const k = btn.dataset.key;
+    if (!k || !window.LetGoHost) return;
+    // Data attributes can't carry literal control bytes — decode JS-escapes.
+    const decoded = k.replace(/\\u([0-9a-fA-F]{4})/g, (_, h) => String.fromCharCode(parseInt(h, 16)));
+    window.LetGoHost.sendInput(decoded);
+    btn.classList.add('pressed');
+    setTimeout(() => btn.classList.remove('pressed'), 90);
+  }
+
+  function bindButton(btn) {
+    btn.addEventListener('pointerdown', (e) => { e.preventDefault(); press(btn); startHoldRepeat(btn); });
+    btn.addEventListener('pointerup', stopHoldRepeat);
+    btn.addEventListener('pointerleave', stopHoldRepeat);
+    btn.addEventListener('pointercancel', stopHoldRepeat);
+    btn.addEventListener('mousedown', (e) => e.preventDefault());  // don't steal terminal focus
+  }
+
+  // --- Touch panes. Two+ panes share the same physical layout (3x3 left + 2x3
+  // right). The right column is identical on every pane so muscle memory works;
+  // only the left 3x3 swaps content. Turn-based, so giving up the D-pad on a
+  // non-movement pane is fine — one nav tap restores it. ---
+  const ESC = '\u001b';
+  const RIGHT_COLUMN = [
+    { key: 'g', glyph: 'g', label: 'GET' },
+    { key: ESC, glyph: 'esc', label: 'BACK' },
+    { key: '>', glyph: '>', label: 'DESC' },
+    { key: 'f', glyph: 'f', label: 'FIRE' },
+    { key: 'i', glyph: 'i', label: 'INV' },
+  ];
+  const PANES = [
+    { // Pane 1 — movement D-pad with auto-explore at center. Directions
+      // hold-repeat; AUTO does not (one tap starts the run).
+      label: 'MOVE',
+      pad: [
+        { key: 'y', glyph: '↖', repeat: true }, { key: 'k', glyph: '↑', repeat: true }, { key: 'u', glyph: '↗', repeat: true },
+        { key: 'h', glyph: '←', repeat: true }, { key: 'x', glyph: 'x', label: 'AUTO' }, { key: 'l', glyph: '→', repeat: true },
+        { key: 'b', glyph: '↙', repeat: true }, { key: 'j', glyph: '↓', repeat: true }, { key: 'n', glyph: '↘', repeat: true },
+      ],
+    },
+    { // Pane 2 — item & meta actions; bottom row is yes/no for game prompts.
+      // WAIT hold-repeats for resting between turns.
+      label: 'ITEMS',
+      pad: [
+        { key: 'a', glyph: 'a', label: 'USE' }, { key: 'e', glyph: 'e', label: 'EQUIP' }, { key: 'd', glyph: 'd', label: 'DROP' },
+        { key: 'm', glyph: 'm', label: 'MSG' }, { key: 'r', glyph: 'r', label: 'RUNES' }, { key: '.', glyph: '·', label: 'WAIT', repeat: true },
+        { key: '<', glyph: '<', label: 'ASCN' }, { key: 'y', glyph: 'y', label: 'YES' }, { key: 'n', glyph: 'n', label: 'NO' },
+      ],
+    },
+    { // Pane 3 — straight letter keys for menu selection (inventory, rune
+      // inscription, item slots). No hold-repeat: held letters would spam picks.
+      label: 'KEYS', padCols: 4, padRows: 3,
+      pad: [
+        { key: 'a', glyph: 'a' }, { key: 'b', glyph: 'b' }, { key: 'c', glyph: 'c' }, { key: 'd', glyph: 'd' },
+        { key: 'e', glyph: 'e' }, { key: 'f', glyph: 'f' }, { key: 'g', glyph: 'g' }, { key: 'h', glyph: 'h' },
+        { key: 'i', glyph: 'i' }, { key: 'j', glyph: 'j' }, { key: 'k', glyph: 'k' }, { key: 'l', glyph: 'l' },
+      ],
+    },
+  ];
+  let currentPane = 0;
+
+  function tileFor(spec) {
+    if (spec === null) { const f = document.createElement('div'); f.className = 'filler'; return f; }
+    const btn = document.createElement('button');
+    btn.dataset.key = spec.key;
+    // Per-instance (not per-key): the same key repeats on one pane and not
+    // another (e.g. "y" is NW movement on Pane 1, YES on Pane 2).
+    if (spec.repeat) btn.dataset.repeat = '1';
+    const labelHtml = spec.label ? `<span class="label">${spec.label}</span>` : '';
+    btn.innerHTML = `<span class="glyph">${spec.glyph}</span>${labelHtml}`;
+    bindButton(btn);
+    return btn;
+  }
+
+  function renderTouch() {
+    const padEl = $('xs-pad'), actEl = $('xs-actions');
+    const pane = PANES[currentPane];
+    padEl.innerHTML = ''; actEl.innerHTML = '';
+    // Per-pane grid override (KEYS is denser); clearing lets the CSS default win.
+    padEl.style.gridTemplateColumns = pane.padCols ? `repeat(${pane.padCols}, 1fr)` : '';
+    padEl.style.gridTemplateRows = pane.padRows ? `repeat(${pane.padRows}, 1fr)` : '';
+    for (const spec of pane.pad) padEl.appendChild(tileFor(spec));
+    for (const spec of RIGHT_COLUMN) actEl.appendChild(tileFor(spec));
+    // Nav tile at slot 6 — swaps panes, doesn't send a key, so it's not routed
+    // through bindButton (no hold-repeat). Label names the destination.
+    const nav = document.createElement('button');
+    nav.className = 'nav';
+    nav.innerHTML = `<span class="label">${PANES[(currentPane + 1) % PANES.length].label + ' →'}</span>`;
+    nav.addEventListener('pointerdown', (e) => {
+      e.preventDefault();
+      stopHoldRepeat();  // kill any in-flight repeat from a tile we're replacing
+      currentPane = (currentPane + 1) % PANES.length;
+      renderTouch();
+    });
+    nav.addEventListener('mousedown', (e) => e.preventDefault());
+    actEl.appendChild(nav);
+  }
+
+  // Hold-to-repeat for opted-in tiles: after REPEAT_INITIAL ms, re-fire every
+  // REPEAT_INTERVAL ms until pointerup/cancel/leave.
+  const REPEAT_INITIAL = 150, REPEAT_INTERVAL = 83, REPEAT_LS_KEY = 'xsofy/auto-repeat';
+  const repeatToggleEl = $('xs-repeat-toggle'), repeatStateEl = $('xs-repeat-state');
+  let repeatEnabled = (localStorage.getItem(REPEAT_LS_KEY) ?? '1') === '1';
+  function paintRepeatState() {
+    if (repeatStateEl) repeatStateEl.textContent = repeatEnabled ? 'on' : 'off';
+    if (repeatToggleEl) repeatToggleEl.style.opacity = repeatEnabled ? '' : '0.5';
+  }
+  paintRepeatState();
+  let cancelHoldRepeat = null;
+  function startHoldRepeat(btn) {
+    if (cancelHoldRepeat) { cancelHoldRepeat(); cancelHoldRepeat = null; }
+    if (!repeatEnabled || btn.dataset.repeat !== '1') return;
+    let intervalId = null;
+    const initialId = setTimeout(() => { intervalId = setInterval(() => press(btn), REPEAT_INTERVAL); }, REPEAT_INITIAL);
+    cancelHoldRepeat = () => { clearTimeout(initialId); if (intervalId) clearInterval(intervalId); };
+  }
+  function stopHoldRepeat() { if (cancelHoldRepeat) { cancelHoldRepeat(); cancelHoldRepeat = null; } }
+
+  renderTouch();  // initial render; tiles bind via tileFor on every pane swap
+  // Static info-row buttons (repeat/font/touch/OPTIONS) — bound once, not rebuilt.
+  document.querySelectorAll('#xsofy-shell .info button').forEach(bindButton);
+  // Safety net: pointer released anywhere (dragged off a button) kills repeat.
+  window.addEventListener('pointerup', stopHoldRepeat);
+  window.addEventListener('pointercancel', stopHoldRepeat);
+
+  repeatToggleEl?.addEventListener('pointerdown', (e) => {
+    e.preventDefault();
+    e.stopPropagation();  // don't also start a repeat on the chip itself
+    repeatEnabled = !repeatEnabled;
+    localStorage.setItem(REPEAT_LS_KEY, repeatEnabled ? '1' : '0');
+    paintRepeatState();
+    stopHoldRepeat();
+  });
+  repeatToggleEl?.addEventListener('mousedown', (e) => e.preventDefault());
+
+  // Font-size cycle. xterm's default 14 is unreadable on a 375px viewport; the
+  // chip cycles a short predictable set. First-ever load picks by orientation.
+  const FONT_SIZES = [12, 14, 18, 22, 28], LS_KEY = 'xsofy/font-size';
+  const cycleEl = $('xs-font-cycle'), fontPxEl = $('xs-font-px');
+  function applyFontSize(n) { setTermFontSize(n); if (fontPxEl) fontPxEl.textContent = n; }
+  function initFontSize() {
+    let n = parseInt(localStorage.getItem(LS_KEY) || '', 10);
+    if (!FONT_SIZES.includes(n)) n = matchMedia('(orientation: portrait)').matches ? 22 : 14;
+    applyFontSize(n);
+  }
+  cycleEl?.addEventListener('pointerdown', (e) => {
+    e.preventDefault();
+    const cur = parseInt(fontPxEl?.textContent || '14', 10);
+    const next = FONT_SIZES[(FONT_SIZES.indexOf(cur) + 1) % FONT_SIZES.length];
+    localStorage.setItem(LS_KEY, String(next));
+    applyFontSize(next);
+  });
+  cycleEl?.addEventListener('mousedown', (e) => e.preventDefault());
+  initFontSize();
+
+  // --- Force-touch: capability OR the persisted dev override sets
+  // body.force-touch (reveals the touch UI in every orientation). The class
+  // lives on <body> because it also retargets #app (the terminal), which is
+  // #xsofy-shell's sibling, not a descendant. The ▦ toggle (dev tier) is an
+  // override for keyboardless fine-pointer sessions (desktop/tablet testing). ---
+  const FORCE_TOUCH_LS_KEY = 'xsofy/force-touch';
+  const touchToggleEl = $('xs-touch-toggle'), touchStateEl = $('xs-touch-state');
+  const coarsePointer = !!window.matchMedia?.('(pointer: coarse)')?.matches;
+  let forceTouchEnabled = localStorage.getItem(FORCE_TOUCH_LS_KEY) === '1';
+  function paintForceTouchState() {
+    // Capability forces it on (a touch device can't turn off its only input
+    // method); the toggle only matters on fine-pointer devices.
+    document.body.classList.toggle('force-touch', coarsePointer || forceTouchEnabled);
+    if (touchStateEl) touchStateEl.textContent = forceTouchEnabled ? 'on' : 'off';
+    if (touchToggleEl) touchToggleEl.style.opacity = forceTouchEnabled ? '' : '0.5';
+  }
+  paintForceTouchState();
+  touchToggleEl?.addEventListener('pointerdown', (e) => {
+    e.preventDefault();
+    e.stopPropagation();
+    forceTouchEnabled = !forceTouchEnabled;
+    localStorage.setItem(FORCE_TOUCH_LS_KEY, forceTouchEnabled ? '1' : '0');
+    paintForceTouchState();
+    // The class toggle changes #app's height via CSS, but FitAddon only
+    // recomputes on a resize/explicit fit. rAF defers the dispatch so the new
+    // layout is in place when fit runs.
+    requestAnimationFrame(() => window.dispatchEvent(new Event('resize')));
+  });
+  touchToggleEl?.addEventListener('mousedown', (e) => e.preventDefault());
+
+  // --- OPTIONS tile — runtime toggle of the debug tier, plus the URL-seeded dev
+  // tier. Tiers are additive: mode-play is the permanent base; the tile toggles
+  // mode-debug (player-visible diagnostics); ?mode=dev adds mode-dev (dev
+  // tooling) on top. The tile cycles play↔debug only — dev is URL-gated, so dev
+  // tooling never appears just from tapping. Diagnostics (turn/perf) are
+  // mode-urldiag, URL-only, so a runtime tap never surfaces dev noise. ---
+  const SHELL_LS_KEY = 'xsofy/shell-state', SHELL_STATES = ['play', 'debug'];
+  const STATE_LABEL = { play: '←', debug: '⚙' };  // shown for the destination tier
   const shellRoot = document.getElementById('xsofy-shell');
+  const shellCycleEl = $('xs-shell-cycle'), shellCycleLabelEl = $('xs-shell-cycle-label');
   const urlMode = new URLSearchParams(location.search).get('mode');
   const devMode = urlMode === 'dev';
-  let shellState = localStorage.getItem('xsofy/shell-state');
-  if (urlMode === 'dev' || urlMode === 'debug') shellState = 'debug';
-  else if (urlMode === 'play') shellState = 'play';
-  else if (shellState !== 'debug') shellState = 'play';
-  shellRoot.classList.toggle('mode-debug', shellState === 'debug' || devMode);
-  shellRoot.classList.toggle('mode-dev', devMode);
-  shellRoot.classList.toggle('mode-urldiag', urlMode === 'debug' || urlMode === 'dev');
+  let currentShellState = localStorage.getItem(SHELL_LS_KEY);
+  if (urlMode === 'dev' || urlMode === 'debug') currentShellState = 'debug';
+  else if (urlMode === 'play') currentShellState = 'play';
+  else if (!SHELL_STATES.includes(currentShellState)) currentShellState = 'play';
+  function applyShellState() {
+    // dev is a strict superset of debug — ?mode=dev pins mode-debug on
+    // regardless of the play↔debug cycle.
+    shellRoot.classList.toggle('mode-debug', currentShellState === 'debug' || devMode);
+    shellRoot.classList.toggle('mode-dev', devMode);
+    shellRoot.classList.toggle('mode-urldiag', urlMode === 'debug' || urlMode === 'dev');
+    if (shellCycleLabelEl) {
+      const next = SHELL_STATES[(SHELL_STATES.indexOf(currentShellState) + 1) % SHELL_STATES.length];
+      shellCycleLabelEl.textContent = STATE_LABEL[next];
+    }
+  }
+  applyShellState();
+  shellCycleEl?.addEventListener('pointerdown', (e) => {
+    e.preventDefault();
+    e.stopPropagation();  // don't also fire the bindButton press path
+    currentShellState = SHELL_STATES[(SHELL_STATES.indexOf(currentShellState) + 1) % SHELL_STATES.length];
+    localStorage.setItem(SHELL_LS_KEY, currentShellState);
+    applyShellState();
+  });
+  shellCycleEl?.addEventListener('mousedown', (e) => e.preventDefault());
 })();
 </script>


### PR DESCRIPTION
**Draft / test-only.** Stacked on #137 so the deploy preview shows the full touch UI (portrait + landscape) with the relayout. Not for independent merge — **folds into #155** if approved.

Two changes to `tools/xsofy-shell.html`:

- Mirror the `.touch` grid — action column to the **left** (2fr), D-pad to the **right** (3fr), via explicit `grid-column` placement (no DOM reorder).
- Reorder `RIGHT_COLUMN` so **Esc/BACK leads** → top-left of the (now left) action block, matching Esc's spot on a QWERTY keyboard.

Preview will publish once the `deploy-preview` build finishes.

---
Screenshots

Laptop (Chrome; responsive size/aspect)

<img width="303" height="357" alt="chrome-laptop-responsive" src="https://github.com/user-attachments/assets/7d5c2c1a-e7bd-4902-ba8e-c7a0fe1f77b6" />

Laptop (Chrome; full size/aspect)
<img width="640" height="357" alt="image" src="https://github.com/user-attachments/assets/ba37567a-938b-4842-9ed0-a1fb9d8040b3" />

