### PR TITLE
fix(percept): treat an empty :fov as uncomputed, not as a result

### DIFF
--- a/xsofy/percept.lg
+++ b/xsofy/percept.lg
@@ -60,7 +60,11 @@
         pos (:pos entity)]
     (cond
       (nil? pos) #{}
-      (and (= entity-id :player) (some? (:fov world))) (:fov world)
+      ;; Non-empty, not merely present: world/empty-world seeds :fov to #{},
+      ;; so a world that hasn't been through update-fov yet carries the key
+      ;; with nothing in it. fov/compute-fov always includes the origin cell,
+      ;; so an empty set can only mean "not computed" — never a real result.
+      (and (= entity-id :player) (seq (:fov world))) (:fov world)
       :else
       (let [[x y] pos
             radius (or (:fov-radius opts) default-fov-radius)

--- a/xsofy/test/percept_test.lg
+++ b/xsofy/test/percept_test.lg
@@ -1,0 +1,51 @@
+(ns xsofy.test.percept-test
+  "entity-fov's cache sentinel.
+
+   The player's FOV is precomputed on the world by update-fov; NPCs get it
+   computed on demand. entity-fov decides which case it's in by looking at
+   :fov, so what an empty :fov means is load-bearing — and since #176 gave
+   empty-world a :fov of #{}, a world that hasn't been through update-fov
+   carries the key with nothing in it."
+  (:require [test :refer [deftest is testing]]
+            [xsofy.percept :as percept]
+            [xsofy.terrain :as terrain]
+            [xsofy.world :as w]))
+
+(defn- room-world
+  "A 10x10 stone room with the player at [2 2] and no FOV computed yet —
+   the shape a property-test generator or scenario builder produces."
+  []
+  (let [t (terrain/make-terrain 10 10)]
+    (terrain/carve-room! t 10 1 1 8 8)
+    (-> (w/empty-world 10 10 0)
+        (assoc :terrain t)
+        (assoc-in [:entities :player]
+                  {:id :player :template :player :pos [2 2]
+                   :body {:hp 10 :max-hp 10}}))))
+
+(deftest player-fov-is-computed-when-the-world-has-none-yet
+  (testing "an empty :fov means not-computed, not an empty result"
+    (let [fov (percept/entity-fov (room-world) :player {})]
+      (is (seq fov))
+      (is (contains? fov [2 2])))))
+
+(deftest player-fov-uses-the-precomputed-set-when-there-is-one
+  (testing "a populated :fov is trusted, not recomputed"
+    (let [world (assoc (room-world) :fov #{[9 9]})]
+      (is (= #{[9 9]} (percept/entity-fov world :player {}))))))
+
+(deftest update-fov-populates-what-entity-fov-then-returns
+  (testing "the real path: update-fov fills :fov and entity-fov hands it back"
+    (let [world (w/update-fov (room-world))]
+      (is (seq (:fov world)))
+      (is (= (:fov world) (percept/entity-fov world :player {}))))))
+
+(deftest npc-fov-is-always-computed
+  (testing "NPCs never read the player's cached set"
+    (let [world (-> (w/update-fov (room-world))
+                    (assoc-in [:entities :rat-1]
+                              {:id :rat-1 :template :rat :pos [7 7]
+                               :body {:hp 3} :ai {:state :idle}}))
+          rat-fov (percept/entity-fov world :rat-1 {})]
+      (is (contains? rat-fov [7 7]))
+      (is (not= (:fov world) rat-fov)))))

--- a/xsofy/test/run.lg
+++ b/xsofy/test/run.lg
@@ -11,6 +11,7 @@
             [xsofy.test.det-test]
             [xsofy.test.world-seed-test]
             [xsofy.test.world-shape-test]
+            [xsofy.test.percept-test]
             [xsofy.test.dispatch-test]
             [xsofy.test.serialize-test]
             [xsofy.test.dag-test]


### PR DESCRIPTION
Follow-up to #176. Independent of #177 — different file, different concern.

## The problem

`entity-fov` decides whether the player's FOV is already cached by asking whether the key is there:

```clojure
(and (= entity-id :player) (some? (:fov world))) (:fov world)
```

That reads the world's *shape* as a signal, and it held only while worlds that hadn't been through `update-fov` had no `:fov` key at all. #176 ended that: `empty-world` seeds `:fov` to `#{}`, so a skeleton-built world carries the key with nothing in it. `entity-fov` now hands that empty set back as though it were a computed result, and every "can the player see X" question answers no.

Nothing reaches it today. `percept` is required only by `balance.lg`, which runs on `make-world` output that `generate-floor` has already FOV'd. The cost lands on whoever writes the first percept-based property test against `check-gen`'s generators and spends an afternoon on visibility assertions that quietly answer false.

## The fix

`(seq (:fov world))`. `fov/compute-fov` seeds its result with the origin cell (`fov.lg:80`), so a computed FOV always holds at least the entity's own position, and an empty one can only mean uncomputed. That makes emptiness a sound sentinel where presence no longer is.

The alternative — dropping `:fov` from `empty-world` to restore the old absent-key signal — would reintroduce exactly the shape drift #172 was about, and leave the next reader of the skeleton wondering why one key is missing.

## Verification

New `percept_test.lg` covers both sides of the branch, the real `update-fov` path, and the NPC path that must never read the player's cache. Its two player-side assertions fail against the current `percept.lg` and pass with this change.

- `make test` — 311 tests, 2810 assertions, 0 fail
