### PR TITLE
docs: add Discord invite link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Xs of Y
 
+> 💬 Come talk about Xs of Y in `#xsofy` on [The Fixpoint](https://discord.gg/Ky535CQ9pj) Discord.
+
 A roguelike written in my [lisp](https://github.com/nooga/let-go), where the magic system is a lisp. 
 
 > Note: This is not finished! It's playable but mild peril and unscheduled explosions are to be expected.


### PR DESCRIPTION
Adds a link to The Fixpoint Discord server and points folks to `#xsofy` for project discussion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)