### PR TITLE
perf(hash): encode salt terms into an accumulator

### DIFF
--- a/xsofy/hash.lg
+++ b/xsofy/hash.lg
@@ -121,11 +121,31 @@
 (def ^:private salt-tag-str 3)
 (def ^:private salt-tag-vec 4)
 
+(defn- conj-int->8-be
+  "Append the low 64 bits of n to acc as 8 big-endian byte values, most
+   significant first.
+
+   The accumulator form is the one the hot path uses: every caller
+   immediately concatenates these 8 bytes onto a longer byte vector, so
+   returning a fresh vector meant allocating one per integer and then
+   copying it through `into`. Written as loop/recur rather than
+   (mapv f (range 8)) for the same reason — the higher-order form
+   allocates a range seq and a closure, and neither the IR optimizer nor
+   the Go lowerer can see through `mapv` to remove them."
+  [acc n]
+  (loop [i 0 acc acc]
+    (if (< i 8)
+      (recur (inc i) (conj acc (bit-and (u64-shr n (* (- 7 i) 8)) 0xFF)))
+      acc)))
+
 (defn- int->8-be
   "Big-endian byte encoding of the low 64 bits of n as a length-8 vector
-   of int byte values [0, 255]. Index 0 holds the most significant byte."
+   of int byte values [0, 255]. Index 0 holds the most significant byte.
+
+   Kept as a named function because the JVM cross-validation twin in
+   test/hash_test_jvm.clj mirrors it directly."
   [n]
-  (mapv #(bit-and (u64-shr n (* (- 7 %) 8)) 0xFF) (range 8)))
+  (conj-int->8-be [] n))
 
 (defn- codepoint->utf8
   "Encode a single Unicode codepoint as a vector of 1-4 int byte values
@@ -165,6 +185,42 @@
   [s]
   (reduce (fn [acc c] (into acc (codepoint->utf8 (int c)))) [] s))
 
+(defn encode-salt-into
+  "Append the v1 encoding of salt-key term `s` to `acc`, returning the
+   extended vector. Byte-for-byte identical to (into acc (encode-salt s));
+   it exists so the hot path never materializes the per-term vector that
+   `into` would immediately copy and discard.
+
+   Declared before encode-salt and self-recursive for the vector case."
+  [acc s]
+  (cond
+    (keyword? s)
+    (let [name-bytes (utf8-bytes (name s))]
+      (assert (< (count name-bytes) 256)
+              (str "Keyword name exceeds 255 bytes: " (name s)))
+      (into (conj acc salt-tag-kw (count name-bytes)) name-bytes))
+
+    (integer? s)
+    (conj-int->8-be (conj acc salt-tag-int) s)
+
+    (string? s)
+    (let [b (utf8-bytes s)]
+      (assert (< (count b) 256)
+              (str "String exceeds 255 bytes (len=" (count b) ")"))
+      (into (conj acc salt-tag-str (count b)) b))
+
+    (vector? s)
+    (let [n (count s)]
+      (assert (< n 256)
+              (str "Vector exceeds 255 elements (len=" n ")"))
+      (reduce encode-salt-into
+              (conj acc salt-tag-vec n)
+              s))
+
+    :else
+    (throw (ex-info "encode-salt: unsupported type"
+                    {:value s :type (type s)}))))
+
 (defn encode-salt
   "Canonical byte encoding of a salt-key (v1). Returns a vector of int byte
    values in [0, 255]. Supported terms: keyword, integer, string, vector of
@@ -176,33 +232,7 @@
    sequences (event tag + a handful of entity ids), so 255 is a comfortable
    ceiling."
   [s]
-  (cond
-    (keyword? s)
-    (let [name-bytes (utf8-bytes (name s))]
-      (assert (< (count name-bytes) 256)
-              (str "Keyword name exceeds 255 bytes: " (name s)))
-      (into [salt-tag-kw (count name-bytes)] name-bytes))
-
-    (integer? s)
-    (into [salt-tag-int] (int->8-be s))
-
-    (string? s)
-    (let [b (utf8-bytes s)]
-      (assert (< (count b) 256)
-              (str "String exceeds 255 bytes (len=" (count b) ")"))
-      (into [salt-tag-str (count b)] b))
-
-    (vector? s)
-    (let [n (count s)]
-      (assert (< n 256)
-              (str "Vector exceeds 255 elements (len=" n ")"))
-      (reduce (fn [acc el] (into acc (encode-salt el)))
-              [salt-tag-vec n]
-              s))
-
-    :else
-    (throw (ex-info "encode-salt: unsupported type"
-                    {:value s :type (type s)}))))
+  (encode-salt-into [] s))
 
 ;; ============================================================================
 ;; combine — the public API for det
@@ -324,12 +354,13 @@
           (assert (< full-len 256)
                   (str "with-folded-salt: salt-key length " full-len
                        " exceeds the 255-element ceiling"))
-          `(let [tail-bytes# (reduce (fn [acc# el#]
-                                       (into acc# (xsofy.hash/encode-salt el#)))
-                                     []
-                                     ~(vec tail))
-                 full-bytes# (into (into [4 ~full-len] ~prefix-elements-bytes)
-                                   tail-bytes#)]
+          ;; Seed the accumulator with the header and the folded prefix, then
+          ;; append the tail terms directly. The older shape built a separate
+          ;; tail vector and then copied it through two `into`s; this produces
+          ;; the identical byte sequence with one accumulator.
+          `(let [full-bytes# (reduce xsofy.hash/encode-salt-into
+                                     (into [4 ~full-len] ~prefix-elements-bytes)
+                                     ~(vec tail))]
              (xsofy.hash/xxh3-64 full-bytes# ~seed)))))
 
     ;; salt-key is not a vector literal — must be a symbol or other expression

--- a/xsofy/hash.lg
+++ b/xsofy/hash.lg
@@ -80,10 +80,6 @@
 
 
 
-
-
-
-
 ;; ============================================================================
 ;; xxh3-64 public API (native interop)
 ;; ============================================================================
@@ -147,6 +143,65 @@
   [n]
   (conj-int->8-be [] n))
 
+(defn- valid-codepoint!
+  "Assert cp is a legal scalar value: in range and not a surrogate half."
+  [cp]
+  (assert (and (>= cp 0) (<= cp 0x10FFFF)
+               (not (and (>= cp 0xD800) (<= cp 0xDFFF))))
+          (str "codepoint->utf8: invalid codepoint " cp)))
+
+(defn- codepoint->utf8-len
+  "How many UTF-8 bytes cp encodes to, without building them. Lets a caller
+   write the length byte that precedes the bytes in the v1 salt format
+   without materializing the bytes first."
+  [cp]
+  (valid-codepoint! cp)
+  (cond (< cp 0x80) 1 (< cp 0x800) 2 (< cp 0x10000) 3 :else 4))
+
+(defn- conj-codepoint->utf8
+  "Append cp's UTF-8 bytes to acc. Accumulator twin of codepoint->utf8,
+   and the form the hot path uses: the vector codepoint->utf8 returns is
+   copied onto a longer vector and discarded at every call site."
+  [acc cp]
+  (valid-codepoint! cp)
+  (cond
+    (< cp 0x80)
+    (conj acc cp)
+
+    (< cp 0x800)
+    (conj acc
+          (bit-or 0xC0 (bit-and (u64-shr cp 6) 0x1F))
+          (bit-or 0x80 (bit-and cp 0x3F)))
+
+    (< cp 0x10000)
+    (conj acc
+          (bit-or 0xE0 (bit-and (u64-shr cp 12) 0x0F))
+          (bit-or 0x80 (bit-and (u64-shr cp 6) 0x3F))
+          (bit-or 0x80 (bit-and cp 0x3F)))
+
+    :else
+    (conj acc
+          (bit-or 0xF0 (bit-and (u64-shr cp 18) 0x07))
+          (bit-or 0x80 (bit-and (u64-shr cp 12) 0x3F))
+          (bit-or 0x80 (bit-and (u64-shr cp 6) 0x3F))
+          (bit-or 0x80 (bit-and cp 0x3F)))))
+
+;; Named rather than inline closures: a closure passed to reduce allocates,
+;; and neither the IR optimizer nor the Go lowerer sees through the
+;; higher-order call to remove it.
+(defn- add-utf8-len [n c] (+ n (codepoint->utf8-len (int c))))
+(defn- conj-utf8-char [acc c] (conj-codepoint->utf8 acc (int c)))
+
+(defn- utf8-len
+  "Byte length of s encoded as UTF-8, allocating nothing."
+  [s]
+  (reduce add-utf8-len 0 s))
+
+(defn- conj-utf8
+  "Append s's UTF-8 bytes to acc."
+  [acc s]
+  (reduce conj-utf8-char acc s))
+
 (defn- codepoint->utf8
   "Encode a single Unicode codepoint as a vector of 1-4 int byte values
    per the UTF-8 spec (RFC 3629). let-go iterates strings as runes
@@ -154,27 +209,7 @@
    each codepoint explicitly. This matches what the JVM's
    String.getBytes(\"UTF-8\") produces for the cross-validation harness."
   [cp]
-  (assert (and (>= cp 0) (<= cp 0x10FFFF)
-               (not (and (>= cp 0xD800) (<= cp 0xDFFF))))
-          (str "codepoint->utf8: invalid codepoint " cp))
-  (cond
-    (< cp 0x80)
-    [cp]
-
-    (< cp 0x800)
-    [(bit-or 0xC0 (bit-and (u64-shr cp 6) 0x1F))
-     (bit-or 0x80 (bit-and cp 0x3F))]
-
-    (< cp 0x10000)
-    [(bit-or 0xE0 (bit-and (u64-shr cp 12) 0x0F))
-     (bit-or 0x80 (bit-and (u64-shr cp 6) 0x3F))
-     (bit-or 0x80 (bit-and cp 0x3F))]
-
-    :else
-    [(bit-or 0xF0 (bit-and (u64-shr cp 18) 0x07))
-     (bit-or 0x80 (bit-and (u64-shr cp 12) 0x3F))
-     (bit-or 0x80 (bit-and (u64-shr cp 6) 0x3F))
-     (bit-or 0x80 (bit-and cp 0x3F))]))
+  (conj-codepoint->utf8 [] cp))
 
 (defn- utf8-bytes
   "Convert a let-go string to its UTF-8 byte representation as a vector of
@@ -183,7 +218,7 @@
    any (.getBytes ...) Java-interop call (which is not implemented for
    let-go's String type)."
   [s]
-  (reduce (fn [acc c] (into acc (codepoint->utf8 (int c)))) [] s))
+  (conj-utf8 [] s))
 
 (defn encode-salt-into
   "Append the v1 encoding of salt-key term `s` to `acc`, returning the
@@ -195,19 +230,20 @@
   [acc s]
   (cond
     (keyword? s)
-    (let [name-bytes (utf8-bytes (name s))]
-      (assert (< (count name-bytes) 256)
-              (str "Keyword name exceeds 255 bytes: " (name s)))
-      (into (conj acc salt-tag-kw (count name-bytes)) name-bytes))
+    (let [nm (name s)
+          n  (utf8-len nm)]
+      (assert (< n 256)
+              (str "Keyword name exceeds 255 bytes: " nm))
+      (conj-utf8 (conj acc salt-tag-kw n) nm))
 
     (integer? s)
     (conj-int->8-be (conj acc salt-tag-int) s)
 
     (string? s)
-    (let [b (utf8-bytes s)]
-      (assert (< (count b) 256)
-              (str "String exceeds 255 bytes (len=" (count b) ")"))
-      (into (conj acc salt-tag-str (count b)) b))
+    (let [n (utf8-len s)]
+      (assert (< n 256)
+              (str "String exceeds 255 bytes (len=" n ")"))
+      (conj-utf8 (conj acc salt-tag-str n) s))
 
     (vector? s)
     (let [n (count s)]

--- a/xsofy/test/hash_test.lg
+++ b/xsofy/test/hash_test.lg
@@ -186,6 +186,31 @@
     ;; "hi" → [0x03, 2, 'h', 'i'] → [3 2 104 105]
     (is (= [3 2 104 105] (h/encode-salt "hi")))))
 
+(deftest encode-salt-multibyte-utf8
+  (testing "String encodes UTF-8 at all four RFC 3629 lengths"
+    ;; The length byte counts BYTES, not codepoints, so each case also pins
+    ;; that utf8-len agrees with the bytes actually emitted. Byte values were
+    ;; cross-checked against the JVM twin's String.getBytes("UTF-8").
+    ;; 1-byte: "abc"
+    (is (= [3 3 97 98 99] (h/encode-salt "abc")))
+    ;; 2-byte: "é" = U+00E9 -> C3 A9
+    (is (= [3 2 195 169] (h/encode-salt "é")))
+    ;; 3-byte: "日" = U+65E5 -> E6 97 A5
+    (is (= [3 3 230 151 165] (h/encode-salt "日")))
+    ;; 4-byte: "😀" = U+1F600 -> F0 9F 98 80, one codepoint but four bytes
+    (is (= [3 4 240 159 152 128] (h/encode-salt "😀")))
+    ;; mixed widths in one string, to catch an encoder that only handles the
+    ;; first codepoint's width
+    (is (= [3 10 97 195 169 230 151 165 240 159 152 128]
+           (h/encode-salt "aé日😀")))
+    ;; empty string still carries its tag and a zero length
+    (is (= [3 0] (h/encode-salt "")))))
+
+(deftest encode-salt-multibyte-keyword
+  (testing "Keyword name encodes UTF-8 with a byte length"
+    ;; :é -> tag 1, length 2 (bytes, not codepoints), C3 A9
+    (is (= [1 2 195 169] (h/encode-salt (keyword "é"))))))
+
 (deftest encode-salt-vector
   (testing "Vector encodes as 0x04 | element-count | element-bytes..."
     ;; [:foo 1] → 0x04, 2, [1, 3, 'f', 'o', 'o'], [2, 0, 0, 0, 0, 0, 0, 0, 1]


### PR DESCRIPTION
The det hot path allocated 96 objects per roll, and 94 of them were salt encoding: `(assoc world :seed ...)` accounts for the other 2. Every layer built a vector that the next layer copied through `into` and discarded.

`int->8-be` was the worst, at 18 allocations to produce 8 bytes. Written as `(mapv f (range 8))` it allocates a range seq and a closure before it allocates the result, and neither the IR optimizer nor the Go lowerer removes them. Lowered, the closure boxes to a native fn, the call goes through a `clojure.core/mapv` trampoline, and since the closure's parameter is untyped, every operation inside it runs through the boxed `rt.*Value` helpers. The `loop`/`recur` form lowers to native `int64` locals and arithmetic instead. `utf8-bytes` had the same shape, reducing a closure over the string and building a 1-4 element vector per codepoint.

## What changed

The encoders take an accumulator and append to it:

- `conj-int->8-be` replaces the intermediate 8-element vector.
- `encode-salt-into` replaces the per-term vector, and the vector arm folds its elements into the same accumulator.
- `conj-codepoint->utf8` appends a codepoint's bytes directly, and `codepoint->utf8-len` reports the byte count without building them, which is what lets the length byte be written before the bytes rather than after materializing them.
- `with-folded-salt` seeds one accumulator with the header and the folded prefix, rather than building a tail vector and copying it through two `into` calls.

`encode-salt`, `int->8-be`, and `codepoint->utf8` remain as named functions, each delegating to its accumulator version, because the JVM cross-validation twin in `test/hash_test_jvm.clj` mirrors them directly. That file is unchanged, so it stays an independent reference. The two `reduce` helpers are named rather than inline closures for the same reason the encoders changed shape.

## Measurements

Allocations per roll, 96 to 55. `allocs/op` is exact, and was identical across three runs:

```
BenchmarkFoldedRollBefore    96 allocs/op
BenchmarkFoldedRollAfter     55 allocs/op
```

Encoding a six-character keyword name, 72 allocations to 30.

Turn time, as medians of interleaved runs alternating which side goes first, each with an A/A control running the same build in both arms:

| lane | before | after | | A/A floor |
|---|---|---|---|---|
| native, 20k `det/int-in` rolls | 0.325s | 0.210s | 35% faster | 1.2% |
| TinyGo wasi under `wasmtime`, same | 30.9s | 19.1s | 38% faster | 0.2% |
| browser, engine bench over 3 fixtures | 64.8s | 51.7s | 20% faster | 1.9% |

The browser figure is per-turn engine cost inside the wasm runtime, driving `xsofy.perf`'s shared core with no render, so it is comparable to `bench/native.lg`. Average turn time across the three fixtures goes from about 64ms to about 51ms; native is about 9ms, so the wasm penalty stays the dominant term. The lanes with a conservative collector gain most, because allocation rate is what dominates there.

## Verification

The encoding is unchanged, which is the point: a shifted seed invalidates every published replay. Checked three ways.

The suite passes 330 tests and 2864 assertions, including the 84 xxh3 goldens.

A differential run against `origin/main` produces identical bytes for keyword, integer, negative integer, 1-, 2-, 3- and 4-byte UTF-8, mixed-width strings, unicode keywords, the empty string, and nested vectors. A 20,000-roll chain ends on the same seed on both engines and both host widths:

```
native before/after, TinyGo before/after -> final-seed = -2114297250817732603
```

The JVM cross-validation in `test/hash_test_jvm.clj` passes unchanged: 38 of 38 published vectors and 13 of 13 streaming cases. That file is an independent Clojure re-implementation rather than a caller of `xsofy.hash`, so it is left alone deliberately; mirroring this refactor into it would cost the independence that makes it worth having. Its `encode-salt` reaches the same bytes by a different route, `String.getBytes("UTF-8")` against our codepoint walk, and the two agree byte for byte on all four UTF-8 widths, a unicode keyword, a mixed-width string, the empty string, and a nested vector. That agreement is the one I most wanted to see: let-go iterates a string as codepoints and the JVM as UTF-16 chars, so an astral character such as U+1F600 is one unit on one side and a surrogate pair on the other.

Multibyte encoding was not covered before, and this change rewrites the encoder, so the cases above are now in the suite. Breaking the 3-byte lead byte previously passed all 328 tests: the string fixture was `"hi"`, and a comment in the test file recorded that the fixtures are "all printable ASCII; we deliberately don't go through utf8-bytes". Every mutation that changes output now fails, checked by reintroducing an error in the 2-, 3- and 4-byte lead bytes and in a 4-byte continuation byte.
