### PR TITLE
fix(world): carry run-scoped fields across floor transitions

### DIFF
--- a/xsofy/test/run.lg
+++ b/xsofy/test/run.lg
@@ -10,6 +10,7 @@
             [xsofy.test.hash-test]
             [xsofy.test.det-test]
             [xsofy.test.world-seed-test]
+            [xsofy.test.world-shape-test]
             [xsofy.test.dispatch-test]
             [xsofy.test.serialize-test]
             [xsofy.test.dag-test]

--- a/xsofy/test/world_shape_test.lg
+++ b/xsofy/test/world_shape_test.lg
@@ -1,0 +1,72 @@
+(ns xsofy.test.world-shape-test
+  "Pins the world map's shape across construction and floor transitions.
+
+   world/empty-world declares what a world holds; world/run-scoped-keys
+   declares what survives a descent. Neither is enforced by anything the
+   compiler can see, so these tests are the enforcement: a field added to
+   the skeleton and forgotten in the transition path fails here rather
+   than three months later as a nil on depth 2 (#177)."
+  (:require [test :refer [deftest is testing]]
+            [xsofy.world :as w]))
+
+(def ^:private skeleton-keys
+  (set (keys (w/empty-world 10 10 0))))
+
+(defn- missing-keys
+  "Skeleton keys absent from world. Absent, not nil-valued: :terrain and
+   :lights are legitimately nil on a live world."
+  [world]
+  (vec (sort (filter (fn [k] (not (contains? world k))) skeleton-keys))))
+
+;; A small world keeps floor generation cheap; the shape doesn't depend on size.
+(defn- run-world []
+  (-> (w/make-world 40 20 7)
+      (assoc :title "The Chasms"
+             :scheme [1 2 3]
+             :quest-item :amulet)))
+
+(deftest make-world-carries-the-whole-skeleton
+  (testing "a constructed world holds every key empty-world declares"
+    (is (= [] (missing-keys (w/make-world 40 20 7))))))
+
+(deftest descending-carries-the-whole-skeleton
+  (testing "a newly generated floor holds every key empty-world declares"
+    (is (= [] (missing-keys (w/change-floor (run-world) 2))))))
+
+(deftest revisiting-carries-the-whole-skeleton
+  (testing "a restored floor holds every key empty-world declares"
+    (let [d2 (w/change-floor (run-world) 2)]
+      (is (= [] (missing-keys (w/change-floor d2 1)))))))
+
+;; --- Run-scoped fields survive a transition (#177) ---
+
+(deftest run-scoped-fields-survive-descending
+  (testing ":title, :scheme and :quest-item outlive the floor they were set on"
+    (let [d2 (w/change-floor (run-world) 2)]
+      (is (= "The Chasms" (:title d2)))
+      (is (= [1 2 3] (:scheme d2)))
+      (is (= :amulet (:quest-item d2))))))
+
+(deftest run-scoped-fields-survive-revisiting
+  (testing "and a restored floor keeps them too"
+    (let [d1 (-> (run-world) (w/change-floor 2) (w/change-floor 1))]
+      (is (= "The Chasms" (:title d1)))
+      (is (= [1 2 3] (:scheme d1)))
+      (is (= :amulet (:quest-item d1))))))
+
+(deftest gameplay-seed-chain-survives-a-transition
+  (testing "seed-input is the origin seed on every floor, not the floor lineage"
+    (let [w0 (run-world)
+          d2 (w/change-floor w0 2)
+          d1 (w/change-floor d2 1)]
+      (is (= 7 (:seed-input w0)))
+      (is (= 7 (:seed-input d2)))
+      (is (= 7 (:seed-input d1))))))
+
+(deftest depth-and-floors-track-the-transition
+  (testing "descending records the departed floor and advances :depth"
+    (let [w0 (run-world)
+          d2 (w/change-floor w0 2)]
+      (is (= 1 (:depth w0)))
+      (is (= 2 (:depth d2)))
+      (is (contains? (:floors d2) 1)))))

--- a/xsofy/world.lg
+++ b/xsofy/world.lg
@@ -192,16 +192,24 @@
    onward, at their zero values. No terrain, no entities — not playable
    until a caller fills :terrain and :entities.
 
-   This is the one place that shape is written down. generate-floor
-   builds on it, and so should any harness that needs a world without
-   dungeon gen (property-test generators, scenario builders). Adding a
-   world field is then one edit here, not an audit of every literal that
-   ever spelled the shape out by hand.
+   This is the one place that shape is written down. generate-floor,
+   restore-floor, and any harness needing a world without dungeon gen
+   (property-test generators, scenario builders) all build on it. Adding
+   a construction-time field is one edit here.
 
-   Fields a later system owns and adds on its own (:rooms-cache from
-   worldgen, :next-id from entity spawning, :scheme from the palette)
-   are deliberately absent — the skeleton is the construction-time
-   shape, not the union of everything a world can hold.
+   Its companion is run-scoped-keys, which answers the other question a
+   world field raises: does it survive a floor transition? The two sets
+   overlap on purpose — :turn and :gold are created here and carried
+   there, while :terrain and :entities are created here and rebuilt per
+   floor. A new field needs an answer in both places, and #177 is what
+   it costs when one of them is a hand-rolled assoc list instead.
+
+   :rooms-cache is deliberately absent: it is per-floor derived data
+   that worldgen rebuilds and every reader guards for nil.
+
+   :terrain is nil rather than a zero-size grid: a caller that forgets to
+   fill it should fail at the first tget, not read plausible garbage out
+   of a grid that disagrees with :width/:height.
 
    :terrain is nil rather than a zero-size grid: a caller that forgets to
    fill it should fail at the first tget, not read plausible garbage out
@@ -228,6 +236,32 @@
    :seed-input seed
    :action-log []})
 
+(def run-scoped-keys
+  "Fields owned by the run, not the floor: they must survive a floor
+   transition. Everything else a world holds is floor-scoped — rebuilt by
+   generate-floor or read back out of the saved floor map.
+
+   :title, :scheme, and :quest-item are set by main.lg after make-world
+   rather than by empty-world, because they belong to the framing of a
+   run (its name, palette, and quest) rather than to the world engine.
+   They still have to survive a descent, which is what put them here:
+   before #177 only :scheme was hand-carried, so dying below depth 1
+   produced a tombstone with no game title (render.lg reads :title).
+
+   :seed is deliberately NOT in this set. It is the head of the RNG
+   chain, and both callers restore it as their final step so that any
+   rolling they do in between (spawn-runestones) consumes the floor
+   lineage rather than the gameplay one. Carrying it here would move
+   that restore earlier and shift every subsequent roll."
+  [:log :turn :gold :rune-table :floors :seed-input :action-log :running
+   :title :scheme :quest-item])
+
+(defn carry-run-state
+  "Copy the run-scoped fields of `from` onto `to`. Keys absent from
+   `from` are left alone rather than nil-ed out."
+  [to from]
+  (merge to (select-keys from run-scoped-keys)))
+
 (defn generate-floor [w h depth player seed-input]
   (dbg/log "generate-floor" w h "depth:" depth "seed-input:" seed-input)
   (let [;; Floor layout is path-independent: derive a construction seed from
@@ -241,15 +275,16 @@
         [px py] (first rooms)]
     (dbg/log "  rooms:" (count rooms) "player-pos:" [px py])
     (let [lights (light/collect-terrain-lights grid w h)
-          ;; Start from the canonical skeleton, then let world-after-terrain
-          ;; win: its :seed is the terrain-advanced floor lineage, and it
-          ;; carries whatever bookkeeping terrain gen left behind. The
-          ;; skeleton's :seed-input stays the origin seed, which is what it
-          ;; means. Both callers reset :seed afterward to continue the
-          ;; gameplay chain.
+          ;; Start from the canonical skeleton. :seed is taken across
+          ;; explicitly rather than by merging world-after-terrain wholesale:
+          ;; the advanced floor lineage is the only thing terrain gen owns
+          ;; here, and a blanket merge would silently hand it every other key
+          ;; the day it starts threading more state. The skeleton's
+          ;; :seed-input stays the origin seed, which is what it means; both
+          ;; callers reset :seed afterward to continue the gameplay chain.
           world (-> (empty-world w h seed-input)
-                    (merge world-after-terrain)
-                    (assoc :terrain grid
+                    (assoc :seed (:seed world-after-terrain)
+                           :terrain grid
                            :entities {:player (assoc player :pos [px py])}
                            :lights lights
                            :depth depth))
@@ -397,27 +432,19 @@
         terrain (:terrain floor)
         w (:width floor)
         h (:height floor)]
-    (-> {:terrain terrain
-         :width w
-         :height h
-         :entities (:entities floor)
-         :fov #{}
-         :memory (:memory floor)
-         :lights (:lights floor)
-         :stains (:stains floor)
-         :gases (:gases floor)
-         :fire-ttl (or (:fire-ttl floor) {})
-         :log (:log world)
-         :turn (:turn world)
-         :gold (or (:gold world) 0)
-         :rune-table (:rune-table world)
-         :depth depth
-         :floors (:floors world)
-         :scheme (:scheme world)
-         :seed (:seed world)
-         :seed-input (:seed-input world)
-         :action-log (or (:action-log world) [])
-         :running true}
+    (-> (empty-world w h (:seed-input world))
+        ;; floor-scoped: everything the saved floor owns
+        (assoc :terrain terrain
+               :entities (:entities floor)
+               :memory (:memory floor)
+               :lights (:lights floor)
+               :stains (:stains floor)
+               :gases (:gases floor)
+               :fire-ttl (or (:fire-ttl floor) {})
+               :depth depth)
+        ;; run-scoped: everything that outlives the floor
+        (carry-run-state world)
+        (assoc :seed (:seed world))
         (inject-player player items nil)
         rebase-creature-ticks)))
 
@@ -692,14 +719,7 @@
             ;; reset player ticks to 0 so they act first on new floor
             (let [player (assoc player :ticks 0 :last-arrival-pos spawn-pos)]
               (-> new-world
-                  (assoc :log (:log saved)
-                         :turn (:turn saved)
-                         :gold (or (:gold saved) 0)
-                         :rune-table (:rune-table saved)
-                         :floors (:floors saved)
-                         :scheme (:scheme world)
-                         :seed-input (:seed-input saved)
-                         :action-log (or (:action-log saved) []))
+                  (carry-run-state saved)
                   (inject-player player items spawn-pos)
                   spawn-runestones
                   ;; final step: continue the gameplay chain from the saved world


### PR DESCRIPTION
# fix(world): carry run-scoped fields across floor transitions

Closes #177. Follow-up to #176.

## The bug

`main.lg:336-338` assocs `:title`, `:scheme`, and `:quest-item` onto the world right after `make-world`. Descending drops two of the three:

```
d1          title= "The Chasms"  scheme= [1 2 3]  quest= :amulet
d2-new      title= nil           scheme= [1 2 3]  quest= nil
d1-revisit  title= nil           scheme= [1 2 3]  quest= nil
```

`render.lg:1196` reads `(or (:title world) "")` for the death-screen tombstone, so a player who dies below depth 1 gets one with no game title. `:quest-item` has no reader yet, so its loss was silent and waiting for the first feature to want it.

The cause is that two places hand-listed what survives a transition — `change-floor`'s carry-over assoc and `restore-floor`'s 21-key world literal — and only `:scheme` made it onto both lists.

## The fix

#176 unified world *construction* onto `empty-world` and left the transition path
spelling the shape out by hand, which is exactly how a field ends up construction-correct and transition-lossy at the same time. This finishes that job:

- `run-scoped-keys` names what belongs to the run rather than the floor.
`carry-run-state` is the single thing both transition paths call.
- `restore-floor` builds on `empty-world` like every other constructor, assoc'ing
only the floor-scoped fields it reads back out of `:floors`.
- `empty-world`'s docstring stops claiming to be the only place the shape is
written down — `restore-floor` sat 180 lines below it proving otherwise. It now names `run-scoped-keys` as the companion answer to "does this field survive a descent?", since a new world field needs an answer in both places.

## Two details worth a reviewer's eye

**`:seed` is deliberately excluded from `run-scoped-keys`.** It heads the RNG chain, and both callers restore it as their *final* step so that `spawn-runestones` in between consumes the floor lineage rather than the gameplay one. Carrying it with the rest would move that restore earlier and shift every subsequent roll. The exclusion is load-bearing, not an oversight, and it's documented at the definition.

**`generate-floor` takes `:seed` across explicitly** instead of merging `world-after-terrain` wholesale. Behavior is identical today — terrain gen threads nothing but `:seed` — but the blanket merge granted it precedence over every skeleton key, so the day it starts threading more state the skeleton would lose silently.

Also corrected in passing: `empty-world`'s docstring claimed `:next-id` comes from entity spawning. `entities/next-id` is seed-derived and never writes that key; the only writer is `det/next-id`, called only from tests.

## Verification

`world_shape_test.lg` pins both halves of the shape: every skeleton key present after construction, after a descent, and after a revisit; and the run-scoped fields surviving both. Its four `:title`/`:quest-item` assertions fail on `main` and pass here. The three skeleton-key tests pass on `main` too — they are regression guards for the next field, not evidence of a second bug.

Determinism is unchanged. A d1→d2→d3→d2→d1 chain produces identical `canonical-bytes` hashes and identical `:seed` at every step before and after, once the newly-surviving `:title`/`:quest-item` are excluded from the comparison.

- `make test` — 314 tests, 2818 assertions, 0 fail
- `make smoke-lg` — OK
- `lg tools/scenariotest.lg --check` on both scenarios — OK

One thing this PR does not touch: `percept.lg:63` uses key presence as its "player FOV already computed" sentinel, which #176 made misleading for skeleton-built worlds. It's a different concern in a different file and gets its own PR.
