### PR TITLE
fix(render): 32-bit-safe cell-hash via unchecked arithmetic

### DIFF
--- a/xsofy/util.lg
+++ b/xsofy/util.lg
@@ -191,9 +191,12 @@
      (clamp8 (+ ab bb))]))
 
 (defn cell-hash
-  "Deterministic spatial hash for per-cell color variation."
+  "Deterministic spatial hash for per-cell color variation.
+   Uses unchecked (wrapping) arithmetic so the 32-bit-multiply products don't
+   trip let-go's checked-* overflow guard on a 32-bit-int runtime (TinyGo wasm).
+   Value is masked to &255, so wrap semantics don't matter for the cosmetic output."
   [x y]
-  (let [h (+ (* x 374761393) (* y 668265263))]
+  (let [h (unchecked-add (unchecked-multiply x 374761393) (unchecked-multiply y 668265263))]
     (bit-and (bit-xor h (bit-shift-right h 13)) 255)))
 
 (defn jitter


### PR DESCRIPTION

`cell-hash` multiplies cell coordinates by large primes with checked arithmetic, so on a 32-bit-int runtime (a TinyGo wasm build of let-go, per nooga/let-go#522) the products overflow and the game dies on the first dungeon render: `ExecutionError: integer overflow` at `cell-hash` via `jitter` → `render-map-tile`.

The hash feeds per-cell color jitter and masks its result to a byte with `bit-and`, so wrap semantics don't affect the output — this switches the mixing steps to `unchecked-multiply`/`unchecked-add`. On 64-bit builds the intermediate products never exceed int64 for any map coordinate, so values (and therefore rendered output) are unchanged there; on 32-bit builds the hash now wraps instead of trapping.

Validated: full test suite passes (292 tests, 0 fail), and a TinyGo wasm build that previously trapped at descend now renders and plays.
