### PR TITLE
build(wasm): emit main.wasm externally and boot it with instantiateStreaming

### DIFF
--- a/.github/actions/build-wasm/action.yml
+++ b/.github/actions/build-wasm/action.yml
@@ -24,11 +24,27 @@ runs:
   steps:
     # 1. Shell-less bundle: -w-shell none emits glue-only HTML exposing
     #    window.LetGoHost, so a project can inject its own client shell (#245).
+    #
+    #    -w-wasm external emits main.wasm alongside a small index.html and
+    #    boots it with instantiateStreaming, instead of baking a gzip-base64
+    #    payload into the HTML.
+    #
+    #    This is a boot-CPU win, not a bytes win. The inline path re-runs atob
+    #    + DecompressionStream + instantiate on every load; streaming compiles
+    #    during the download. Measured on two GitHub Pages deploys differing
+    #    only by this flag, 10 scored rounds each, time to the xterm grid:
+    #
+    #      cold  952ms -> 272ms  (0.286x)
+    #      warm  331ms ->  45ms  (0.136x)
+    #
+    #    External ships 3.7% MORE on the wire (5,866,730 B in one request
+    #    against 6,085,397 B in two, both gzipped by Pages) and still finishes
+    #    in a seventh of the time warm.
     - name: Build WASM (shell-less)
       shell: bash
       run: |
         if [ -n "${{ inputs.letgo-src }}" ]; then export LETGO_SRC="${{ inputs.letgo-src }}"; fi
-        let-go -w "${{ inputs.dist }}" -w-shell none main.lg
+        let-go -w "${{ inputs.dist }}" -w-shell none -w-wasm external main.lg
 
     # 2. Inject xsofy's own shell: rune font (Fairfax HD, OFL) + ?font=system.
     #    Without this the bundle ships let-go's generic shell (no rune face,

--- a/.github/actions/build-wasm/action.yml
+++ b/.github/actions/build-wasm/action.yml
@@ -24,22 +24,10 @@ runs:
   steps:
     # 1. Shell-less bundle: -w-shell none emits glue-only HTML exposing
     #    window.LetGoHost, so a project can inject its own client shell (#245).
-    #
-    #    -w-wasm external emits main.wasm alongside a small index.html and
-    #    boots it with instantiateStreaming, instead of baking a gzip-base64
-    #    payload into the HTML.
-    #
-    #    This is a boot-CPU win, not a bytes win. The inline path re-runs atob
-    #    + DecompressionStream + instantiate on every load; streaming compiles
-    #    during the download. Measured on two GitHub Pages deploys differing
-    #    only by this flag, 10 scored rounds each, time to the xterm grid:
-    #
-    #      cold  952ms -> 272ms  (0.286x)
-    #      warm  331ms ->  45ms  (0.136x)
-    #
-    #    External ships 3.7% MORE on the wire (5,866,730 B in one request
-    #    against 6,085,397 B in two, both gzipped by Pages) and still finishes
-    #    in a seventh of the time warm.
+    #    -w-wasm external emits main.wasm beside the HTML so the loader streams
+    #    and compiles it, rather than re-running atob + DecompressionStream +
+    #    instantiate on every load. A boot-CPU win, not a size win; external is
+    #    slightly larger on the wire. Timings in nooga/xsofy#191.
     - name: Build WASM (shell-less)
       shell: bash
       run: |

--- a/tests/e2e/static-server.js
+++ b/tests/e2e/static-server.js
@@ -9,7 +9,7 @@ const DIST = process.env.DIST || path.join(__dirname, 'dist');
 const PORT = Number(process.env.PORT || 8123);
 const COI = process.env.COI === '1';
 
-const TYPES = { '.html': 'text/html', '.js': 'text/javascript' };
+const TYPES = { '.html': 'text/html', '.js': 'text/javascript', '.wasm': 'application/wasm' };
 
 http.createServer((req, res) => {
   const urlPath = req.url.split('?')[0];


### PR DESCRIPTION
## What changes

One flag in the shared build action: `lg -w` gains `-w-wasm external`, so the bundle ships a small `index.html` plus a separate `main.wasm` that the loader fetches and streams, instead of a single HTML file with a gzip-base64 payload baked into it.

`lg -w` has supported this since let-go#246. Nothing else in the chain moves.

## Why

Boot CPU. The inline path re-runs `atob`, then `DecompressionStream`, then instantiate on **every** load. `instantiateStreaming` compiles the module while it downloads, and the browser can reuse its compiled-module cache afterwards.

It is not a size win, and the numbers say so plainly. External ships **3.7% more** on the wire: 5,866,730 B in one request against 6,085,397 B in two, both gzipped by Pages. It still finishes in a seventh of the time on a warm load, because the cost was never transfer.

## Measurement

Two GitHub Pages deploys differing by exactly this commit, built from the same source. 14 rounds, first 4 discarded, arms alternating order each round so neither systematically eats the cold-CDN-edge penalty. Time from navigation to the xterm grid existing:

| | inline | external | ratio |
|---|---:|---:|---:|
| cold | 952 ms (905-1010) | 272 ms (228-345) | **0.286x** |
| warm | 331 ms (311-890) | 45 ms (37-58) | **0.136x** |

Per-round ranges are disjoint on both rows.

An A/A control on the same harness — identical URLs in both arms — put the warm noise floor at 2.8% and the cold floor at 17%. The warm effect is thirty times its floor; the cold effect is four times its own. An earlier version of the harness ran one arm first every round and reported a 44% difference between identical URLs, which is what prompted the alternation and the control.

## What was checked

- `inject_shell.lg` and `patch_wasm_coi.lg` both still find their markers under external mode and patch cleanly.
- Pages serves `main.wasm` as `content-type: application/wasm` with `content-encoding: gzip`, so streaming compile is actually available rather than silently falling back.
- The deployed bundle boots with `crossOriginIsolated === true` through the service-worker shim, with no console or page errors, and plays.
- `tests/browser/smoke.mjs` already maps `.wasm` to `application/wasm`, so the smoke gate needed no change.

## Scope

The cold-load advantage depends on the server compressing and setting the right content type. GitHub Pages does both, which is what production uses. A server that does neither can reverse the cold result; the warm result does not depend on it.

## Related CI fixes

The current upstream-latest failure is a stale `let-go` cache/toolchain issue, not a failure of the external-WASM change:

- Cache behavior originally introduced in #163
- Draft cache-key correction in #193
- Upstream cached-binary robustness fix in nooga/let-go#837
