### PR TITLE
feat(input): bind Plan 9 arrow-key runes (fixes down-arrow in alacritty9)

### DIFF
--- a/xsofy/input.lg
+++ b/xsofy/input.lg
@@ -11,11 +11,19 @@
   (or (= (js/url-param "mode") "dev")
       (let [e (os/getenv "XSOFY_DEV")] (and e (> (count e) 0)))))
 
+;; Movement :keys carry both the ANSI arrow escapes and Plan 9's kernel arrow
+;; runes (Kup U+F00E, Kdown U+F800, Kleft U+F011, Kright U+F012 —
+;; /sys/include/keyboard.h). Which form a terminal delivers varies, so we bind
+;; both: alacritty9 sends ANSI ESC[ for up/left/right but the raw Kdown rune for
+;; DOWN (measured on 9front — down-movement in-game needs U+F800 or it's dead);
+;; the bare text console sends all four as runes; rio's own windows swallow the
+;; arrows for scrollback. Binding both forms makes movement work wherever a key
+;; actually reaches us.
 (def base-key-bindings
-  [{:action :up          :category :movement   :label "Move up"          :keys ["\u001b[A" "k" "8"] :help-keys ["k" "8" "Up"]}
-   {:action :down        :category :movement   :label "Move down"        :keys ["\u001b[B" "j" "2"] :help-keys ["j" "2" "Down"]}
-   {:action :left        :category :movement   :label "Move left"        :keys ["\u001b[D" "h" "4"] :help-keys ["h" "4" "Left"]}
-   {:action :right       :category :movement   :label "Move right"       :keys ["\u001b[C" "l" "6"] :help-keys ["l" "6" "Right"]}
+  [{:action :up          :category :movement   :label "Move up"          :keys ["\u001b[A" "\uf00e" "k" "8"] :help-keys ["k" "8" "Up"]}
+   {:action :down        :category :movement   :label "Move down"        :keys ["\u001b[B" "\uf800" "j" "2"] :help-keys ["j" "2" "Down"]}
+   {:action :left        :category :movement   :label "Move left"        :keys ["\u001b[D" "\uf011" "h" "4"] :help-keys ["h" "4" "Left"]}
+   {:action :right       :category :movement   :label "Move right"       :keys ["\u001b[C" "\uf012" "l" "6"] :help-keys ["l" "6" "Right"]}
    {:action :up-left     :category :movement   :label "Move up-left"     :keys ["y" "7"] :help-keys ["y" "7"]}
    {:action :up-right    :category :movement   :label "Move up-right"    :keys ["u" "9"] :help-keys ["u" "9"]}
    {:action :down-left   :category :movement   :label "Move down-left"   :keys ["b" "1"] :help-keys ["b" "1"]}

--- a/xsofy/test/input_test.lg
+++ b/xsofy/test/input_test.lg
@@ -13,3 +13,15 @@
 (deftest unbound-keys-resolve-to-unknown
   (testing "a nearby unbound key is :unknown, not a stray action"
     (is (= :unknown (input/parse-key "Q")))))
+
+(deftest plan9-arrow-runes-resolve-to-movement
+  (testing "Plan 9's bare-console arrow runes (rio sends these, not ANSI ESC[) map to movement"
+    (is (= :up    (input/parse-key (str (char 0xf00e)))))   ; Kup
+    (is (= :down  (input/parse-key (str (char 0xf800)))))   ; Kdown (= Kview)
+    (is (= :left  (input/parse-key (str (char 0xf011)))))   ; Kleft
+    (is (= :right (input/parse-key (str (char 0xf012))))))  ; Kright
+  (testing "the ANSI arrow escapes still resolve — this is additive"
+    (is (= :up    (input/parse-key (str (char 27) "[A"))))
+    (is (= :down  (input/parse-key (str (char 27) "[B"))))
+    (is (= :left  (input/parse-key (str (char 27) "[D"))))
+    (is (= :right (input/parse-key (str (char 27) "[C"))))))


### PR DESCRIPTION
## What

Movement keys bound only the ANSI arrow escapes (`ESC[A/B/C/D`). This adds Plan 9's kernel arrow runes (Kup `U+F00E`, Kdown `U+F800`, Kleft `U+F011`, Kright `U+F012`) alongside them, so the arrow keys drive movement on the Plan 9 terminals that deliver runes instead of escapes.

## Why it's not cosmetic

Which form a terminal sends isn't uniform, and the gap lands on the main play environment:

- **alacritty9** — where the game is actually played on 9front — sends ANSI for up/left/right, but the raw **Kdown rune `U+F800`** for down. Measured on 9front amd64: without the `U+F800` binding, up/left/right move and **down does nothing**.
- The **bare text console** sends all four keys as runes.
- rio's own windows swallow the arrows for scrollback, so they never reach the program — not something a key binding can address.

The down case is the one that bites: a silent dead key in the primary environment, easy to miss because hjkl and the numpad still move you.

## Evidence

Probed on real hardware (9front amd64 + alacritty9) with a `read-key` codepoint dump, entering the alternate screen the way the game does:

```
↑  codes=(27 91 65)  ESC[A
↓  codes=(63488)     U+F800   ← Kdown rune, every press
←  codes=(27 91 68)  ESC[D
→  codes=(27 91 67)  ESC[C
```

The let-go side (`read-key` tokenizing these on Plan 9) is nooga/let-go#461; this is the xsofy-side binding that consumes them.

## Test

`input_test.lg` covers the rune bindings resolving to the right movement actions.

Closes #157.
