### PR TITLE
perf: drop dead ir.passes.pipeline require

### DIFF
--- a/main.lg
+++ b/main.lg
@@ -1,6 +1,3 @@
-(require 'ir.passes.pipeline)
-;;;(alter-var-root #'*ir-compile* (constantly true))
-
 (ns xsofy.main
   (:require [term]
             [os]


### PR DESCRIPTION
## What

Remove the top-of-`main.lg` `(require 'ir.passes.pipeline)` and the commented-out `*ir-compile*` activation next to it.

## Why

The require loads the entire `ir.*` compiler tree (`build`, `lower`, `lower-go`, `passes/*`) at startup, but nothing uses it. The line that would turn the runtime IR optimizer on — `(alter-var-root #'*ir-compile* (constantly true))` — has always been commented out, so `*ir-compile*` stays false, `defn` never routes through `ir.passes.pipeline/compile-form`, and the pipeline is never resolved. It's dead bundle weight, and because it never executes, nothing at runtime flags it. It came in with an unrelated spell refactor (`8801328`) as a disabled experiment.

## Impact

Recompiling `main.lg` to a bundle both ways:

| | bundle |
|---|---|
| with the require | 1.00 MB |
| without it | 0.57 MB |
| delta | **-442 KB (-42%)** |

That's the `.lgb` embedded in the wasm build, so it's a direct download-size win. Boot decode drops proportionally too, since the bundle is decoded eagerly at startup.

No behavior change: with the require removed, the game boots to the interactive title screen ("Press any key") with no error. Confirmed by running it, and consistent with an execution trace showing the `ir.*` chunks are never entered during boot.

## Re-enabling later

If the runtime IR optimizer is wanted, the pair comes back together — the `require` and the `alter-var-root` — so this doesn't foreclose the experiment, it just stops shipping it turned off.
