### PR TITLE
test(fov): cover occlusion, doorways, and sight radius

### DIFF
--- a/xsofy/test/fov_test.lg
+++ b/xsofy/test/fov_test.lg
@@ -1,0 +1,104 @@
+(ns xsofy.test.fov-test
+  "Occlusion: the part of sight that a wall is supposed to take away.
+
+   compute-fov (recursive shadowcasting) and terrain/has-clear-line?
+   (Bresenham) are the two answers to 'can this point see that one', and
+   both were untested before #184 — every FOV test ran in an open room, so
+   an implementation that ignored walls outright would have passed.
+
+   The base fixture is one room split by a solid column, which makes the
+   assertions independent of the casting order: the two halves share no
+   open cell, so nothing on the far side is reachable by any route. Opening
+   a single gap in that column then pins the harder half of shadowcasting,
+   where sight passes through the gap but not around it."
+  (:require [test :refer [deftest is testing]]
+            [xsofy.fov :as fov]
+            [xsofy.terrain :as terrain]
+            [xsofy.world :as w]))
+
+(def ^:private size 10)
+(def ^:private radius 12) ; larger than the room: reach never limits these tests
+
+(defn- room
+  "A 10x10 stone room carved to a 8x8 floor. With `divided?`, a column of
+   wall-stone at x=5 spans the full interior height, sealing [1..4] off
+   from [6..8]."
+  [divided?]
+  (let [t (terrain/make-terrain size size)]
+    (terrain/carve-room! t size 1 1 8 8)
+    (when divided?
+      (doseq [y (range 1 9)]
+        (terrain/tset! t size 5 y 8)))
+    t))
+
+(defn- room-with-doorway
+  "The divided room, but with one open cell at [5 4] — the only way through."
+  []
+  (let [t (terrain/make-terrain size size)]
+    (terrain/carve-room! t size 1 1 8 8)
+    (doseq [y (range 1 9)]
+      (when (not= y 4)
+        (terrain/tset! t size 5 y 8)))
+    t))
+
+(defn- world-with [terrain]
+  (assoc (w/empty-world size size 0) :terrain terrain))
+
+(defn- visible-from [terrain x y]
+  (fov/compute-fov terrain size size x y radius))
+
+(deftest a-wall-is-visible-but-does-not-let-sight-past-it
+  (testing "the blocking tile is lit; the cells in its shadow are not"
+    (let [seen (visible-from (room true) 2 2)]
+      (is (contains? seen [2 2]) "the origin is always included")
+      (is (contains? seen [4 2]) "open floor short of the wall")
+      (is (contains? seen [5 2]) "the wall itself, which is what you look at")
+      (is (not (contains? seen [6 2])) "immediately behind the wall")
+      (is (not (contains? seen [7 2])) "further behind it")
+      (is (not (contains? seen [7 7])) "diagonally behind it"))))
+
+(deftest an-open-room-sees-across
+  (testing "control: the same room without the column hides nothing"
+    (let [seen (visible-from (room false) 2 2)]
+      (is (contains? seen [7 2]))
+      (is (contains? seen [7 7])))))
+
+(deftest occlusion-is-symmetric
+  (testing "the far side is equally blind looking back"
+    (let [divided (room true)]
+      (is (not (contains? (visible-from divided 2 2) [7 2])))
+      (is (not (contains? (visible-from divided 7 2) [2 2]))))))
+
+(deftest a-doorway-admits-sight-only-along-its-own-line
+  (testing "level with the gap, the far side is lit through it and nowhere else"
+    (let [seen (fov/compute-fov (room-with-doorway) size size 2 4 radius)]
+      (is (contains? seen [5 4]) "the gap itself")
+      (is (contains? seen [7 4]) "through the gap, straight ahead")
+      (is (contains? seen [8 4]) "as far as the far wall")
+      (is (not (contains? seen [6 3])) "one row up, already in shadow")
+      (is (not (contains? seen [6 5])) "one row down, likewise")
+      (is (not (contains? seen [7 7])) "the rest of the far half stays dark"))))
+
+(deftest radius-bounds-sight-by-euclidean-distance
+  (testing "reach is a circle, not a square: the diagonal runs out first"
+    (let [open (room false)
+          r2 (fov/compute-fov open size size 2 2 2)
+          r3 (fov/compute-fov open size size 2 2 3)]
+      (is (contains? r2 [4 2]) "two cells along the row is within radius 2")
+      (is (not (contains? r2 [5 2])) "three is not")
+      (is (contains? r3 [5 2]) "and is once the radius grows")
+      (is (not (contains? r2 [4 4]))
+          "the diagonal is 2.83 away, so radius 2 excludes it")
+      (is (contains? r3 [4 4]) "radius 3 reaches it"))))
+
+(deftest has-clear-line-stops-at-an-obstruction
+  (testing "Bresenham agrees with the shadowcaster about the same wall"
+    (let [divided (world-with (room true))]
+      (is (terrain/has-clear-line? divided 2 2 4 2)
+          "both endpoints on the near side")
+      (is (not (terrain/has-clear-line? divided 2 2 7 2))
+          "the column sits between them"))))
+
+(deftest has-clear-line-is-clear-in-an-open-room
+  (testing "control: without the column the same pair has a line"
+    (is (terrain/has-clear-line? (world-with (room false)) 2 2 7 2))))

--- a/xsofy/test/percept_test.lg
+++ b/xsofy/test/percept_test.lg
@@ -1,11 +1,17 @@
 (ns xsofy.test.percept-test
-  "entity-fov's cache sentinel.
+  "entity-fov's cache sentinel, and what it returns once an obstruction
+   is in the way.
 
    The player's FOV is precomputed on the world by update-fov; NPCs get it
    computed on demand. entity-fov decides which case it's in by looking at
    :fov, so what an empty :fov means is load-bearing — and since #176 gave
    empty-world a :fov of #{}, a world that hasn't been through update-fov
-   carries the key with nothing in it."
+   carries the key with nothing in it.
+
+   The occlusion tests below cover the other half (#184): every cache case
+   here runs in an open room where everything can see everything, so they
+   would pass just as well against an FOV that ignored walls. The geometry
+   itself is pinned in xsofy.test.fov-test."
   (:require [test :refer [deftest is testing]]
             [xsofy.percept :as percept]
             [xsofy.terrain :as terrain]
@@ -22,6 +28,22 @@
         (assoc-in [:entities :player]
                   {:id :player :template :player :pos [2 2]
                    :body {:hp 10 :max-hp 10}}))))
+
+(defn- rat-at
+  "room-world's rat: enough of an entity for entity-fov to place it."
+  [pos]
+  {:id :rat-1 :template :rat :pos pos :body {:hp 3} :ai {:state :idle}})
+
+(defn- divided-room-world
+  "room-world with a stone column at x=5 spanning the full interior, sealing
+   the player at [2 2] into the left half and a rat at [7 2] into the right.
+   The two halves share no open cell, so neither entity has a line to the
+   other by any route."
+  []
+  (let [world (room-world)]
+    (doseq [y (range 1 9)]
+      (terrain/tset! (:terrain world) 10 5 y 8))
+    (assoc-in world [:entities :rat-1] (rat-at [7 2]))))
 
 (deftest player-fov-is-computed-when-the-world-has-none-yet
   (testing "an empty :fov means not-computed, not an empty result"
@@ -49,3 +71,23 @@
           rat-fov (percept/entity-fov world :rat-1 {})]
       (is (contains? rat-fov [7 7]))
       (is (not= (:fov world) rat-fov)))))
+
+(deftest an-obstruction-truncates-the-fov-at-the-wall
+  (testing "the wall itself is seen; nothing behind it is"
+    (let [fov (percept/entity-fov (divided-room-world) :player {})]
+      (is (contains? fov [4 2]) "open floor on the player's side")
+      (is (contains? fov [5 2]) "the blocking tile is visible, being lit")
+      (is (not (contains? fov [6 2])) "first cell in the wall's shadow")
+      (is (not (contains? fov [7 2])) "the far side of the room"))))
+
+(deftest entities-on-opposite-sides-of-an-obstruction-cannot-see-each-other
+  (testing "occlusion holds in both directions, not just from the player"
+    (let [world (divided-room-world)]
+      (is (not (contains? (percept/entity-fov world :player {}) [7 2])))
+      (is (not (contains? (percept/entity-fov world :rat-1 {}) [2 2]))))))
+
+(deftest the-same-room-without-the-obstruction-is-mutually-visible
+  (testing "control: the blindness above is the wall, not an empty FOV"
+    (let [world (assoc-in (room-world) [:entities :rat-1] (rat-at [7 2]))]
+      (is (contains? (percept/entity-fov world :player {}) [7 2]))
+      (is (contains? (percept/entity-fov world :rat-1 {}) [2 2])))))

--- a/xsofy/test/run.lg
+++ b/xsofy/test/run.lg
@@ -12,6 +12,7 @@
             [xsofy.test.world-seed-test]
             [xsofy.test.world-shape-test]
             [xsofy.test.percept-test]
+            [xsofy.test.fov-test]
             [xsofy.test.dispatch-test]
             [xsofy.test.serialize-test]
             [xsofy.test.dag-test]


### PR DESCRIPTION
`compute-fov` and `terrain/has-clear-line?` are the two answers to "can this point see that one", and neither had a test. Every FOV case in the suite ran in an open carved room, and no test asserted that a cell was *absent* from a computed FOV. The existing percept tests pin which FOV set `entity-fov` hands back, precomputed vs. computed on demand, rather than what that set contains.

@nnunley raised this reviewing #179, suggesting an obstruction in the middle of the room to check that entities on opposite sides can't see each other. That became #184.

## What's covered

New `xsofy/test/fov_test.lg` holds the geometry. The fixture is one room split by a solid column of wall-stone, which keeps the assertions independent of casting order: the two halves share no open cell, so nothing on the far side is reachable by any route.

- A wall is itself visible, and stops sight past it. The cell you look *at* is lit; the cells in its shadow are not.
- Occlusion holds looking either way, not only outward from the player.
- A single gap in the column admits sight along its own line and nowhere else. This is the harder half of shadowcasting: from a position level with the gap, the far side is lit straight through it while the cells flanking it stay dark.
- Radius bounds reach by euclidean distance rather than a square, so the diagonal runs out before the row does.

`percept_test.lg` gets the same obstruction at the entity level, which is what #184 asked for: a player and a rat either side of the column cannot see each other, in either direction.

Every occlusion case is paired with an unobstructed control in the same room. Without those, the suite would pass just as well against an FOV that returned nothing at all.

## Verification

Beyond the assertions passing, both halves were checked by mutation:

| Mutation | Result |
|---|---|
| `terrain/transparent?` returns `true` for every tile | 13 new assertions fail |
| `compute-fov`'s radius bound removed | the 2 radius assertions fail |

In both runs the controls still pass, so the failures are the occlusion and reach claims specifically rather than the fixture collapsing.

The transparency mutation also fails one existing assertion, `npc-fov-is-always-computed`'s check that a rat's FOV differs from the player's — with every tile transparent the two sets coincide. That was the suite's only incidental grip on occlusion, and it fails for a reason unrelated to what it tests.

No production code changes; this is tests only.

Closes #184
