### PR TITLE
feat(shell): mobile keypad rearrangement + font touch-ups

### DIFF
--- a/tools/xsofy-shell.html
+++ b/tools/xsofy-shell.html
@@ -714,7 +714,7 @@ body.dpad-cool #xsofy-shell button.dpad .label { color: rgba(168, 198, 224, 0.55
     { key: 'd', glyph: 'd', label: 'DROP' },    mv('y','↖','y'), mv('k','↑','k'), mv('u','↗','u'),
     { key: '<', glyph: '<', label: 'ASC' },     mv('h','←','h'), { key: 'x', glyph: 'x', label: 'AUTO' }, mv('l','→','l'),
     { key: '>', glyph: '>', label: 'DESC' },    mv('b','↙','b'), mv('j','↓','j'), mv('n','↘','n'),
-    { key: 'r', glyph: 'r', label: 'RUNES' },   { key: 'y', glyph: 'y', label: 'YES' },   { key: 'n', glyph: 'n', label: 'NO' },    { key: '.', glyph: '·', label: 'WAIT', repeat: true },
+    { key: 'r', glyph: 'r', label: 'RUNES' },   { key: 'n', glyph: 'n', label: 'NO' },    { key: 'y', glyph: 'y', label: 'YES' },   { key: '.', glyph: '·', label: 'WAIT', repeat: true },
   ]};
   // Each pane is a FLAT, row-major tile list: a spec, `null` (empty), or (a-z
   // only) a spacer. MOVE is a 6-col grid holding movement + common actions + y/n;
@@ -725,15 +725,17 @@ body.dpad-cool #xsofy-shell button.dpad .label { color: rgba(168, 198, 224, 0.55
   const PANES = [
     { label: 'PLAY', cols: 6, land: LAND_PLAY, tiles: [
       // 5 rows (same height as the a-z keyboard pane). D-pad centered on the
-      // right (rows 2-4, cols 4-6) with y/n/wait below it (row 5). esc anchors
+      // right (rows 2-4, cols 4-6) with n/y/enter below it (row 5); wait rides
+      // top row where enter was (swap: wait is the high-frequency key). esc anchors
       // top-left; col 2 runs the menu letters a-e in order (a/d/e double as
       // their game actions, b/c are pure menu picks); col 3 stacks fire/get,
       // then the stair pair, then runes. Remaining cells are muted placeholders.
-      { key: ESC, glyph: 'esc', label: 'BACK' }, { key: 'a', glyph: 'a', label: 'USE' },   { key: 'f', glyph: 'f', label: 'FIRE' },  { key: '\r', glyph: '⏎', label: 'ENTER' }, { key: 'm', glyph: 'm', label: 'MSG' }, { key: 'i', glyph: 'i', label: 'INV' },
+      // ` (DEV) opens the dev console — dev-gated game-side, a no-op otherwise.
+      { key: ESC, glyph: 'esc', label: 'BACK' }, { key: 'a', glyph: 'a', label: 'USE' },   { key: 'f', glyph: 'f', label: 'FIRE' },  { key: '.', glyph: '·', label: 'WAIT', repeat: true }, { key: 'm', glyph: 'm', label: 'MSG' }, { key: 'i', glyph: 'i', label: 'INV' },
       { key: '?', glyph: '?', label: 'HELP' },   { key: 'b', glyph: 'b' },                 { key: 'g', glyph: 'g', label: 'GET' },   mv('y','↖','y'), mv('k','↑','k'), mv('u','↗','u'),
-      null,                                      { key: 'c', glyph: 'c' },                 { key: '<', glyph: '<', label: 'ASC' },   mv('h','←','h'), { key: 'x', glyph: 'x', label: 'AUTO' }, mv('l','→','l'),
+      { key: '`', glyph: '`', label: 'DEV' },    { key: 'c', glyph: 'c' },                 { key: '<', glyph: '<', label: 'ASC' },   mv('h','←','h'), { key: 'x', glyph: 'x', label: 'AUTO' }, mv('l','→','l'),
       null,                                      { key: 'd', glyph: 'd', label: 'DROP' },  { key: '>', glyph: '>', label: 'DESC' },  mv('b','↙','b'), mv('j','↓','j'), mv('n','↘','n'),
-      null,                                      { key: 'e', glyph: 'e', label: 'EQUIP' }, { key: 'r', glyph: 'r', label: 'RUNES' }, { key: 'y', glyph: 'y', label: 'YES' }, { key: 'n', glyph: 'n', label: 'NO' }, { key: '.', glyph: '·', label: 'WAIT', repeat: true },
+      null,                                      { key: 'e', glyph: 'e', label: 'EQUIP' }, { key: 'r', glyph: 'r', label: 'RUNES' }, { key: 'n', glyph: 'n', label: 'NO' }, { key: 'y', glyph: 'y', label: 'YES' }, { key: '\r', glyph: '⏎', label: 'ENTER' },
     ]},
     { label: 'a–z', cols: 20,
       // Landscape sheet variant: 4 rows to give the game back a strip — the
@@ -744,7 +746,7 @@ body.dpad-cool #xsofy-shell button.dpad .label { color: rgba(168, 198, 224, 0.55
         ...'1234567890'.split('').map(kbd),
         ...'qwertyuiop'.split('').map(kbd),
         { key: '?', glyph: '?', span: 1, cls: 'kbd' }, ...'asdfghjkl'.split('').map(kbd), { key: '\r', glyph: '⏎', span: 1, cls: 'kbd' },
-        { key: ESC, glyph: 'esc', label: 'BACK', span: 3 }, ...'zxcvbnm'.split('').map(kbd), { key: '\u007f', glyph: '⌫', span: 3, cls: 'kbd' },
+        { key: ESC, glyph: 'esc', label: 'BACK', span: 2 }, { key: '(', glyph: '(', span: 1, cls: 'kbd' }, { key: ')', glyph: ')', span: 1, cls: 'kbd' }, ...'zxcvbnm'.split('').map(kbd), { key: '\u007f', glyph: '⌫', span: 2, cls: 'kbd' },
       ]},
       tiles: [
       // iPhone-ish QWERTY on a fine 20-col grid (each key spans 2 units = 10 per
@@ -757,7 +759,7 @@ body.dpad-cool #xsofy-shell button.dpad .label { color: rgba(168, 198, 224, 0.55
       ...'1234567890'.split('').map(kbd),
       ...'qwertyuiop'.split('').map(kbd),
       spacer(1), ...'asdfghjkl'.split('').map(kbd), spacer(1),
-      spacer(3), ...'zxcvbnm'.split('').map(kbd), { key: '\u007f', glyph: '⌫', span: 3, cls: 'kbd' },
+      { key: '(', glyph: '(', span: 2, cls: 'kbd' }, { key: ')', glyph: ')', span: 2, cls: 'kbd' }, ...'zxcvbnm'.split('').map(kbd), { key: '\u007f', glyph: '⌫', span: 2, cls: 'kbd' },
       { key: ESC, glyph: 'esc', label: 'BACK', span: 3 }, { key: ' ', glyph: '␣', label: 'SPACE', span: 11 }, { key: '?', glyph: '?', label: 'HELP', span: 3 }, { key: '\r', glyph: '⏎', label: 'ENTER', span: 3 },
     ]},
   ];
@@ -905,13 +907,15 @@ body.dpad-cool #xsofy-shell button.dpad .label { color: rgba(168, 198, 224, 0.55
   repeatToggleEl?.addEventListener('mousedown', (e) => e.preventDefault());
 
   // Font-size cycle. xterm's default 14 is unreadable on a 375px viewport; the
-  // chip cycles a short predictable set. First-ever load picks by orientation.
+  // chip cycles a short predictable set. First-ever load picks by orientation
+  // (landscape/desktop bumped 14 -> 18: 14 reads small on laptop screens too;
+  // a stored user choice always wins over these defaults).
   const FONT_SIZES = [12, 14, 18, 22, 28], LS_KEY = 'xsofy/font-size';
   const cycleEl = $('xs-font-cycle'), fontPxEl = $('xs-font-px');
   function applyFontSize(n) { setTermFontSize(n); if (fontPxEl) fontPxEl.textContent = n; }
   function initFontSize() {
     let n = parseInt(localStorage.getItem(LS_KEY) || '', 10);
-    if (!FONT_SIZES.includes(n)) n = matchMedia('(orientation: portrait)').matches ? 22 : 14;
+    if (!FONT_SIZES.includes(n)) n = matchMedia('(orientation: portrait)').matches ? 22 : 18;
     applyFontSize(n);
   }
   cycleEl?.addEventListener('pointerdown', (e) => {


### PR DESCRIPTION
Polish for the existing Touch-UI web shell's on-screen keypad, sliced out of the shader demo spike (#168), since it's independent. The changes are sensible, unambiguous / pre-existing usability gaps, noticed during general play testing against the mobile shell. No renderer or shader code here, just `tools/xsofy-shell.html`. 

## Changes

- **PLAY pane — WAIT/ENTER swap.** Wait is the high-frequency key, so it moves up to the top row where enter was; enter takes wait's old corner. `y`/`n` also swap to `n`/`y` to match the landscape variant.
- **PLAY pane — `` ` `` (DEV) tile.** Fills the empty col-1/row-3 cell so the dev console is reachable on touch devices with no physical keyboard. The console is dev-gated game-side (`?mode=dev`), so the key is a no-op for regular players.
- **a–z pane — `(` and `)` keys.** Added left of `z`. Portrait: they replace the stagger spacer and backspace slims 3→2. Landscape: thin span-1 keys, esc/backspace slim to fit. Makes the dev console's command syntax typeable on touch.
- **Font default 14 → 18 (landscape/desktop).** 14 reads small on laptop screens too; portrait keeps its phone-tuned 22. A stored user choice (the font chip's localStorage value) still wins over both defaults, so nobody's existing setting changes.

<img width="203" height="171" alt="image" src="https://github.com/user-attachments/assets/b1243bb0-c860-407f-a51e-6ee3b0a2df62" />

<img width="440" height="757" alt="image" src="https://github.com/user-attachments/assets/531c9b18-ef6e-4493-b874-5f90a03211f6" />


<img width="1041" height="755" alt="image" src="https://github.com/user-attachments/assets/8e7a8bae-86e2-4ddc-a0f8-a02aba423f96" />


## Notes

Every keypad row still tiles cleanly: PLAY stays 6×6→5 rows (30 cells), and the a–z rows sum to 20 units in both orientations. These exact hunks were exercised under Playwright as part of #168; the PR-preview smoke gate covers boot here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Made with [Cursor](https://cursor.com)