### PR TITLE
fix(replay): terminate rle under Clojure-lazy drop

### DIFF
--- a/xsofy/replay.lg
+++ b/xsofy/replay.lg
@@ -175,7 +175,7 @@
       out
       (let [x (first xs)
             run (count (take-while (fn [y] (= y x)) xs))]
-        (recur (drop run xs) (conj out [x run]))))))
+        (recur (seq (drop run xs)) (conj out [x run]))))))
 
 ;; --- encode / decode ---
 


### PR DESCRIPTION

let-go's #429 compat work (nooga/let-go@3772dea) made `drop` properly lazy per the Clojure contract: it now returns a lazy seq that is never nil. `rle` in `xsofy/replay.lg` terminated its loop on `(nil? xs)`, which only worked against the old eager `drop` — once the input is exhausted, the run length is 0 and `(drop 0 xs)` recurs on the same empty seq forever, growing the output vector unboundedly. On any lg past `v1.12.0-rc` the replay codec spins until killed (the test suite hangs at the replay round-trip test, with memory climbing into the gigabytes).

The fix re-seqs the recur argument — `(seq (drop run xs))` — which is nil on empty, the standard idiom for loops that test with `nil?`. I swept the rest of the codebase for the same pattern; every other `drop`/`partition`/`concat` result feeds an eager consumer (`vec`, `set`, `count`), so this was the only site.

Validated against lg at both ends: the pinned `v1.12.0-rc` (unchanged behavior, suite green) and current let-go main `2be9033`, where the round-trip goes from spinning past a 2-minute timeout to 71 ms and the full suite passes (292 tests, 0 fail).
