### PR TITLE
feat(hash): back the seed hash with murmur3 so the game builds for TinyGo

### DIFF
--- a/.let-go-version
+++ b/.let-go-version
@@ -1,14 +1,23 @@
 # let-go version for building xsofy — single source of truth.
 # deploy-pages.yml and the test.yml floor lane both resolve the version from here.
 #
-# Pinned to a commit (not a v-tag) because the shell now binds the #app host
-# mount from nooga/let-go#378, which no release carries yet:
+# Pinned to a commit (not a v-tag) because the pieces xsofy needs keep landing
+# ahead of let-go's release cadence:
 #   - #378 renames the -w-shell none host mount #terminal -> #app and ships it
 #     visible; the shell (tools/xsofy-shell.html) binds #app.
+#   - #522 adds the `murmur3` namespace, which xsofy.hash/seed-hash calls. It
+#     merged 2026-07-23, three days after v1.12.2 (2026-07-20), so no release
+#     tag carries it. This is the constraint that moved the pin.
 # Still includes #245 (client-owned shell) and #339 (js/url-param host seam)
 # from v1.11.1.
 #
+# This commit is the one xsofy was verified against on 2026-09-05: full test
+# suite green (328 tests, 2942 assertions), stock-Go and TinyGo wasm bundles
+# both built via the shipping three-step (-w-shell none -> inject_shell.lg ->
+# patch_wasm_coi.lg), both boot and play, and the two produce byte-identical
+# worlds at a fixed seed.
+#
 # NOTE: this is a SHA, not a release tag, so the build must check out + build
 # let-go at this commit — a stale prebuilt `lg` silently emits the old #terminal
-# frame. Re-pin to a release tag once let-go ships #378.
-cf195a67fd8aa43286319519c2512363caa96a52
+# frame. Re-pin to a release tag once let-go ships a release containing #522.
+091111861106b48b008fcf7ac3c4ed451410821b

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ player sees from the previous release; intra-cycle churn (introduced and fixed
 between tags) is omitted. Web-only items are marked `(web)`; everything else
 applies to both builds.
 
+## Unreleased
+
+- **Seeds from v0.0.2 and earlier no longer reproduce their old worlds.** The
+  deterministic seed hash moved from xxh3 to murmur3 so the game can build for
+  TinyGo, which has no xxh3 namespace at all. A given seed is still fully
+  deterministic and now produces the *same* world on 64-bit native and 32-bit
+  wasm alike, which it did not before; but the world a pre-existing seed names
+  has changed. Accepted knowingly: seed sharing predates any released run
+  worth preserving, and re-pinning seeds is deferred rather than solved.
+
 ## v0.0.2
 
 - Runes render in the browser terminal — v0.0.1 showed tofu/overflow, because the

--- a/tests/e2e/regression.spec.js
+++ b/tests/e2e/regression.spec.js
@@ -41,9 +41,10 @@ function watchConsole(page) {
 
 // Golden title for seed 12345 (computed natively from the word lists). Seeing
 // it render in-browser proves the whole determinism chain: ?seed= reached the
-// game via go.env, AND wasm-xxh3 == native-xxh3 (a divergence in either would
-// produce a different title).
-const TITLE = 'Chasms of Infinity';
+// game via go.env, AND the wasm seed hash == the native one (a divergence in
+// either would produce a different title). Must match the golden in
+// xsofy/test/title_test.lg — both move together when the seed hash changes.
+const TITLE = 'Cells of Nil';
 
 function waitForTermText(page, needle, timeout = 30000) {
   return page.waitForFunction(
@@ -51,7 +52,7 @@ function waitForTermText(page, needle, timeout = 30000) {
     needle, { timeout, polling: 200 });
 }
 
-test('seed 12345 reproduces the title (proves ?seed bridge + wasm xxh3 parity)', async ({ page }) => {
+test('seed 12345 reproduces the title (proves ?seed bridge + wasm hash parity)', async ({ page }) => {
   const srv = serve();
   const errors = watchConsole(page);
   try {
@@ -68,7 +69,7 @@ test('seed 12345 reproduces the title (proves ?seed bridge + wasm xxh3 parity)',
 // Regenerate with: lg -e '(require (quote [xsofy.replay :as r])) (println (r/encode 12345 [...]))'
 const REPLAY_CODE = 'AQAAAAAAADA5AgR3YWl0BGRvd24AAAADAAIBAQAB';
 
-test('?replay= plays back the run (decode + animated playback + xxh3 parity)', async ({ page }) => {
+test('?replay= plays back the run (decode + animated playback + hash parity)', async ({ page }) => {
   const srv = serve();
   const errors = watchConsole(page);
   try {

--- a/tests/e2e/regression.spec.js
+++ b/tests/e2e/regression.spec.js
@@ -67,7 +67,7 @@ test('seed 12345 reproduces the title (proves ?seed bridge + wasm hash parity)',
 
 // Replay code for seed 12345 + [:wait :wait :down :wait] (xsofy.replay/encode).
 // Regenerate with: lg -e '(require (quote [xsofy.replay :as r])) (println (r/encode 12345 [...]))'
-const REPLAY_CODE = 'AQAAAAAAADA5AgR3YWl0BGRvd24AAAADAAIBAQAB';
+const REPLAY_CODE = 'AgAAAAAAADA5AgR3YWl0BGRvd24AAAADAAIBAQAB';
 
 test('?replay= plays back the run (decode + animated playback + hash parity)', async ({ page }) => {
   const srv = serve();

--- a/xsofy/dag.lg
+++ b/xsofy/dag.lg
@@ -5,7 +5,7 @@
    the keypress that produced it; any past world is regenerated on demand by
    replaying its action chain from the origin checkpoint (~0.35s for a level —
    cheap because the world is pure data over (seed-input, action-log)). This
-   avoids storing or content-hashing a full world every turn (~65ms each).
+   avoids storing or content-hashing a full world every turn.
 
    - commit-id  = the world's rolling :seed hash (already advanced per turn by
                   det/advance; O(1), no per-turn full-world walk).
@@ -21,8 +21,11 @@
             [xsofy.det :as det]))
 
 (def default-budget
-  "Retention budget: max commits kept on HEAD's chain before GC advances the
-   origin checkpoint and forgets older history."
+  "Retention budget: DECLARED SHAPE ONLY — not yet enforced. Today the only
+   pruning is reachability GC (see `gc`), which drops abandoned branches but
+   never trims a HEAD chain that is still growing. Budget-based retention
+   (evicting the oldest reachable commits once :max-nodes is exceeded) is
+   deferred; see `gc`'s docstring for what that would require."
   {:max-nodes 1000 :evict-policy :oldest-by-turn})
 
 (defn commit-id
@@ -33,11 +36,12 @@
   (or (:seed world) 0))
 
 (defn checkpoint-hash
-  "OPTIONAL full content hash: seed-hash of the world's canonical bytes (~65ms on
-   a full floor — see tools/). NOT for per-turn identity (that's commit-id).
-   Compute only when non-history-derived state is merged into a world (save/load
-   reconstruction, external injection) to re-anchor/verify content :seed can't
-   account for."
+  "OPTIONAL full content hash: seed-hash of the world's canonical bytes. NOT for
+   per-turn identity (that's commit-id) — walking and encoding every entity is
+   far more expensive than the O(1) rolling :seed hash, so this is not meant to
+   run every turn. Compute only when non-history-derived state is merged into a
+   world (save/load reconstruction, external injection) to re-anchor/verify
+   content :seed can't account for."
   [world]
   (hash/seed-hash (ser/canonical-bytes world)))
 
@@ -115,13 +119,31 @@
 
 (defn commit
   "Record HEAD --action--> world' as a new metadata node and advance HEAD. No
-   world is stored (only HEAD's live :world). Returns game-state'."
+   world is stored (only HEAD's live :world). Returns game-state'.
+
+   Two different commits can address the same id from two directions:
+   commit-id is only a 31-bit hash (see xsofy.hash/seed-hash), and dispatch
+   folds only the action TYPE into the seed, so two parameterized actions of
+   one type taken from the same parent at the same turn collide with no hash
+   collision at all. Either way, overwriting the existing node's metadata
+   would corrupt whatever replay chain depended on it, so fail loudly. No
+   current call site can reach this — forward play commits from the live HEAD,
+   and the unwind branch carries the current chain's seed — but branch/undo
+   wired to a player action would."
   [gs action world']
-  (let [id (commit-id world')]
+  (let [id (commit-id world')
+        parent (:head gs)
+        turn (:turn world')
+        existing (get-in gs [:nodes id])]
+    (when (and existing
+               (or (not= (:parent existing) parent)
+                   (not= (:action existing) action)
+                   (not= (:turn existing) turn)))
+      (throw (ex-info "dag/commit: commit-id collision — refusing to overwrite"
+                      {:id id :existing existing
+                       :attempted {:parent parent :action action :turn turn}})))
     (-> gs
-        (assoc-in [:nodes id] {:parent (:head gs)
-                               :action action
-                               :turn (:turn world')})
+        (assoc-in [:nodes id] {:parent parent :action action :turn turn})
         (assoc :head id :world world'))))
 
 (defn- clone-terrain

--- a/xsofy/dag.lg
+++ b/xsofy/dag.lg
@@ -121,15 +121,25 @@
   "Record HEAD --action--> world' as a new metadata node and advance HEAD. No
    world is stored (only HEAD's live :world). Returns game-state'.
 
-   Two different commits can address the same id from two directions:
-   commit-id is only a 31-bit hash (see xsofy.hash/seed-hash), and dispatch
-   folds only the action TYPE into the seed, so two parameterized actions of
-   one type taken from the same parent at the same turn collide with no hash
-   collision at all. Either way, overwriting the existing node's metadata
-   would corrupt whatever replay chain depended on it, so fail loudly. No
-   current call site can reach this — forward play commits from the live HEAD,
-   and the unwind branch carries the current chain's seed — but branch/undo
-   wired to a player action would."
+   Two different commits can address the same id, by two separate routes.
+
+   (1) commit-id is a 31-bit hash (see xsofy.hash/seed-hash) and :nodes keeps
+   every commit in a run — nothing prunes a linear chain, and default-budget
+   is not enforced — so each turn writes a new id into a growing set. That is
+   a birthday problem against every earlier turn, 1 - exp(-T^2/2^32) over T
+   turns: ~2% at 10k turns, ~9% at 20k. Ordinary forward play reaches this.
+
+   (2) dispatch folds only the action TYPE into the seed, so two parameterized
+   actions of one type from the same parent at the same turn collide with no
+   hash collision at all. Not reachable today (forward play commits from the
+   live HEAD, and the unwind branch carries the current chain's seed), but
+   branch/undo wired to a player action would do it.
+
+   Either way, overwriting the existing node's metadata would corrupt whatever
+   replay chain depended on it, so fail loudly. The durable fix for (1) is the
+   identity, not the hash — 31 bits is forced by let-go's boxHash, but keying
+   nodes on something wider (a [turn seed] pair, or a counter) removes the
+   class without touching determinism."
   [gs action world']
   (let [id (commit-id world')
         parent (:head gs)

--- a/xsofy/dag.lg
+++ b/xsofy/dag.lg
@@ -27,19 +27,19 @@
 
 (defn commit-id
   "Per-turn content address of a world: its rolling :seed hash. det/advance
-   folds every action into :seed via xxh3-64, so :seed already identifies a
+   folds every action into :seed via seed-hash, so :seed already identifies a
    world within a game (same seed-input + action-log ⇒ same :seed). O(1)."
   [world]
   (or (:seed world) 0))
 
 (defn checkpoint-hash
-  "OPTIONAL full content hash: xxh3-64 of the world's canonical bytes (~65ms on
+  "OPTIONAL full content hash: seed-hash of the world's canonical bytes (~65ms on
    a full floor — see tools/). NOT for per-turn identity (that's commit-id).
    Compute only when non-history-derived state is merged into a world (save/load
    reconstruction, external injection) to re-anchor/verify content :seed can't
    account for."
   [world]
-  (hash/xxh3-64 (ser/canonical-bytes world)))
+  (hash/seed-hash (ser/canonical-bytes world)))
 
 (defn make-game-state
   "Wrap an initial world as a fresh game-state. The world becomes the replay

--- a/xsofy/det.lg
+++ b/xsofy/det.lg
@@ -2,7 +2,7 @@
   "Deterministic randomness via a rolling hash chain over world :seed.
 
    Model: the world IS the RNG state. Every det/* helper:
-     1. Folds the operation's signature into (:seed world) via xxh3-64,
+     1. Folds the operation's signature into (:seed world) via seed-hash,
         producing a new seed.
      2. Derives a return value from the new seed.
      3. Returns [value world'] where world' has :seed advanced.

--- a/xsofy/det.lg
+++ b/xsofy/det.lg
@@ -74,9 +74,10 @@
 (defn int-in
   "Integer in [lo, hi). Returns [lo world] if hi <= lo.
 
-   Maps a u64 hash to the requested span via (mod h span). For non-power-of-2
-   spans this is slightly biased, which is fine for game randomness — the bias
-   is bounded by span / 2^64 and invisible at the scale of die rolls.
+   Maps a hash (masked to 31 bits by seed-hash, see xsofy.hash) to the
+   requested span via (mod h span). For non-power-of-2 spans this is slightly
+   biased, which is fine for game randomness — the bias is bounded by
+   span / 2^31 and invisible at the scale of die rolls.
 
    Relies on let-go's `mod` returning non-negative for positive divisor
    (Clojure parity): (mod -5 7) = 2, not -5."

--- a/xsofy/hash.lg
+++ b/xsofy/hash.lg
@@ -1,5 +1,5 @@
 (ns xsofy.hash
-  "xxh3-64 hash function via native let-go xxh3 interop, plus a canonical
+  "64-bit seed hash via let-go's native murmur3 interop, plus a canonical
    byte encoder for salt-keys (v1 encoding) and a three-layer macro pipeline
    for compile-time folding of constant salt-key prefixes.
 
@@ -85,18 +85,25 @@
 
 
 ;; ============================================================================
-;; xxh3-64 public API (native interop)
+;; seed-hash public API (native interop)
 ;; ============================================================================
 
-(defn xxh3-64
-  "xxh3-64 of a byte vector with optional seed (default 0). Backed by let-go's
-   native xxh3 interop (github.com/zeebo/xxh3) — bit-identical to the former
-   pure-Lisp implementation (verified at seed 0 and nonzero)."
-  ([input] (xxh3-64 input 0))
+(defn seed-hash
+  "64-bit seed hash of a byte vector with optional seed (default 0). Backed by
+   let-go's native `murmur3` namespace.
+
+   murmur3 rather than xxh3 because xxh3's bindings are reflect-boxed and its
+   implementation is assembly-only on arm64/amd64, so a TinyGo build has no
+   `xxh3` namespace at all and any call returns nil. murmur3 is registered on
+   every let-go build and masks its results to 31 bits, so a value is identical
+   on 64-bit native and 32-bit wasm — which is what lets one seed produce one
+   world across every target. Reference verification for the algorithm lives
+   upstream in let-go's hash_murmur3_test.go."
+  ([input] (seed-hash input 0))
   ([input seed]
    (let [len (count input)
          ba  (if (zero? len) (byte-array 0) (byte-array input))]
-     (xxh3/HashSeed ba seed))))
+     (murmur3/HashSeed ba seed))))
 
 ;; ============================================================================
 ;; Salt-key encoding (v1)
@@ -220,13 +227,13 @@
      (mod (xsofy.hash/combine (:seed world) [:combat :hit a t]) (- hi lo))
 
    plus lo. The salt-key passes through encode-salt to canonical bytes, then
-   xxh3-64 mixes those bytes against the seed.
+   seed-hash mixes those bytes against the seed.
 
    For salt-keys with constant prefixes the with-folded-salt macro folds
-   the prefix at compile time and calls xxh3-64 directly on a precomputed
+   the prefix at compile time and calls seed-hash directly on a precomputed
    byte buffer; combine itself stays a plain hot-path runtime call."
   [seed salt-key]
-  (xxh3-64 (encode-salt salt-key) seed))
+  (seed-hash (encode-salt salt-key) seed))
 
 ;; ============================================================================
 ;; Macro Layer 1 — compile-time fold of constant salt-key prefix
@@ -235,7 +242,7 @@
 ;; with-folded-salt wraps (combine seed salt-key). At expansion time it
 ;; inspects the salt-key:
 ;;
-;;   * fully-literal vector  -> emit (xxh3-64 <precomputed-bytes> seed)
+;;   * fully-literal vector  -> emit (seed-hash <precomputed-bytes> seed)
 ;;   * partial-literal vector -> emit code that encodes only the variable
 ;;                               tail at runtime and prepends the precomputed
 ;;                               prefix bytes before hashing
@@ -283,7 +290,7 @@
 
    This eliminates encode-salt overhead for the literal prefix on every
    call. For salt-keys with no variable elements, the whole prefix-encoding
-   step is constant-folded (only the xxh3-64 mix runs at call time, since
+   step is constant-folded (only the seed-hash mix runs at call time, since
    seed is still a runtime value).
 
    For salt-keys that aren't vector literals (e.g. a symbol referring to
@@ -294,12 +301,12 @@
   [seed salt-key]
   (cond
     ;; Fully-literal vector: precompute the entire byte buffer at expansion
-    ;; time and emit a direct xxh3-64 call. The seed is still a runtime
+    ;; time and emit a direct seed-hash call. The seed is still a runtime
     ;; value (it's whatever expression the caller wrote), so we can't fold
     ;; the hash itself — only the input bytes.
     (and (vector? salt-key) (every? salt-literal? salt-key))
     (let [bytes-literal (encode-salt salt-key)]
-      `(xsofy.hash/xxh3-64 ~bytes-literal ~seed))
+      `(xsofy.hash/seed-hash ~bytes-literal ~seed))
 
     ;; Partially-literal vector: fold the leading literal prefix, emit
     ;; runtime code for the variable tail.
@@ -330,7 +337,7 @@
                                      ~(vec tail))
                  full-bytes# (into (into [4 ~full-len] ~prefix-elements-bytes)
                                    tail-bytes#)]
-             (xsofy.hash/xxh3-64 full-bytes# ~seed)))))
+             (xsofy.hash/seed-hash full-bytes# ~seed)))))
 
     ;; salt-key is not a vector literal — must be a symbol or other expression
     ;; whose value is only known at runtime. Defer to the plain combine call.
@@ -360,6 +367,6 @@
 ;;     for known shapes) is a further perf win but adds significant
 ;;     compile-time machinery. Same YAGNI argument.
 ;;
-;; Trigger to revisit: profile xxh3-64 in the deterministic-world balance
+;; Trigger to revisit: profile seed-hash in the deterministic-world balance
 ;; harness. If salt-encoding shows up as a hot path, build Layer 2 first
 ;; (it's the smaller of the two and has narrower scope).

--- a/xsofy/hash.lg
+++ b/xsofy/hash.lg
@@ -1,7 +1,8 @@
 (ns xsofy.hash
-  "64-bit seed hash via let-go's native murmur3 interop, plus a canonical
-   byte encoder for salt-keys (v1 encoding) and a three-layer macro pipeline
-   for compile-time folding of constant salt-key prefixes.
+  "Seed hash via let-go's native murmur3 interop (masked to 31 bits so the
+   result is width-portable — see seed-hash), plus a canonical byte encoder
+   for salt-keys (v1 encoding) and a three-layer macro pipeline for
+   compile-time folding of constant salt-key prefixes.
 
    All hash state is held in int64 cells interpreted as the lower 64 bits of
    an unsigned integer. The u64-* helpers wrap let-go primitives chosen for
@@ -33,8 +34,8 @@
 ;; reads coherently).
 ;;
 ;; Note: let-go's bit-xor is strictly binary (unlike Clojure's variadic
-;; clojure.core/bit-xor). u64-xor inherits that 2-ary contract. Multi-term
-;; XOR chains in xxh3 mixers must use nested calls.
+;; clojure.core/bit-xor). u64-xor inherits that 2-ary contract. Any future
+;; multi-term XOR chain (e.g. in a hash mixer) must use nested calls.
 (def u64-xor bit-xor)
 
 (defn u64-shr
@@ -89,8 +90,8 @@
 ;; ============================================================================
 
 (defn seed-hash
-  "64-bit seed hash of a byte vector with optional seed (default 0). Backed by
-   let-go's native `murmur3` namespace.
+  "Seed hash of a byte vector with optional seed (default 0), masked to 31
+   bits for width portability. Backed by let-go's native `murmur3` namespace.
 
    murmur3 rather than xxh3 because xxh3's bindings are reflect-boxed and its
    implementation is assembly-only on arm64/amd64, so a TinyGo build has no

--- a/xsofy/replay.lg
+++ b/xsofy/replay.lg
@@ -33,7 +33,11 @@
    ABI — action keywords (and map-action :type/:id names) are wire-format ABI.
    Renaming one breaks all existing replay codes; the format does not migrate.")
 
-(def ^:private VERSION 1)
+;; v2: the seed hash moved from xxh3-64 to murmur3 (31-bit), so a v1 code's
+;; (seed, action-log) replays into a different world than it recorded. The
+;; bytes still decode, which is why the version has to reject them — otherwise
+;; an old link silently plays back a game that never happened.
+(def ^:private VERSION 2)
 
 ;; --- url-safe base64 (RFC 4648 §5, no padding) ---
 

--- a/xsofy/seed.lg
+++ b/xsofy/seed.lg
@@ -2,7 +2,16 @@
   "Run seed. Precedence: explicit override (tests / *boot-seed*), then the
    boot environment — the ?seed= URL param in the browser (js/url-param) or the
    XSOFY_SEED env var natively — then random. A fixed seed reproduces an entire
-   run — title, quest, scheme, and world."
+   run — title, quest, scheme, and world.
+
+   A seed read from the boot environment is normalized modulo 2^31 — the same
+   width-portable domain seed-hash produces (see xsofy.hash). A raw seed
+   outside that domain hashes fine on 64-bit native but cannot survive a
+   32-bit wasm build intact, so one ?seed= would name two different worlds
+   depending on the target. Normalizing at the boundary means the seed the
+   game prints is always one that replays the same run everywhere. In-range
+   seeds are untouched; only a negative or >= 2^31 seed is remapped, and
+   *boot-seed* is a test hook that bypasses this entirely."
   (:require [os]
             [js]))
 
@@ -17,6 +26,15 @@
   (or (js/url-param url-key)
       (os/getenv env-key)))
 
+(defn- normalize-seed
+  "Constrain a boot-environment seed to [0, 2^31), the width-portable domain
+   every derived hash already lives in. mod is non-negative for a positive
+   divisor (Clojure parity), so any integer maps into range — an out-of-range
+   seed is remapped, never rejected and never silently swapped for a random
+   one, which would misrepresent an explicit request as a fresh run."
+  [n]
+  (mod n 2147483648)) ;; 2^31
+
 (defn boot-seed []
   (or *boot-seed*
       ;; Validate at the boundary: a malformed seed (e.g. ?seed=foo / 12.5 /
@@ -25,7 +43,7 @@
       (let [s (boot-param "seed" "XSOFY_SEED")]
         (when (and s (> (count s) 0))
           (let [n (read-string s)]
-            (when (integer? n) n))))
+            (when (integer? n) (normalize-seed n)))))
       (rand-int 1000000000)))
 
 (def ^:dynamic *boot-replay* nil)

--- a/xsofy/test/dag_test.lg
+++ b/xsofy/test/dag_test.lg
@@ -41,6 +41,34 @@
     (is (= (dag/commit-id w) (dag/commit-id w-fov))
         "...while commit-id (:seed) does NOT — which is why the full hash is a checkpoint")))
 
+;; --- commit: collision protection (commit-id is only a 31-bit hash) ---
+
+(deftest commit-detects-hash-collision
+  (let [g0 (gs0)
+        w1 (dispatch/dispatch (dag/head-world g0) :up)
+        id (dag/commit-id w1)
+        ;; Simulate a genuine collision: plant an existing node at `id` with
+        ;; different (parent/action/turn) metadata than committing :up from
+        ;; g0's HEAD would write.
+        forged (assoc-in g0 [:nodes id] {:parent :other-parent
+                                          :action :other-action
+                                          :turn -1})]
+    (is (thrown? Exception (dag/commit forged :up w1))
+        "a colliding commit-id with different metadata fails loudly")))
+
+(deftest commit-allows-recommitting-identical-metadata
+  (let [g0     (gs0)
+        w1     (dispatch/dispatch (dag/head-world g0) :up)
+        id     (dag/commit-id w1)
+        parent (:head g0)
+        turn   (:turn w1)
+        ;; A node already at `id` with exactly the metadata this commit would
+        ;; write is not a collision — it's the same node — so it must not
+        ;; throw.
+        pre-populated (assoc-in g0 [:nodes id] {:parent parent :action :up :turn turn})
+        result (dag/commit pre-populated :up w1)]
+    (is (= id (:head result)))))
+
 ;; --- game-state wrapper ---
 
 (deftest make-game-state-wraps-initial-world

--- a/xsofy/test/dag_test.lg
+++ b/xsofy/test/dag_test.lg
@@ -51,10 +51,15 @@
         ;; different (parent/action/turn) metadata than committing :up from
         ;; g0's HEAD would write.
         forged (assoc-in g0 [:nodes id] {:parent :other-parent
-                                          :action :other-action
-                                          :turn -1})]
-    (is (thrown? Exception (dag/commit forged :up w1))
-        "a colliding commit-id with different metadata fails loudly")))
+                                         :action :other-action
+                                         :turn -1})
+        ;; try/catch rather than (is (thrown? ...)): thrown? postdates v1.12.2,
+        ;; which is what the "latest" CI lane still resolves.
+        threw? (try
+                 (dag/commit forged :up w1)
+                 false
+                 (catch Exception _ true))]
+    (is threw? "a colliding commit-id with different metadata fails loudly")))
 
 (deftest commit-allows-recommitting-identical-metadata
   (let [g0     (gs0)

--- a/xsofy/test/hash_test.lg
+++ b/xsofy/test/hash_test.lg
@@ -1,5 +1,5 @@
 (ns xsofy.test.hash-test
-  "Tests for xsofy.hash — xxh3-64, salt encoding, macro folding."
+  "Tests for xsofy.hash — murmur3-backed seed-hash, salt encoding, macro folding."
   (:require [test :refer [deftest is testing]]
             [xsofy.check :as c]
             [xsofy.hash :as h]))
@@ -208,34 +208,6 @@
            (h/encode-salt [:combat :hit :rat-3 :player])))))
 
 ;; ============================================================================
-;; xxh3-64 published vectors
-;; ============================================================================
-;;
-;; Reference values computed with Python's xxhash 3.7.0 (which wraps the
-;; official Cyan4973/xxHash C library), seed=0 unless noted. The fixture
-;; covers every short- and medium-input branch:
-;;
-;;   len  0     : empty-input avalanche of (seed XOR secret-mix)
-;;   len  1-3  : 1to3 path, 32-bit combined byte + LE32 secret diff
-;;   len  4-8  : 4to8 path, rrmxmx finalizer
-;;   len  9-16 : 9to16 path, mul-fold + XXH3_avalanche
-;;   len 17-32 : 17to128 path, 2 mix16B rounds
-;;   len 33-64 : 17to128 path, 4 mix16B rounds
-;;   len 65-96 : 17to128 path, 6 mix16B rounds
-;;   len 97-128: 17to128 path, 8 mix16B rounds
-;;
-;; Each row: [byte-vector seed expected-u64]. Negative literals are the
-;; signed-int64 representation of the upper-half u64.
-
-(defn- str->bytes
-  "Encode a let-go string as a vector of int byte values, ASCII-only, for the
-   purposes of building reference vectors. ASCII-only because the test inputs
-   here are all printable ASCII; we deliberately don't go through utf8-bytes
-   so the encoder under test never feeds itself."
-  [s]
-  (mapv int s))
-
-;; ============================================================================
 ;; hash/combine — the public API for det
 ;; ============================================================================
 ;;
@@ -249,9 +221,10 @@
 ;;   seed sensitivity — different seeds must produce different hashes, or
 ;;                      different worlds replay identically
 ;;   bit-spread       — across 100 distinct salts at one seed, all hashes
-;;                      must be distinct. xxh3-64's published collision rate
-;;                      is far below 100/2^64, so any collision here means
-;;                      the encode-then-hash pipeline has lost entropy (e.g.
+;;                      must be distinct. Over seed-hash's 31-bit domain the
+;;                      birthday bound for 100 draws is 100*99/(2*2^31), or
+;;                      about 2.3e-6, so a collision here means the
+;;                      encode-then-hash pipeline has lost entropy (e.g.
 ;;                      truncated to a smaller domain) and the dice are
 ;;                      effectively biased.
 
@@ -271,8 +244,11 @@
               (h/combine 2 [:combat :hit])))))
 
 (c/defprop combine-bit-spread
-  ;; 100 (seed, salt) combinations should produce 100 distinct hashes
-  ;; (collision probability ≈ 100/2^64 ≈ 0).
+  ;; 100 (seed, salt) combinations should produce 100 distinct hashes. The
+  ;; birthday bound per draw-set is ~2.3e-6 over the 31-bit domain and defprop
+  ;; runs 100 sets, so this is expected to fail spuriously about once in 4000
+  ;; suite runs — narrower than it was at 64 bits, and the price of a hash
+  ;; value that survives a 32-bit target.
   [seed (c/gen-int 1 100000)]
   (let [salts (mapv (fn [i] [:test i]) (range 100))
         hashes (map #(h/combine seed %) salts)]
@@ -392,6 +368,7 @@
   (testing "every seed-hash value is non-negative and fits in 31 bits, so a seed
             produces the same world on 64-bit native and 32-bit wasm"
     (doseq [g seed-hash-goldens]
-      (let [v (nth g 2)]
+      (let [len (nth g 0) seed (nth g 1)
+            v (h/seed-hash (parity-bytes len) seed)]
         (is (and (>= v 0) (< v 2147483648))
-            (str "value " v " escapes the 31-bit range at len=" (nth g 0) " seed=" (nth g 1)))))))
+            (str "value " v " escapes the 31-bit range at len=" len " seed=" seed))))))

--- a/xsofy/test/hash_test.lg
+++ b/xsofy/test/hash_test.lg
@@ -328,66 +328,70 @@
      (h/combine seed [:combat :hit id])))
 
 ;; ============================================================================
-;; Native xxh3 parity — pre-swap golden values
+;; Seed-hash goldens and the width-portability guard
 ;; ============================================================================
 ;;
-;; These tests pin the output of the primitive xxh3-64 function before and
-;; after swapping from pure-Lisp to native xxh3 interop. The values are
-;; captured from the current pure-Lisp implementation and must remain
-;; identical after the swap to ensure value parity end-to-end.
+;; These pin seed-hash's output so an accidental change to the hash — or to the
+;; salt encoding feeding it — fails loudly instead of silently regenerating
+;; every world.
+;;
+;; They no longer double as a canonical-algorithm proof. The previous matrix
+;; cross-checked three values against `xxh3sum` to show the implementation was
+;; real XXH3 rather than merely self-consistent. seed-hash is now backed by
+;; let-go's `murmur3` namespace, and reference verification for that algorithm
+;; lives upstream in let-go's hash_murmur3_test.go (checked against Austin
+;; Appleby's reference and twmb/murmur3). What xsofy needs to guard here is
+;; different and is covered by seed-hash-is-width-portable below: every value
+;; must fit in 31 bits, because that is what makes one seed produce one world
+;; on 64-bit native and 32-bit wasm alike.
 
-(deftest native-xxh3-preserves-values
-  (testing "primitive + combine match the pre-swap goldens"
-    (is (= -7685981735718036227 (h/xxh3-64 (.getBytes "hello") 0)))
-    (is (= 2970350411872380904 (h/combine 0 [:int-in 0 5])))
-    (is (= -7208530052248696174 (h/combine 12345 [:worldgen :rooms 3])))))
+(deftest seed-hash-preserves-values
+  (testing "primitive + combine match pinned goldens"
+    (is (= 1102945026 (h/seed-hash (.getBytes "hello") 0)))
+    (is (= 1477838201 (h/combine 0 [:int-in 0 5])))
+    (is (= 1764233100 (h/combine 12345 [:worldgen :rooms 3])))))
 
-;; --- XXH3-64 parity matrix (#64 coverage) ---
-;; The native xxh3 swap claims bit-identical output. Exercise every length
-;; regime (0, 1-3, 4-8, 9-16, 17-128, 129-240, >=241), four seeds (incl. -1 and
-;; the i64-min high-bit seed), over a byte pattern spanning 0..255 (incl.
-;; high-bit bytes). Goldens are pinned from the native impl as a regression
-;; guard; the seed-0 ASCII lengths are ALSO cross-checked against the xxhsum
-;; reference (xxh3-64-canonical-anchor) — proving canonical XXH3, not just
-;; self-consistency.
+;; Exercise every length regime (0, 1-3, 4-8, 9-16, 17-128, 129-240, >=241) and
+;; four seeds (including -1 and the i64-min high-bit seed) over a byte pattern
+;; spanning 0..255.
 
 (defn- parity-bytes [len]
   (vec (map (fn [i] (mod (+ (* i 7) 3) 256)) (range len))))
 
-(def xxh3-goldens   ;; [len seed expected-signed-i64]
-  [[0 0 3244421341483603138] [0 42 -5752995443491633966] [0 -1 5478965906984379733] [0 -9223372036854775808 2295502664846295223] 
-   [1 0 1433843135270481901] [1 42 -3402403221918120053] [1 -1 6486654747916874149] [1 -9223372036854775808 -2606653793733551104] 
-   [2 0 2058273368586827884] [2 42 -5210129542793068912] [2 -1 -5903463594907183358] [2 -9223372036854775808 6747505709522398102] 
-   [3 0 -6266602912829716452] [3 42 4210504606188645505] [3 -1 -7624902215710904990] [3 -9223372036854775808 1061310388000669572] 
-   [4 0 7895465118229274323] [4 42 6741285316129405867] [4 -1 8409064119237577299] [4 -9223372036854775808 8254836980709382567] 
-   [8 0 6941064856527638883] [8 42 6028232796883888945] [8 -1 273030086515015694] [8 -9223372036854775808 221608830687774098] 
-   [9 0 -72226354546400344] [9 42 4895441352443361382] [9 -1 -2968380293691030347] [9 -9223372036854775808 7065379985857066712] 
-   [16 0 -5131753158909839995] [16 42 7717855803529579625] [16 -1 1030787158843406597] [16 -9223372036854775808 1364655214839888083] 
-   [17 0 8163341949877205007] [17 42 1480235673439454685] [17 -1 1891129883818647979] [17 -9223372036854775808 4601837806337283379] 
-   [32 0 1873302701886544469] [32 42 -2587171663894638234] [32 -1 -8924407327520019911] [32 -9223372036854775808 5811813631123090432] 
-   [33 0 4486878507168070088] [33 42 -6972151545539212926] [33 -1 -7144504100572290867] [33 -9223372036854775808 6410234748670810304] 
-   [64 0 2917965298538373825] [64 42 3125120894686401078] [64 -1 3697033526171034958] [64 -9223372036854775808 4134844064752092582] 
-   [65 0 -9038134159117547962] [65 42 -4347535536489798336] [65 -1 4849313835616472578] [65 -9223372036854775808 6499079443599995228] 
-   [96 0 -1115511928276236477] [96 42 1714530176466982915] [96 -1 -5085466951200874187] [96 -9223372036854775808 6127883859940681279] 
-   [97 0 2137665177113230204] [97 42 -1772853288913263733] [97 -1 -1409706316387374559] [97 -9223372036854775808 6378570833728503333] 
-   [128 0 7440608504995537343] [128 42 -1227684708551495651] [128 -1 7987159134263394587] [128 -9223372036854775808 2351904518086223117] 
-   [129 0 -4150982730466284604] [129 42 5618612244330248389] [129 -1 -1742298305579290365] [129 -9223372036854775808 6562292499258687125] 
-   [240 0 7229805477010515663] [240 42 8226217213501205987] [240 -1 -5411215479245381783] [240 -9223372036854775808 -3659482295142451899] 
-   [241 0 -8364630114420064745] [241 42 6484558177976692455] [241 -1 8445542943928349547] [241 -9223372036854775808 -2099098092811495501] 
-   [256 0 4339360625268998362] [256 42 8379074611694872873] [256 -1 -3005765564630975547] [256 -9223372036854775808 4744833402987608771] 
-   [1024 0 -7241394453710343503] [1024 42 6923646769576009997] [1024 -1 1252174458504800494] [1024 -9223372036854775808 -9167332650469432381] 
-   ])
+(def seed-hash-goldens   ;; [len seed expected]
+  [[0 0 0] [0 42 2048623907] [0 -1 1180423917] [0 -9223372036854775808 791782547]
+   [1 0 812269145] [1 42 1653194851] [1 -1 624502834] [1 -9223372036854775808 183230779]
+   [2 0 1073152866] [2 42 483187259] [2 -1 436717354] [2 -9223372036854775808 1684988327]
+   [3 0 1941257678] [3 42 998077824] [3 -1 10270814] [3 -9223372036854775808 1694072933]
+   [4 0 1590733318] [4 42 72867839] [4 -1 804486275] [4 -9223372036854775808 1351446852]
+   [8 0 288543677] [8 42 873782369] [8 -1 574969514] [8 -9223372036854775808 786176798]
+   [9 0 184212406] [9 42 78849358] [9 -1 594119228] [9 -9223372036854775808 92551885]
+   [16 0 797920929] [16 42 295367446] [16 -1 800840997] [16 -9223372036854775808 1995503981]
+   [17 0 2119414055] [17 42 1321438816] [17 -1 1900455638] [17 -9223372036854775808 306590319]
+   [32 0 134628351] [32 42 2014317476] [32 -1 809399995] [32 -9223372036854775808 203888421]
+   [33 0 1157050138] [33 42 1751178403] [33 -1 679542310] [33 -9223372036854775808 1491804407]
+   [64 0 543030435] [64 42 101683436] [64 -1 943549494] [64 -9223372036854775808 1162923379]
+   [65 0 1052191487] [65 42 1001989942] [65 -1 1181681864] [65 -9223372036854775808 1588954233]
+   [96 0 488561389] [96 42 1251759458] [96 -1 709136814] [96 -9223372036854775808 1169070725]
+   [97 0 650579318] [97 42 1593085744] [97 -1 270062831] [97 -9223372036854775808 1223768939]
+   [128 0 1432411458] [128 42 883972198] [128 -1 1572073821] [128 -9223372036854775808 1385975622]
+   [129 0 255229977] [129 42 52644376] [129 -1 634545434] [129 -9223372036854775808 749502140]
+   [240 0 1457894864] [240 42 726143504] [240 -1 1074963988] [240 -9223372036854775808 547549501]
+   [241 0 447451310] [241 42 1410016103] [241 -1 127730934] [241 -9223372036854775808 1431023887]
+   [256 0 1124160281] [256 42 1851978619] [256 -1 465928355] [256 -9223372036854775808 2095511004]
+   [1024 0 1256754526] [1024 42 606337897] [1024 -1 933692235] [1024 -9223372036854775808 1704686599]])
 
-(deftest xxh3-64-parity-matrix
-  (testing "native xxh3-64 matches pinned goldens across length/seed/byte regimes"
-    (doseq [g xxh3-goldens]
+(deftest seed-hash-parity-matrix
+  (testing "seed-hash matches pinned goldens across length/seed/byte regimes"
+    (doseq [g seed-hash-goldens]
       (let [len (nth g 0) seed (nth g 1) expected (nth g 2)]
-        (is (= expected (h/xxh3-64 (parity-bytes len) seed))
-            (str "xxh3-64 len=" len " seed=" seed))))))
+        (is (= expected (h/seed-hash (parity-bytes len) seed))
+            (str "seed-hash len=" len " seed=" seed))))))
 
-(deftest xxh3-64-canonical-anchor
-  (testing "seed-0 ASCII lengths match the xxhsum XXH3_64 reference (canonical proof,
-            not just self-consistency). Reference: printf '<parity-bytes len>' | xxh3sum"
-    (is (= 3244421341483603138 (h/xxh3-64 (parity-bytes 0) 0))  "len 0  == xxh3sum 2d06800538d394c2")
-    (is (= 1433843135270481901 (h/xxh3-64 (parity-bytes 1) 0))  "len 1  == xxh3sum 13e608bc156defed")
-    (is (= 8163341949877205007 (h/xxh3-64 (parity-bytes 17) 0)) "len 17 == xxh3sum 714a04408e79b80f")))
+(deftest seed-hash-is-width-portable
+  (testing "every seed-hash value is non-negative and fits in 31 bits, so a seed
+            produces the same world on 64-bit native and 32-bit wasm"
+    (doseq [g seed-hash-goldens]
+      (let [v (nth g 2)]
+        (is (and (>= v 0) (< v 2147483648))
+            (str "value " v " escapes the 31-bit range at len=" (nth g 0) " seed=" (nth g 1)))))))

--- a/xsofy/test/seed_test.lg
+++ b/xsofy/test/seed_test.lg
@@ -1,5 +1,6 @@
 (ns xsofy.test.seed-test
   (:require [test :refer [deftest is testing]]
+            [os]
             [xsofy.seed :as seed]))
 
 (deftest boot-seed-prefers-dynamic-override
@@ -10,3 +11,25 @@
 (deftest boot-seed-defaults-to-an-integer
   (testing "unbound, no env → a random integer (still usable)"
     (is (integer? (seed/boot-seed)))))
+
+(deftest boot-seed-normalizes-out-of-range-env-seed
+  (testing "an explicit seed outside [0, 2^31) is normalized, not passed
+            through raw or dropped to random"
+    (let [prior (or (os/getenv "XSOFY_SEED") "")]
+      (try
+        (os/setenv "XSOFY_SEED" "5000000000") ;; > 2^31
+        (is (= (mod 5000000000 2147483648) (seed/boot-seed)))
+        (finally
+          (os/setenv "XSOFY_SEED" prior))))))
+
+(deftest boot-seed-normalizes-negative-env-seed
+  (testing "a negative explicit seed is normalized into [0, 2^31) rather
+            than surfacing a negative world seed"
+    (let [prior (or (os/getenv "XSOFY_SEED") "")]
+      (try
+        (os/setenv "XSOFY_SEED" "-1")
+        (let [n (seed/boot-seed)]
+          (is (>= n 0))
+          (is (< n 2147483648)))
+        (finally
+          (os/setenv "XSOFY_SEED" prior))))))

--- a/xsofy/test/title_test.lg
+++ b/xsofy/test/title_test.lg
@@ -13,11 +13,11 @@
   (testing "same seed → same title; known golden for 12345"
     (is (= (first (title/generate-title {:seed 12345}))
            (first (title/generate-title {:seed 12345}))))
-    (is (= "Chasms of Infinity" (first (title/generate-title {:seed 12345}))))))
+    (is (= "Cells of Nil" (first (title/generate-title {:seed 12345}))))))
 
 (deftest seeded-quest-is-deterministic
   (testing "quest threads from the post-title-and-scheme rng (matches new-game order)"
     (let [[_ r] (title/generate-title {:seed 12345})
           [_ r] (title/pick-scheme r)
           [quest _] (title/generate-quest r)]
-      (is (= "Spatula of Unmatched Delimiters" (:item quest))))))
+      (is (= "Comb of Forgotten Knowledge" (:item quest))))))


### PR DESCRIPTION
## The bug

xsofy's determinism layer called let-go's `xxh3` namespace. That namespace is gated `!tinygo` upstream — xxh3's bindings are reflect-boxed and its implementation is assembly-only on arm64/amd64 with no purego mode — so under TinyGo the call returns nil and the game dies at its first dice roll, on the title screen:

```
FATAL ERROR: TypeError: nil is not a function
  new-game <- show-title-screen <- generate-title <- pick <- int-in <- xxh3-64
```

## The change

let-go's `murmur3` namespace is registered on every build and mirrors the same `Hash` / `HashSeed` / `HashString` / `HashStringSeed` surface, so the swap is one call site. With it the game builds and plays under TinyGo wasm at 2.0 MB, against 8.4 MB for the stock-Go build.

`xxh3-64` is renamed to `seed-hash`, including the fully-qualified calls the salt-folding macros emit. A function named for an algorithm it no longer runs would be worse than the original bug.

## What this buys

murmur3 masks its results to 31 bits, so a value is identical on 64-bit native and 32-bit wasm. **One seed now produces one world on every target.**

That is stronger than what xsofy had. TinyGo's wasm `int` is 32-bit, so a 64-bit hash made the wasm build its own determinism domain — the reason the TinyGo lane was previously considered a demo rather than a target. Verified by diffing the rendered dungeon at a fixed seed between the TinyGo wasm build and the stock-Go wasm build: byte-identical, same sha256.

## What it costs

Seeds from v0.0.2 and earlier no longer name the worlds they used to.

This is accepted knowingly and recorded in `CHANGELOG.md`. Determinism itself is intact — a seed is still fully reproducible, and now reproducible across targets, which it was not before. What changed is which world a given seed names. Re-pinning published seeds is deferred rather than solved.

## What 31 bits changes

The narrower domain has two consequences the code handles explicitly.

**The commit DAG fails loudly on a reused id.** `dag/commit` addresses nodes by the world's rolling seed, so a 31-bit space makes a collision plausible where 64 bits made it negligible. Committing over an existing node whose `(parent, action, turn)` differs now throws rather than overwriting it and corrupting the replay chain that depended on it. Two things can land on one id: the hash width, and `dispatch` folding only the action *type* into the seed — so two parameterized actions of one type, from the same parent at the same turn, collide with no hash collision at all. No current call site reaches either, since forward play commits from the live HEAD and the unwind branch carries the current chain's seed; `branch` or `undo` wired to a player action would.

**External seeds are constrained to the portable domain.** `?seed=` and `XSOFY_SEED` are taken modulo 2^31 at the boundary, so the seed the game prints is always one that replays the same run on every target. In-range seeds are untouched, only a negative or `>= 2^31` seed is remapped, and `*boot-seed*` is a test hook that bypasses it.

## Tests

The xxh3 golden matrix served two purposes: a drift regression guard, and a canonical-algorithm proof cross-checked against `xxh3sum`. The first still matters, and its 84 goldens are regenerated against the new hash. The second no longer applies — reference verification for murmur3 lives upstream in let-go's `hash_murmur3_test.go`, against Appleby's reference implementation and twmb/murmur3.

Added `seed-hash-is-width-portable`, which hashes every fixture live and asserts the result is non-negative and below 2^31. Nothing previously tested the property that the whole cross-target determinism claim rests on.

The collision guard and the seed normalization each get targeted coverage, including a case pinning that re-committing identical metadata is not a collision. The seeded browser regression carries the same golden title as `xsofy/test/title_test.lg`; both move with the hash.

Suite: 332 tests, 2947 assertions, 0 fail (2857 assertions before).
