### PR TITLE
bench: sample turns in microseconds instead of whole milliseconds

### DIFF
--- a/bench/native.lg
+++ b/bench/native.lg
@@ -36,11 +36,13 @@
   (println "=== xsofy native engine benchmark ===")
   (println (format "trials per fixture: %d (each a distinct seed); turns vary — see n" TRIALS))
   (println)
-  (println (format "%-12s %6s %6s %6s %6s %6s" "fixture" "n" "avg" "p50" "p95" "max"))
-  (println (format "%-12s %6s %6s %6s %6s %6s" "--------" "------" "------" "------" "------" "------"))
+  (println (format "%-12s %6s %9s %9s %9s %9s" "fixture" "n" "avg-ms" "p50-ms" "p95-ms" "max-ms"))
+  (println (format "%-12s %6s %9s %9s %9s %9s" "--------" "------" "------" "------" "------" "------"))
   (doseq [f fixtures]
-    (let [s (perf/run-fixture f seeds 1)]   ; :per-seed ignored here
-      (println (format "%-12s %6d %5dms %5dms %5dms %5dms"
-                       (str (:name s)) (:n s) (:avg s) (:p50 s) (:p95 s) (:max s))))))
+    (let [s  (perf/run-fixture f seeds 1)   ; :per-seed ignored here
+          ms (fn [us] (/ (double us) 1000.0))]
+      (println (format "%-12s %6d %9.3f %9.3f %9.3f %9.3f"
+                       (str (:name s)) (:n s)
+                       (ms (:avg s)) (ms (:p50 s)) (ms (:p95 s)) (ms (:max s)))))))
 
 (-main)

--- a/xsofy/perf.lg
+++ b/xsofy/perf.lg
@@ -16,17 +16,20 @@
 ;; their seed strategy (spread of worlds vs a pinned world) via run-fixture args.
 
 (defn time-turn
-  "Run one turn; return [new-world ms]."
+  "Run one turn; return [new-world µs]. Microseconds because whole-ms
+   sampling floor-quantizes a ~9ms turn to 9, hiding sub-ms deltas from
+   every downstream stat; µs keeps samples as small ints (a 32-bit int
+   still holds ~35min)."
   [w key-str]
   (let [k  (input/parse-key key-str)
-        t0 (System/currentTimeMillis)
+        t0 (System/nanoTime)
         w' (world/update-world w k)
-        dt (- (System/currentTimeMillis) t0)]
+        dt (quot (- (System/nanoTime) t0) 1000)]
     [w' dt]))
 
 (defn run-trial
   "One trial: fresh world at `seed`, up to n turns (stops early on player
-   death). Returns a vector of per-turn ms."
+   death). Returns a vector of per-turn µs."
   [keystroke-fn n seed]
   (loop [w (world/make-world 79 30 seed)
          i 0
@@ -49,11 +52,12 @@
   ;; trials, or a zero-turn fixture).
   (let [n (count samples)]
     (if (zero? n)
-      {:n 0 :avg 0 :p50 0 :p95 0 :max 0}
+      {:n 0 :avg 0 :p50 0 :p95 0 :max 0 :unit :us}
       (let [sorted (vec (sort samples))
             sum (reduce + samples)]
-        {:n   n
-         :avg (quot sum n)
+        {:n    n
+         :unit :us
+         :avg  (quot sum n)
          :p50 (percentile sorted 0.50)
          :p95 (percentile sorted 0.95)
          :max (last sorted)}))))


### PR DESCRIPTION
`xsofy.perf/time-turn` timed each turn with `System/currentTimeMillis`, so every per-turn sample was floor-quantized to a whole millisecond before any statistic ran. On a ~9 ms turn that hides anything smaller than ~10% from every downstream percentile — and the quantization error is correlated, so summing samples doesn't recover it. We hit this A/B-ing lg builds against the pinned release: two builds whose real difference was ~0.8 ms/turn read as identical 9 ms columns.

Changes:

- `time-turn` samples with `System/nanoTime` and returns integer **microseconds**. Integer µs keeps aggregation exact, stays readable in the dev console's `'bench` dump, and fits a 32-bit int (~35 min/turn) where nanoseconds would overflow at ~2.1 s on TinyGo-class targets.
- `summarize` maps carry `:unit :us` so consumers don't have to guess the unit from magnitude.
- `bench/native.lg` prints ms with three decimals (`avg-ms`/`p50-ms`/... headers instead of a per-cell suffix).

Same build, before and after:

```
:wait           285     9ms     9ms    12ms    22ms      (before)
:wait           285     9.966     9.252    13.914    40.708  (after)
```

Verified: full test suite green (318 tests, 0 fail); the bench runs under both the pinned v1.12.2 lg and a tip build; the console `'bench` command still returns in well under a second.
