### PR TITLE
Top-down perf: cull never-seen cells (22x), plus frame timing and two input fixes

### DIFF
--- a/main_gl.lg
+++ b/main_gl.lg
@@ -123,20 +123,44 @@
 ;; Input Parsing
 ;; ==========================================================
 
+(defn arrow-seq
+  "The ANSI sequence input/parse-key binds for an arrow key name, else nil."
+  [name]
+  (case name
+    "up" "\u001b[A"
+    "down" "\u001b[B"
+    "left" "\u001b[D"
+    "right" "\u001b[C"
+    nil))
+
 (defn parse-glplat-event
-  "Parse a glplat event string (e.g., 'key:w', 'key:escape', 'char:x') to a key string
-   that input/parse-key can consume."
+  "Parse a glplat event string (e.g., 'key:w', 'key:escape', 'char:x') to a key
+   string that input/parse-key can consume. nil means ignore this event.
+
+   Two things this has to get right, and originally got neither:
+
+   Arrows need the ESC prefix. input/parse-key compares whole strings against
+   bindings like \"\\u001b[A\", so a bare \"[A\" matched nothing and the arrow
+   keys did not move the player at all.
+
+   A printable key arrives twice. GLFW fires the key callback (key:k) and the
+   char callback (char:k) for one physical press, and dispatching both moved
+   the player two tiles per keystroke. The char: event is the one to keep — it
+   is the only one carrying shift state, and xsofy binds shifted keys (K/J/H/L
+   run, > descend, ? help) that key: reports only as their lowercase name. So a
+   key:/key-repeat: event naming a single printable character is dropped here
+   and its char: twin does the work."
   [event-str]
   (cond
-    (string/starts-with? event-str "key:escape") ""
-    (string/starts-with? event-str "key:") (let [key (subs event-str 4)]
-                                             (case key
-                                               "up" "[A"
-                                               "down" "[B"
-                                               "left" "[D"
-                                               "right" "[C"
-                                               key))  ;; fallback to raw key
-    (string/starts-with? event-str "key-repeat:") (subs event-str 11)
+    (string/starts-with? event-str "key:escape") ""
+    (string/starts-with? event-str "key:")
+    (let [name (subs event-str 4)]
+      (or (arrow-seq name)
+          (when (> (count name) 1) name)))
+    (string/starts-with? event-str "key-repeat:")
+    (let [name (subs event-str 11)]
+      (or (arrow-seq name)
+          (when (> (count name) 1) name)))
     (string/starts-with? event-str "char:") (subs event-str 5)
     :else nil))
 

--- a/main_gl.lg
+++ b/main_gl.lg
@@ -160,6 +160,58 @@
         (#(reduce world/log-msg % (:messages quest))))))
 
 ;; ==========================================================
+;; Frame-time instrumentation (XSOFY_GL_PERF)
+;; ==========================================================
+
+;; Two clocks, because they answer different questions and only one of them
+;; responds to render work. `cpu` is BeginFrame → just-before-EndFrame: the
+;; segment we actually control (bridge → grid-verts → SubmitTriangles).
+;; `interval` is render-entry to render-entry, which includes EndFrame's vsync
+;; block. A change that halves vertex work moves `cpu` and leaves `interval`
+;; pinned near the refresh period — so reading only wall-clock frame time would
+;; report every optimization as a no-op.
+
+(defn new-perf-acc []
+  {:n 0 :cpu-sum 0.0 :cpu-min 1.0e9 :cpu-max 0.0
+   :int-sum 0.0 :last-t nil :bg 0 :glyphs 0 :total 0})
+
+(defn perf-note-verts!
+  "Record the batch sizes the current frame emitted, so a culling change shows
+   up as vertices, not only as milliseconds."
+  [perf* bg glyphs]
+  (when perf*
+    (swap! perf* assoc :bg bg :glyphs glyphs)))
+
+(defn perf-record!
+  "Fold one frame's timings in; emit a line every `every` frames and reset."
+  [perf* every t-entry cpu-ms]
+  (when perf*
+    (let [a (swap! perf* (fn [a]
+                           (-> a
+                               (assoc :n (inc (:n a))
+                                      :total (inc (:total a))
+                                      :last-t t-entry)
+                               (assoc :cpu-sum (+ (:cpu-sum a) cpu-ms))
+                               (assoc :cpu-min (min (:cpu-min a) cpu-ms))
+                               (assoc :cpu-max (max (:cpu-max a) cpu-ms))
+                               (assoc :int-sum (+ (:int-sum a)
+                                                  (if (:last-t a)
+                                                    (* 1000.0 (- t-entry (:last-t a)))
+                                                    0.0))))))]
+      (when (>= (:n a) every)
+        (let [n (:n a)]
+          (print (str "XSOFY_GL_PERF: frames " (- (:total a) n) "-" (dec (:total a))
+                      "  cpu mean " (format "%.2f" (/ (:cpu-sum a) n)) "ms"
+                      " min " (format "%.2f" (:cpu-min a)) "ms"
+                      " max " (format "%.2f" (:cpu-max a)) "ms"
+                      "  interval mean " (format "%.2f" (/ (:int-sum a) n)) "ms"
+                      "  verts bg " (:bg a) " glyph " (:glyphs a) "\n")))
+        (swap! perf* (fn [a]
+                       (merge (new-perf-acc)
+                              {:total (:total a) :last-t (:last-t a)
+                               :bg (:bg a) :glyphs (:glyphs a)})))))))
+
+;; ==========================================================
 ;; Matrix Helpers
 ;; ==========================================================
 
@@ -281,12 +333,13 @@
 (defn render-top-down
   "Render top-down view with ortho projection (xz-ground mapped to screen via rotate-x).
    Verify clip-space projection with two test points: cell (0,0) and cell (0,29)."
-  [world tex-id atlas dump? frame vfx]
+  [world tex-id atlas dump? frame vfx perf*]
   (let [map-rect {:x 0 :y 0 :w (:width world) :h (:height world)}
         cells (bridge/grid-cells world map-rect)
         {:keys [bg glyphs]} (grid/grid-verts cells atlas {:cell-w 0.5 :cell-h 1.0})
         bg-count (quot (count bg) 9)
         glyph-count (quot (count glyphs) 9)
+        _ (perf-note-verts! perf* bg-count glyph-count)
 
         ;; Build correct MVP
         mvp (build-top-down-mvp)
@@ -411,7 +464,7 @@
 
 (defn render-first-person
   "Render first-person view: perspective camera, billboarded entities."
-  [world pres-state tex-id atlas dump? frame vfx]
+  [world pres-state tex-id atlas dump? frame vfx perf*]
   (let [;; Player position
         [px py] (get-in world [:entities :player :pos])
         facing (:facing pres-state)
@@ -439,7 +492,11 @@
         bg-count (quot (count bg) 9)
         glyph-count (quot (count glyphs) 9)
         wall-count (quot (count wall-verts) 9)
-        entity-count (quot (count entity-verts) 9)]
+        entity-count (quot (count entity-verts) 9)
+        ;; FP reports floors+walls as "bg": both are terrain geometry, so the
+        ;; culling delta stays comparable with the top-down line.
+        _ (perf-note-verts! perf* (+ bg-count wall-count)
+                            (+ glyph-count entity-count))]
 
     (glplat/SetMatrix mvp)
 
@@ -656,17 +713,18 @@
 (defn gl-render
   "Paint one frame from loop state (render subscriber — presents itself,
    the loop core never flushes)."
-  [st {:keys [tex-id atlas dump? title-runes start-time shot-path shot-at shot-done*]}]
+  [st {:keys [tex-id atlas dump? title-runes start-time shot-path shot-at shot-done*
+              perf* perf-every]}]
   (let [{:keys [world pres vfx frame]} st
         t (glplat/Time)
         elapsed (- t start-time)]
     (glplat/BeginFrame 0.1 0.1 0.15)
     (case (:mode pres)
       :title (render-title world title-runes elapsed tex-id atlas)
-      :top-down (render-top-down world tex-id atlas dump? frame vfx)
+      :top-down (render-top-down world tex-id atlas dump? frame vfx perf*)
       :falling (render-falling world pres t tex-id atlas dump? vfx)
-      :fp (render-first-person world pres tex-id atlas dump? frame vfx)
-      (render-top-down world tex-id atlas dump? frame vfx))
+      :fp (render-first-person world pres tex-id atlas dump? frame vfx perf*)
+      (render-top-down world tex-id atlas dump? frame vfx perf*))
     (when (not= (:mode pres) :title)
       (render-hud world tex-id atlas))
     ;; Screenshot hook: capture the composed back buffer once, before
@@ -677,6 +735,9 @@
       (when dump?
         (print (str "XSOFY_GL_DUMP: screenshot " shot-path
                     " at " (format "%.2f" elapsed) "s\n"))))
+    ;; Sample before EndFrame: past this point we are measuring the driver's
+    ;; vsync wait, not our own work.
+    (perf-record! perf* perf-every t (* 1000.0 (- (glplat/Time) t)))
     (glplat/EndFrame)))
 
 (defn -main []
@@ -697,6 +758,10 @@
         shot-path (getenv-str "XSOFY_GL_SHOT")
         shot-at (parse-number (getenv-str "XSOFY_GL_SHOT_AT") 1.0)
         skip-title? (boolean (getenv-str "XSOFY_GL_SKIP_TITLE"))
+        ;; XSOFY_GL_PERF=N reports frame timings every N frames (N<=0 disables).
+        perf-every (let [n (parse-number (getenv-str "XSOFY_GL_PERF") 0)]
+                     (when (> n 0) (int n)))
+        perf* (when perf-every (atom (new-perf-acc)))
         force-fall-str (getenv-str "XSOFY_GL_FORCE_FALL")
         force-fall-secs (when force-fall-str
                           (parse-number force-fall-str -1.0))
@@ -731,7 +796,9 @@
                  :title-runes title-runes
                  :shot-path shot-path
                  :shot-at shot-at
-                 :shot-done* (atom false)}]
+                 :shot-done* (atom false)
+                 :perf* perf*
+                 :perf-every perf-every}]
         (ui/run-loop
           {:sources [(glplat-input-source) (ui/clock-source 0)]
            :state {:world world

--- a/main_gl.lg
+++ b/main_gl.lg
@@ -335,7 +335,9 @@
    Verify clip-space projection with two test points: cell (0,0) and cell (0,29)."
   [world tex-id atlas dump? frame vfx perf*]
   (let [map-rect {:x 0 :y 0 :w (:width world) :h (:height world)}
-        cells (bridge/grid-cells world map-rect)
+        ;; Cull never-seen cells: they painted black-on-black. gl-render clears
+        ;; top-down to black so the result is the same pixels, minus the work.
+        cells (bridge/grid-cells world map-rect true)
         {:keys [bg glyphs]} (grid/grid-verts cells atlas {:cell-w 0.5 :cell-h 1.0})
         bg-count (quot (count bg) 9)
         glyph-count (quot (count glyphs) 9)
@@ -718,7 +720,12 @@
   (let [{:keys [world pres vfx frame]} st
         t (glplat/Time)
         elapsed (- t start-time)]
-    (glplat/BeginFrame 0.1 0.1 0.15)
+    ;; Top-down culls its never-seen cells, which used to paint the backdrop
+    ;; black themselves. Clear to black there so culling is invisible; the
+    ;; other modes still paint or show the original slate.
+    (if (= (:mode pres) :top-down)
+      (glplat/BeginFrame 0.0 0.0 0.0)
+      (glplat/BeginFrame 0.1 0.1 0.15))
     (case (:mode pres)
       :title (render-title world title-runes elapsed tex-id atlas)
       :top-down (render-top-down world tex-id atlas dump? frame vfx perf*)

--- a/xsofy/gl/bridge.lg
+++ b/xsofy/gl/bridge.lg
@@ -102,8 +102,20 @@
 (defn grid-cells
   "Extract all visible cells from world as a vector of {:col :row :glyph :fg :bg}.
    Composition: terrain base, entity overlay, with full FOV/memory/lighting logic.
-   Returns cells in row-major order."
-  [world map-rect]
+   Returns cells in row-major order.
+
+   `cull-unseen?` drops cells that are neither in FOV nor remembered. Those
+   render as a space glyph on a black background — nothing — but still cost a
+   map, a bg quad and a glyph quad each, and on a typical floor they are the
+   overwhelming majority of the grid.
+
+   It is opt-in rather than the default because 'draws nothing' is only true
+   against a black clear colour. The top-down view qualifies. The first-person
+   view does not: there the unseen floor quads are the black ground plane you
+   see under the horizon, and dropping them would show the clear colour through
+   the floor."
+  ([world map-rect] (grid-cells world map-rect false))
+  ([world map-rect cull-unseen?]
   (let [{:keys [terrain width height fov memory]} world
         lights (or (:lights world) [])
         stains (or (:stains world) {})
@@ -125,22 +137,23 @@
     (dotimes [y (min height (:h map-rect))]
       (dotimes [x (min width (:w map-rect))]
         (let [visible (contains? fov [x y])
-              remembered (get memory [x y])
-              tile (when visible (terrain/tget terrain width x y))
-              lv (when visible (light/light-at x y lights))
-              stain (when visible (get stains [x y]))
-              gas (when visible (get gases [x y]))
-              ;; Start with terrain or memory or unseen
-              terrain-data (cond
-                             visible (terrain-cell tile visible remembered lv stain gas)
-                             remembered (memory-cell remembered)
-                             :else (unseen-cell))
-              ;; Overlay entity if present and visible
-              entity-data (when visible (entity-cell-overlay world entity-map x y))
-              final-data (if entity-data
-                           (assoc terrain-data :glyph (:glyph entity-data)
-                             :fg (:fg entity-data)
-                             :bg (:bg entity-data))
-                           terrain-data)]
-          (swap! cells conj (assoc final-data :col x :row y)))))
-    @cells))
+              remembered (get memory [x y])]
+          (when (or visible remembered (not cull-unseen?))
+            (let [tile (when visible (terrain/tget terrain width x y))
+                  lv (when visible (light/light-at x y lights))
+                  stain (when visible (get stains [x y]))
+                  gas (when visible (get gases [x y]))
+                  ;; Start with terrain or memory or unseen
+                  terrain-data (cond
+                                 visible (terrain-cell tile visible remembered lv stain gas)
+                                 remembered (memory-cell remembered)
+                                 :else (unseen-cell))
+                  ;; Overlay entity if present and visible
+                  entity-data (when visible (entity-cell-overlay world entity-map x y))
+                  final-data (if entity-data
+                               (assoc terrain-data :glyph (:glyph entity-data)
+                                 :fg (:fg entity-data)
+                                 :bg (:bg entity-data))
+                               terrain-data)]
+              (swap! cells conj (assoc final-data :col x :row y)))))))
+    @cells)))

--- a/xsofy/gl/grid.lg
+++ b/xsofy/gl/grid.lg
@@ -139,7 +139,10 @@
 
    Returns: {:bg <flat float vector> :glyphs <flat float vector>}"
   [cells atlas opts]
-  (let [bg-quads (mapv #(cell-bg-quad % (dissoc opts :fallback))
+  ;; Hoist the dissoc: it does not depend on the cell, and inside the lambda it
+  ;; rebuilt the opts map once per cell.
+  (let [bg-opts (dissoc opts :fallback)
+        bg-quads (mapv #(cell-bg-quad % bg-opts)
                        cells)
         glyph-quads (mapv #(cell-quad % atlas opts)
                           cells)]


### PR DESCRIPTION
Four commits on top of `gl-frontend` at `cc43ffb`, so this merges with a button. Nothing is rebased and nothing of yours moves.

The presentation state machine and the fall into first person are a clever way to get a 3D view out of a glyph grid without giving up the grid, and porting the frame loop onto `ui/run-loop` made the render path easy to follow from the outside. Everything below is downstream of that.

We were rebasing the branch onto current `main` for a downstream experiment and profiled it along the way. The results seemed worth handing back.

## What's here

**Frame timing (`XSOFY_GL_PERF=N`).** The branch had no frame instrumentation, so its cost was unmeasured rather than unoptimized. This reports two clocks every N frames:

- `cpu` — `BeginFrame` to just before `EndFrame`, the part we control.
- `interval` — render entry to render entry, including the vsync block
inside `EndFrame`.

The second clock is what made the diagnosis possible. A vsync-bound loop shows `interval` pinned near 16.7ms while `cpu` moves freely. Here the two tracked each other, which pointed at our own vertex building.

**Culling never-seen cells, which is the win.** A cell that is neither in FOV nor remembered draws a space glyph on a black background, so it contributes nothing visible, but it still costs a map in `grid-cells` plus a background quad and a glyph quad in `grid-verts`. At seed 42 that was 2,330 of 2,370 cells.

| | before | after |
|---|---|---|
| cells | 2,370 | 40 |
| verts per batch | 14,220 | 240 |
| cpu per frame | ~400ms | ~18ms |

The captured frame is byte-identical before and after, which is the property that makes this safe: a 22x reduction that changes no pixels.

Culling is opt-in, and off in first person by design. There the unseen floor quads are the black ground plane under the horizon and the clear colour reads as sky, so dropping them would show sky through the floor. It is sound in top-down because top-down clears to black, and the cells being dropped are what was painting that black.

One caveat on the absolute numbers: ~18ms was measured on a quiet machine, and the same build measures around 55ms under heavy load. The ratio was taken back-to-back in a single machine state, so it holds; the frames-per-second figure is load-dependent and should be read as indicative.

**A `dissoc` hoist in `grid-verts`,** which is bookkeeping rather than a win. It rebuilt the options map once per cell. After culling it buys nothing measurable at 40 cells, and it is here only because the first-person path still sends all 2,370 cells through `grid-verts`.

**Two input fixes,** both present since the branch first became playable:

- *Every keypress moved two tiles.* GLFW fires the key callback and the
char callback for one physical press, so `k` arrived as both `key:k` and `char:k`, and both parsed to `:up` and both dispatched.
- *The arrow keys did nothing at all.* `input/parse-key` compares whole
strings against escape-prefixed bindings, and the mapping emitted a bare two-character sequence, which matched nothing and parsed to `:unknown`. That is why the only usable movement keys were the ones that double-fired.

Keeping the `char:` event resolves both, because it alone carries shift state, and xsofy binds shifted keys that `key:` reports only by their lowercase name (`K`/`J`/`H`/`L` to run, `>` to descend, `?` for help). Before this, Shift+K dispatched `:up` and `:run-up` together. Verified per key class against the real parser: `k` gives one `:up`, Shift+K gives `:run-up` only, Up arrow gives `:up`, `>` gives `:descend`, and a held arrow repeats.

**Taking only part of it.** The `dissoc` hoist touches `grid.lg` alone and is independent. The other three all touch `main_gl.lg`, so they cherry-pick cleanly in order but not individually.

## Two rebase findings

Neither is in this PR, but both come up whenever the branch moves forward.

**The test suite hangs on this branch's current base.** It reaches `decode . encode = identity on (seed, actions)` in `replay-test` in about 70 seconds, then spins and allocates without bound. We measured 12.4 GB resident before killing it. Nothing in this PR causes it: clean `cc43ffb` with none of our commits reproduces it exactly, and none of these commits touch replay. On current `main` the same suite finishes in 60 seconds at 444 tests and 3,066 assertions with nothing failing, so it appears to be fixed upstream already.

**`title.lg` conflicts on rebase, and the natural resolution is wrong.** Taking the branch side drops the two `sfx/with-frame` calls that arrived with #174. The resolution that preserves both keeps main's body verbatim and grafts only the guard onto it. One detail that is easy to miss: `os/getenv` returns `""` rather than `nil` for an unset variable, so the guard has to test by count.

## Not done, on purpose

- **Caching static terrain geometry.** This was our next planned step
until culling obsoleted it. It assumed rebuilding 2,370 cells per frame; the real number is now 40.
- **Driving the loop from FOV plus memory** instead of scanning the grid.
We tried it and it came out 2.5x slower, because building the position set each frame costs more than the tight scan does. Reverted, and noted here so nobody re-derives it.
- **Escape still does not quit.** It maps to `""` and parses to
`:unknown`. We took that for intentional and left it.
- **Shift plus arrow cannot run.** glplat's key callback accepts GLFW's
modifier argument and discards it, so this needs a change on the let-go side rather than here.

## Where the remaining time goes

Of the ~18ms: `grid-cells` is roughly 2 to 4ms, `grid-verts` roughly 5 to 11ms, and the rest is HUD, VFX, and submit. At about 175 microseconds per cell, `grid-verts` is no longer doing algorithmic work that can be deleted; that is interpretation overhead on flat float-vector construction, which makes the next lever a let-go one rather than a game one.

Merge as-is if it looks right, or take the input fixes alone and leave the perf work. The one piece I would not defer is the rebase: the suite hang makes the branch hard to validate as it stands, and it is already fixed on `main`.
