### PR TITLE
ci: key lg cache on exact Go version

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -49,15 +49,18 @@ jobs:
       # to be re-verified against a run to know it is right.
       - name: Resolve cache paths
         run: |
-          echo "GOPATH=$(go env GOPATH)" >> "$GITHUB_ENV"
-          echo "PLAYWRIGHT_BROWSERS_PATH=$HOME/.cache/ms-playwright" >> "$GITHUB_ENV"
+          {
+            echo "GOPATH=$(go env GOPATH)"
+            echo "LG_CACHE_GO_VERSION=$(go env GOVERSION)"
+            echo "PLAYWRIGHT_BROWSERS_PATH=$HOME/.cache/ms-playwright"
+          } >> "$GITHUB_ENV"
 
       - name: Cache lg binary
         id: lgcache
         uses: actions/cache@v4
         with:
           path: ${{ env.GOPATH }}/bin/let-go
-          key: lg-bin-${{ runner.os }}-go1.26-${{ steps.letgo.outputs.version }}
+          key: lg-bin-${{ runner.os }}-${{ env.LG_CACHE_GO_VERSION }}-${{ steps.letgo.outputs.version }}
 
       - name: Install let-go
         if: steps.lgcache.outputs.cache-hit != 'true'

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -69,7 +69,9 @@ jobs:
           } >> "$GITHUB_ENV"
 
       # pull_request_target runs may restore default-branch caches but cannot
-      # save a miss. Trusted deploy/manual runs seed this cache.
+      # save a miss. Trusted deploy/manual runs seed this cache. After a Go
+      # patch bump the new key is empty until test.yml on main or a deploy run
+      # writes it; this lane rebuilds from source in the meantime.
       - name: Restore lg binary cache
         id: lgcache
         uses: actions/cache/restore@v4

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -62,8 +62,11 @@ jobs:
       # to be re-verified against a run to know it is right.
       - name: Resolve cache paths
         run: |
-          echo "GOPATH=$(go env GOPATH)" >> "$GITHUB_ENV"
-          echo "PLAYWRIGHT_BROWSERS_PATH=$HOME/.cache/ms-playwright" >> "$GITHUB_ENV"
+          {
+            echo "GOPATH=$(go env GOPATH)"
+            echo "LG_CACHE_GO_VERSION=$(go env GOVERSION)"
+            echo "PLAYWRIGHT_BROWSERS_PATH=$HOME/.cache/ms-playwright"
+          } >> "$GITHUB_ENV"
 
       # pull_request_target runs may restore default-branch caches but cannot
       # save a miss. Trusted deploy/manual runs seed this cache.
@@ -72,7 +75,7 @@ jobs:
         uses: actions/cache/restore@v4
         with:
           path: ${{ env.GOPATH }}/bin/let-go
-          key: lg-bin-${{ runner.os }}-go1.26-${{ steps.letgo.outputs.version }}
+          key: lg-bin-${{ runner.os }}-${{ env.LG_CACHE_GO_VERSION }}-${{ steps.letgo.outputs.version }}
 
       - name: Install let-go
         if: steps.lgcache.outputs.cache-hit != 'true'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,13 +39,16 @@ jobs:
           # the lg-binary cache below is what saves the compile.
           cache: false
 
-      # Ask Go where it installs rather than restating the default. `~/go` is
-      # correct on today's ubuntu-latest runners, but nothing here declares
-      # that; a runner or a job-level GOPATH that disagreed would leave the
-      # cache pointing somewhere `go install` never writes, and the only
-      # symptom would be a permanent silent miss.
-      - name: Resolve GOPATH
-        run: echo "GOPATH=$(go env GOPATH)" >> "$GITHUB_ENV"
+      # Ask Go where it installs and which exact toolchain is active rather
+      # than restating either default. GOPATH keeps the cache aligned with
+      # `go install`; GOVERSION keeps a binary built by one patch release from
+      # being restored after setup-go has moved to the next patch release.
+      - name: Resolve Go cache identity
+        run: |
+          {
+            echo "GOPATH=$(go env GOPATH)"
+            echo "LG_CACHE_GO_VERSION=$(go env GOVERSION)"
+          } >> "$GITHUB_ENV"
 
       # The pinned lane reads .let-go-version; the latest lane resolves the
       # moving `latest` to its concrete version so the binary cache below can
@@ -62,13 +65,13 @@ jobs:
 
       # No go.sum in this repo means no dependency-keyed Go cache, so every
       # run was compiling let-go from source (~1-3 min). Cache the built
-      # binary keyed on the resolved version instead.
+      # binary keyed on the resolved let-go and exact Go versions instead.
       - name: Cache lg binary
         id: lgcache
         uses: actions/cache@v4
         with:
           path: ${{ env.GOPATH }}/bin/let-go
-          key: lg-bin-${{ runner.os }}-go1.26-${{ steps.letgo.outputs.version }}
+          key: lg-bin-${{ runner.os }}-${{ env.LG_CACHE_GO_VERSION }}-${{ steps.letgo.outputs.version }}
 
       - name: Install let-go ${{ steps.letgo.outputs.version }}
         if: steps.lgcache.outputs.cache-hit != 'true'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,10 +39,14 @@ jobs:
           # the lg-binary cache below is what saves the compile.
           cache: false
 
-      # Ask Go where it installs and which exact toolchain is active rather
+      # Ask Go where it installs and which toolchain setup-go activated rather
       # than restating either default. GOPATH keeps the cache aligned with
       # `go install`; GOVERSION keeps a binary built by one patch release from
       # being restored after setup-go has moved to the next patch release.
+      # GOVERSION is the runner's toolchain, not necessarily the one that
+      # builds the binary: under GOTOOLCHAIN=auto, `go install` switches to a
+      # newer `toolchain` line in let-go's go.mod. Inert while that line stays
+      # at or below the runner's Go (go1.26.5 on let-go main as of 2026-09-10).
       - name: Resolve Go cache identity
         run: |
           {


### PR DESCRIPTION
## Summary

- resolve the exact active Go version alongside GOPATH
- include that version in the cached `let-go` binary key
- keep test, deploy, and restore-only preview workflows on the same cache identity

## Why

#163 introduced the `let-go` binary cache and correctly derived GOPATH from `go env` so the cache path follows the install target. The cache key still identified the toolchain only as `go1.26`, however, so every Go 1.26 patch release shared one compiled-binary cache.

#191 exposed the consequence: a runner using Go 1.26.8 restored a `let-go` binary built under Go 1.26.7. The binary retained that vanished build-time GOROOT and its WASM smoke test could not find `wasm_exec.js`.

This change derives `LG_CACHE_GO_VERSION` from `go env GOVERSION` and includes it in all three keys. A Go patch update now misses once, rebuilds the binary with the active toolchain, and seeds matching deploy/preview caches.

The companion upstream robustness fix is nooga/let-go#837. That fix makes cached or relocated `let-go` binaries follow the Go toolchain actually selected for the WASM build; this PR independently makes the cache identity describe the binary's full build toolchain.

## Related

- Cache introduction and GOPATH discussion: #163
- Failure that exposed the missing key input: #191
- Upstream relocatability fix: nooga/let-go#837

## Verification

- `actionlint .github/workflows/test.yml .github/workflows/deploy-pages.yml .github/workflows/pr-preview.yml`
- `git diff --check`
