### PR TITLE
refactor(world): `empty-world` — one canonical world-state skeleton

### DIFF
--- a/tools/scenariotest/build.lg
+++ b/tools/scenariotest/build.lg
@@ -79,26 +79,11 @@
                         [(str "scenariotest: " (or (:name sc) "scenario"))]
                         (or (:log sc) [])
                         (when (:desc sc) [(:desc sc)])))
-        base {:terrain terrain
-              :width w
-              :height h
-              :entities {:player player}
-              :fov #{}
-              :memory {}
-              :lights nil
-              :stains {}
-              :gases {}
-              :fire-ttl {}
-              :log boot-log
-              :turn 0
-              :depth depth
-              :floors {}
-              :gold 0
-              :rune-table {}
-              :running true
-              :seed seed
-              :seed-input seed
-              :action-log []}
+        base (assoc (world/empty-world w h seed)
+                    :terrain terrain
+                    :entities {:player player}
+                    :log boot-log
+                    :depth depth)
         w0 (reduce spawn-creature base creatures)
         w1 (if gear? (world/give-starting-items w0) w0)]
     (world/update-fov w1)))

--- a/xsofy/check_gen.lg
+++ b/xsofy/check_gen.lg
@@ -29,6 +29,7 @@
   (:require [xsofy.check :as c]
             [xsofy.terrain :as terrain]
             [xsofy.entities :as ent]
+            [xsofy.world :as world]
             ;; Load template registries (defcreature / defitem populate
             ;; the shared @ent/templates atom).
             [xsofy.bestiary]
@@ -41,19 +42,19 @@
 ;; --- Minimal world for spell/world properties ---
 
 (defn minimal-stone-room
-  "Build a 10x10 stone-floor room with stone walls. No entities."
+  "Build a 10x10 stone-floor room with stone walls. No entities.
+
+   Shape comes from world/empty-world so these generated worlds stay
+   structurally identical to the ones the game builds — a property test
+   run against a world missing a key the code under test reads covers
+   less than it appears to. Seed 0 matches what det/advance already
+   defaults to when :seed is absent, so rolls are unchanged."
   []
   (let [w 10
         h 10
         t (terrain/make-terrain w h)]
     (terrain/carve-room! t w 1 1 (- w 2) (- h 2))
-    {:terrain t
-     :width w
-     :height h
-     :entities {}
-     :turn 0
-     :gold 0
-     :rune-table {}}))
+    (assoc (world/empty-world w h 0) :terrain t)))
 
 ;; --- Player ---
 
@@ -149,8 +150,7 @@
     (loop [i 0
            fires []]
       (if (= i (* inner-w inner-h))
-        {:world {:terrain t :width w :height h
-                 :entities {} :turn 0 :gold 0 :rune-table {}}
+        {:world (assoc (world/empty-world w h 0) :terrain t)
          :fire-cells fires}
         (let [x (+ 1 (mod i inner-w))
               y (+ 1 (quot i inner-w))
@@ -251,8 +251,9 @@
         (assoc-in [:entities :player] player)
         (spawn-creatures creature-spawns)
         (spawn-items item-spawns)
-        ;; depth + floors map needed by save/restore code paths
-        (assoc :depth 1 :floors {} :fire-ttl fire-ttls))))
+        ;; :depth/:floors come from the skeleton; :fire-ttl is real
+        ;; generated data, one entry per fire tile in the room.
+        (assoc :fire-ttl fire-ttls))))
 
 ;; --- Picking two distinct entities from a world (for combat properties) ---
 ;; A combat property needs an attacker-id and a target-id. We pick the

--- a/xsofy/test/combat_prop.lg
+++ b/xsofy/test/combat_prop.lg
@@ -118,8 +118,8 @@
   [world g/gen-rich-world]
   (let [[player items] (w/extract-player-items world)
         ;; inject into a fresh empty world at original pos
-        fresh {:entities {} :turn 0 :width (:width world) :height (:height world)
-               :terrain (:terrain world) :gold 0 :rune-table {}}
+        fresh (assoc (w/empty-world (:width world) (:height world) 0)
+                     :terrain (:terrain world))
         restored (w/inject-player fresh player items (:pos player))
         rp (get-in restored [:entities :player])]
     (and (some? rp)

--- a/xsofy/world.lg
+++ b/xsofy/world.lg
@@ -187,6 +187,47 @@
 
 ;; --- World Creation ---
 
+(defn empty-world
+  "Bare world skeleton: the fields a world carries from construction
+   onward, at their zero values. No terrain, no entities — not playable
+   until a caller fills :terrain and :entities.
+
+   This is the one place that shape is written down. generate-floor
+   builds on it, and so should any harness that needs a world without
+   dungeon gen (property-test generators, scenario builders). Adding a
+   world field is then one edit here, not an audit of every literal that
+   ever spelled the shape out by hand.
+
+   Fields a later system owns and adds on its own (:rooms-cache from
+   worldgen, :next-id from entity spawning, :scheme from the palette)
+   are deliberately absent — the skeleton is the construction-time
+   shape, not the union of everything a world can hold.
+
+   :terrain is nil rather than a zero-size grid: a caller that forgets to
+   fill it should fail at the first tget, not read plausible garbage out
+   of a grid that disagrees with :width/:height."
+  [w h seed]
+  {:terrain nil
+   :width w
+   :height h
+   :entities {}
+   :fov #{}
+   :memory {}
+   :lights nil
+   :stains {}
+   :gases {}
+   :fire-ttl {}
+   :log []
+   :turn 0
+   :depth 1
+   :floors {}
+   :gold 0
+   :rune-table {}
+   :running true
+   :seed seed
+   :seed-input seed
+   :action-log []})
+
 (defn generate-floor [w h depth player seed-input]
   (dbg/log "generate-floor" w h "depth:" depth "seed-input:" seed-input)
   (let [;; Floor layout is path-independent: derive a construction seed from
@@ -200,23 +241,18 @@
         [px py] (first rooms)]
     (dbg/log "  rooms:" (count rooms) "player-pos:" [px py])
     (let [lights (light/collect-terrain-lights grid w h)
-          ;; merge gameplay fields onto the terrain-advanced world.
-          ;; :seed from world-after-terrain is preserved (assoc doesn't drop existing keys
-          ;; we don't override).
-          world (assoc world-after-terrain
-                       :terrain grid
-                       :width w
-                       :height h
-                       :entities {:player (assoc player :pos [px py])}
-                       :fov #{}
-                       :memory {}
-                       :lights lights
-                       :stains {}
-                       :gases {}
-                       :log []
-                       :turn 0
-                       :depth depth
-                       :running true)
+          ;; Start from the canonical skeleton, then let world-after-terrain
+          ;; win: its :seed is the terrain-advanced floor lineage, and it
+          ;; carries whatever bookkeeping terrain gen left behind. The
+          ;; skeleton's :seed-input stays the origin seed, which is what it
+          ;; means. Both callers reset :seed afterward to continue the
+          ;; gameplay chain.
+          world (-> (empty-world w h seed-input)
+                    (merge world-after-terrain)
+                    (assoc :terrain grid
+                           :entities {:player (assoc player :pos [px py])}
+                           :lights lights
+                           :depth depth))
           world (det/with-context world [:worldgen :floor depth])]
       (dbg/log "  populating rooms")
       (let [;; spawn creatures per room (each call returns world')
@@ -272,10 +308,12 @@
         world (second rune-pair)]
     (-> world
         give-starting-items
-        (assoc :floors {} :gold 0 :rune-table rune-table)
+        ;; :floors/:gold/:seed-input/:action-log already carry their zero
+        ;; values from empty-world via generate-floor.
+        (assoc :rune-table rune-table)
         spawn-runestones
         ;; final step: start the continuous gameplay chain at the origin seed
-        (assoc :seed seed :seed-input seed :action-log []))))
+        (assoc :seed seed))))
 
 ;; --- Floor Transition ---
 ;; Saves current floor, extracts player + inventory items,


### PR DESCRIPTION
# refactor(world): `empty-world` — one canonical world-state skeleton

Closes #172. Follows up @nnunley's review comments on #170.

## Why

`xsofy.world/make-world` is the only world constructor and it's fused to `generate-floor`, so it always runs full dungeon gen. Anything that wants a world without dungeon gen has no lighter constructor to call and hand-rolls the map literal instead. Four copies existed, in two shapes that disagree:

| Site | Keys set |
|---|---|
| `check-gen/minimal-stone-room` | 7 |
| `check-gen/build-feature-room` | 7 |
| `combat_prop`'s `fresh` fixture | 7 |
| `tools/scenariotest/build.lg`'s `base` (added in #170) | 20 |

The three 7-key literals have identical key sets; `base` sets 20. So the split is the one #172 named — a test-side shape and a scenario-side shape, 13 keys apart.

Nothing tied any of them to what `update-world` and friends read. Add a field to the world map and the generated worlds silently fall behind: a property test keeps running green against a world missing the very key the code under test reads, covering less than it looks like it covers. `gen-rich-world` was already patching `:depth`, `:floors`, and `:fire-ttl` back on after the fact to close part of that gap.

## What

`world/empty-world` is now the one place the construction-time world shape is written down. `generate-floor` builds on it, and each hand-rolled literal starts from it and assocs only what's specific to that caller:

```clojure
(assoc (world/empty-world w h seed)
       :terrain terrain
       :entities {:player player}
       :log boot-log
       :depth depth)
```

Adding a *construction-time* field is one edit here instead of an audit across four files. A field that also has to survive a floor transition still needs `restore-floor` and `change-floor` updated by hand — see the follow-up note below.

## Decisions

**Plain map, not a `defrecord`.** #172 raised the option. A record would catch the missing-key class harder than a docstring does, but the codebase treats world as an ordinary map throughout: `assoc`, `get-in`, `:keys` destructuring, `serialize/canonical-bytes` walking it generically. The churn isn't worth it for a shape one function now owns. Happy to run with this or switch to a record if you'd rather have construction-time validation.

**`:terrain` is nil, not a degenerate grid.** The other open question in #172. A zero-size grid would let `empty-world` alone avoid crashing, at the price of a world whose `:width`/`:height` disagree with its terrain. Nil means a caller that forgets to fill it fails at the first `tget` instead of reading plausible garbage.

**The skeleton covers construction-time shape only.** `:rooms-cache`, `:next-id`, and `:scheme` belong to the systems that add them later, so they stay out.

**`invariant-test`'s sparse room is unchanged.** The tests for `world-invariants?` shouldn't be built from the production constructor, or a broken `empty-world` goes invisible to exactly the predicate meant to catch it.

**`generate-floor` merge order.** The skeleton goes down first, then `world-after-terrain` merges over it so terrain gen's advanced `:seed` lineage still wins. The skeleton contributes `:seed-input` as the origin seed, which is what that key means on both call paths. Both callers reset `:seed` afterward, same as before.

## Verification

World content is unchanged except for one added empty key. `make-world` at seeds 1, 42, and 1000, plus a d1→d2→d3→d2 floor-transition chain, produce the same `canonical-bytes` hash on this branch as on `main` once the newly-present `:fire-ttl {}` is removed. That key is new on every freshly generated world, so a whole-world `checkpoint-hash` does change; nothing persists or asserts against one (replay codes are `(seed, action-log)`, `dag/commit-id` is `:seed` alone).

- `make test` — 307 tests, 2803 assertions, 0 fail
- `make smoke-lg` — OK
- `lg tools/scenariotest.lg --check` on both scenarios — OK
