### PR TITLE
ci: cache the lg binary and Playwright browsers; align Go with the deploy

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -39,8 +39,19 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: '1.26'
+          # No go.sum in this repo — the lg-binary cache below replaces the
+          # inert module cache.
+          cache: false
+
+      - name: Cache lg binary
+        id: lgcache
+        uses: actions/cache@v4
+        with:
+          path: ~/go/bin/let-go
+          key: lg-bin-${{ runner.os }}-go1.26-${{ steps.letgo.outputs.version }}
 
       - name: Install let-go
+        if: steps.lgcache.outputs.cache-hit != 'true'
         run: go install github.com/nooga/let-go@${{ steps.letgo.outputs.version }}
 
       # The shared build: shell-less + xsofy's own client shell (rune font +
@@ -56,6 +67,15 @@ jobs:
         with:
           node-version: '20'
 
+      # Both test dirs download chromium (~150MB) without this; the cache
+      # keyed on the two lockfiles makes both `playwright install` calls
+      # no-op the download when the pinned versions haven't moved.
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: pw-${{ runner.os }}-${{ hashFiles('tests/browser/package-lock.json', 'tests/e2e/package-lock.json') }}
+
       - name: Install smoke dependencies
         working-directory: tests/browser
         run: |
@@ -69,7 +89,7 @@ jobs:
       - name: E2E seeded regression (@playwright/test)
         working-directory: tests/e2e
         run: |
-          npm install --no-audit --no-fund
+          npm ci --no-audit --no-fund
           npx playwright install chromium
           DIST="$GITHUB_WORKSPACE/dist" npx playwright test
 

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -43,11 +43,20 @@ jobs:
           # inert module cache.
           cache: false
 
+      # Ask the tools where they install rather than restating their defaults.
+      # Both values are what the runner already uses; declaring them means the
+      # cache path and the install target cannot drift apart, and neither has
+      # to be re-verified against a run to know it is right.
+      - name: Resolve cache paths
+        run: |
+          echo "GOPATH=$(go env GOPATH)" >> "$GITHUB_ENV"
+          echo "PLAYWRIGHT_BROWSERS_PATH=$HOME/.cache/ms-playwright" >> "$GITHUB_ENV"
+
       - name: Cache lg binary
         id: lgcache
         uses: actions/cache@v4
         with:
-          path: ~/go/bin/let-go
+          path: ${{ env.GOPATH }}/bin/let-go
           key: lg-bin-${{ runner.os }}-go1.26-${{ steps.letgo.outputs.version }}
 
       - name: Install let-go
@@ -73,7 +82,7 @@ jobs:
       - name: Cache Playwright browsers
         uses: actions/cache@v4
         with:
-          path: ~/.cache/ms-playwright
+          path: ${{ env.PLAYWRIGHT_BROWSERS_PATH }}
           key: pw-${{ runner.os }}-${{ hashFiles('tests/browser/package-lock.json', 'tests/e2e/package-lock.json') }}
 
       - name: Install smoke dependencies

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -56,9 +56,11 @@ jobs:
           # inert module cache.
           cache: false
 
-      - name: Cache lg binary
+      # pull_request_target runs may restore default-branch caches but cannot
+      # save a miss. Trusted deploy/manual runs seed this cache.
+      - name: Restore lg binary cache
         id: lgcache
-        uses: actions/cache@v4
+        uses: actions/cache/restore@v4
         with:
           path: ~/go/bin/let-go
           key: lg-bin-${{ runner.os }}-go1.26-${{ steps.letgo.outputs.version }}
@@ -78,8 +80,9 @@ jobs:
         with:
           node-version: '20'
 
-      - name: Cache Playwright browsers
-        uses: actions/cache@v4
+      # Restore-only for the same pull_request_target restriction above.
+      - name: Restore Playwright browser cache
+        uses: actions/cache/restore@v4
         with:
           path: ~/.cache/ms-playwright
           key: pw-${{ runner.os }}-${{ hashFiles('tests/browser/package-lock.json', 'tests/e2e/package-lock.json') }}

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -52,8 +52,19 @@ jobs:
         uses: actions/setup-go@v5
         with:
           go-version: '1.26'
+          # No go.sum in this repo — the lg-binary cache below replaces the
+          # inert module cache.
+          cache: false
+
+      - name: Cache lg binary
+        id: lgcache
+        uses: actions/cache@v4
+        with:
+          path: ~/go/bin/let-go
+          key: lg-bin-${{ runner.os }}-go1.26-${{ steps.letgo.outputs.version }}
 
       - name: Install let-go
+        if: steps.lgcache.outputs.cache-hit != 'true'
         run: go install github.com/nooga/let-go@${{ steps.letgo.outputs.version }}
 
       - name: Build WASM bundle
@@ -66,6 +77,12 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '20'
+
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: pw-${{ runner.os }}-${{ hashFiles('tests/browser/package-lock.json', 'tests/e2e/package-lock.json') }}
 
       - name: Install smoke dependencies
         working-directory: tests/browser

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -56,13 +56,22 @@ jobs:
           # inert module cache.
           cache: false
 
+      # Ask the tools where they install rather than restating their defaults.
+      # Both values are what the runner already uses; declaring them means the
+      # cache path and the install target cannot drift apart, and neither has
+      # to be re-verified against a run to know it is right.
+      - name: Resolve cache paths
+        run: |
+          echo "GOPATH=$(go env GOPATH)" >> "$GITHUB_ENV"
+          echo "PLAYWRIGHT_BROWSERS_PATH=$HOME/.cache/ms-playwright" >> "$GITHUB_ENV"
+
       # pull_request_target runs may restore default-branch caches but cannot
       # save a miss. Trusted deploy/manual runs seed this cache.
       - name: Restore lg binary cache
         id: lgcache
         uses: actions/cache/restore@v4
         with:
-          path: ~/go/bin/let-go
+          path: ${{ env.GOPATH }}/bin/let-go
           key: lg-bin-${{ runner.os }}-go1.26-${{ steps.letgo.outputs.version }}
 
       - name: Install let-go
@@ -84,7 +93,7 @@ jobs:
       - name: Restore Playwright browser cache
         uses: actions/cache/restore@v4
         with:
-          path: ~/.cache/ms-playwright
+          path: ${{ env.PLAYWRIGHT_BROWSERS_PATH }}
           key: pw-${{ runner.os }}-${{ hashFiles('tests/browser/package-lock.json', 'tests/e2e/package-lock.json') }}
 
       - name: Install smoke dependencies

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,24 +29,41 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      # The pinned lane reads .let-go-version; the latest lane uses its matrix
-      # value. One source of truth for the floor, shared with the Pages deploy.
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          # Match the Pages deploy toolchain (deploy-pages.yml) so the floor
+          # lane tests with the Go the shipped bundle is actually built with.
+          go-version: '1.26'
+          # This repo has no go.sum, so setup-go's module cache is inert;
+          # the lg-binary cache below is what saves the compile.
+          cache: false
+
+      # The pinned lane reads .let-go-version; the latest lane resolves the
+      # moving `latest` to its concrete version so the binary cache below can
+      # key on it. One source of truth for the floor, shared with the deploy.
       - name: Resolve let-go version
         id: letgo
         run: |
           if [ "${{ matrix.pin }}" = "true" ]; then
             v="$(grep -v '^#' .let-go-version | grep . | head -1 | tr -d '[:space:]')"
           else
-            v="${{ matrix.letgo }}"
+            v="$(go list -m -f '{{.Version}}' github.com/nooga/let-go@${{ matrix.letgo }})"
           fi
           echo "version=$v" >> "$GITHUB_OUTPUT"
 
-      - name: Set up Go
-        uses: actions/setup-go@v5
+      # No go.sum in this repo means no dependency-keyed Go cache, so every
+      # run was compiling let-go from source (~1-3 min). Cache the built
+      # binary keyed on the resolved version instead.
+      - name: Cache lg binary
+        id: lgcache
+        uses: actions/cache@v4
         with:
-          go-version: '1.24'
+          path: ~/go/bin/let-go
+          key: lg-bin-${{ runner.os }}-go1.26-${{ steps.letgo.outputs.version }}
 
       - name: Install let-go ${{ steps.letgo.outputs.version }}
+        if: steps.lgcache.outputs.cache-hit != 'true'
         run: go install github.com/nooga/let-go@${{ steps.letgo.outputs.version }}
 
       - name: Print let-go info

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,6 +39,14 @@ jobs:
           # the lg-binary cache below is what saves the compile.
           cache: false
 
+      # Ask Go where it installs rather than restating the default. `~/go` is
+      # correct on today's ubuntu-latest runners, but nothing here declares
+      # that; a runner or a job-level GOPATH that disagreed would leave the
+      # cache pointing somewhere `go install` never writes, and the only
+      # symptom would be a permanent silent miss.
+      - name: Resolve GOPATH
+        run: echo "GOPATH=$(go env GOPATH)" >> "$GITHUB_ENV"
+
       # The pinned lane reads .let-go-version; the latest lane resolves the
       # moving `latest` to its concrete version so the binary cache below can
       # key on it. One source of truth for the floor, shared with the deploy.
@@ -59,7 +67,7 @@ jobs:
         id: lgcache
         uses: actions/cache@v4
         with:
-          path: ~/go/bin/let-go
+          path: ${{ env.GOPATH }}/bin/let-go
           key: lg-bin-${{ runner.os }}-go1.26-${{ steps.letgo.outputs.version }}
 
       - name: Install let-go ${{ steps.letgo.outputs.version }}


### PR DESCRIPTION
Follow-through from the CI audit on the let-go side (nooga/let-go#581, #583, #584): the xsofy workflows are cheap per run, but their fixed costs repeat on every run and none of them were cached.

**Cache the built `lg` binary.** xsofy has no `go.sum`, so setup-go's dependency cache never engaged — every run of tests, deploy, and preview compiled let-go from source (~1–3 min each). The binary is now cached keyed on the resolved let-go version; the tests' `latest` lane resolves the moving tag to its concrete version first (`go list -m`) so it caches on the same footing. A version bump or new release misses the cache once and rebuilds, which is the correct behavior.

**Cache Playwright's chromium.** Each fresh deploy downloaded Chromium and its supporting browser assets into Playwright's shared Linux cache; the later e2e install already reused that directory within the same job. A cache keyed on the two lockfiles avoids repeating the cross-run download while the pinned versions hold. The e2e step also switches to `npm ci` against its committed lockfile.

**Go 1.26 in tests.** The floor lane was testing on Go 1.24 while `deploy-pages.yml` builds the shipped bundle with 1.26 — the version the tests validate now matches the version that ships.

One mechanical note: `pr-preview.yml` runs on `pull_request_target`, which takes its workflow from `main`, so the restore steps activate after this merges rather than on this PR's own preview. GitHub gives `pull_request_target` runs restore-only access to default-branch caches, so previews benefit after a trusted deploy or manual run seeds the matching cache; a preview cache miss installs normally but is not saved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
